### PR TITLE
Add a test demonstrating vdp1 system and user clipping.

### DIFF
--- a/yabauseut/src/vdp1.c
+++ b/yabauseut/src/vdp1.c
@@ -52,6 +52,75 @@ void vdp1_draw_test()
 
 void vdp1_clip_test()
 {
+   int gouraud_table_address = 0x40000;
+   u32 clipping_mode = 3;//outside
+
+   u16* p = (u16 *)(0x25C00000 + gouraud_table_address);
+
+   for (;;)
+   {
+      vdp_start_draw_list();
+
+      sprite_struct quad;
+
+      //system clipping
+      quad.x = 319 - 8;
+      quad.y = 223 - 8;
+
+      vdp_system_clipping(&quad);
+
+      //user clipping
+      quad.x = 8;
+      quad.y = 8;
+      quad.x2 = 319 - 16;
+      quad.y2 = 223 - 16;
+
+      vdp_user_clipping(&quad);
+
+      //fullscreen polygon
+      quad.x = 319;
+      quad.y = 0;
+      quad.x2 = 319;
+      quad.y2 = 223;
+      quad.x3 = 0;
+      quad.y3 = 223;
+      quad.x4 = 0;
+      quad.y4 = 0;
+
+      quad.bank = RGB16(0x10, 0x10, 0x10);//gray
+
+      quad.gouraud_addr = gouraud_table_address;
+
+      quad.attr = (clipping_mode << 9) | 4;//use gouraud shading
+
+      //red, green, blue, and white
+      p[0] = RGB16(31, 0, 0);
+      p[1] = RGB16(0, 31, 0);
+      p[2] = RGB16(0, 0, 31);
+      p[3] = RGB16(31, 31, 31);
+
+      vdp_draw_polygon(&quad);
+
+      vdp_end_draw_list();
+
+      vdp_vsync();
+
+      if (per[0].but_push_once & PAD_A)
+      {
+         clipping_mode = 0; //clipping disabled
+      }
+      if (per[0].but_push_once & PAD_B)
+      {
+         clipping_mode = 2; //inside drawing mode
+      }
+      if (per[0].but_push_once & PAD_C)
+      {
+         clipping_mode = 3; //outside drawing mode
+      }
+
+      if (per[0].but_push_once & PAD_START)
+         break;
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The user clipping mode can be selected with the A, B and C buttons.  Here is an image of it running on real hardware, showing the outside drawing mode.
![clip-test](https://cloud.githubusercontent.com/assets/10871998/8579898/4cd68502-2585-11e5-8bf6-8ab43ad142f9.jpg)
