### PR TITLE
Add support in vidsoft.c for vdp1 outside clipping mode.

### DIFF
--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -2096,6 +2096,19 @@ static void putpixel(int x, int y) {
 			y >= vdp1clipystart &&
 			y < vdp1clipyend);
 
+      //vdp1_clip_test in yabauseut
+      if ((cmd.CMDPMOD >> 9) & 0x3 == 0x3)//outside clipping mode
+      {
+         //don't display inside the box
+         if (Vdp1Regs->userclipX1 <= x && 
+            x <= Vdp1Regs->userclipX2 && 
+            Vdp1Regs->userclipY1 <= y && 
+            y <= Vdp1Regs->userclipY2) 
+         {
+            clipped = 1;
+         }
+      }
+
 		if (cmd.CMDPMOD & 0x0400) PopUserClipping();
 
 		if (clipped) return;


### PR DESCRIPTION
Outside clipping only displays sprite pixels outside the user clipping coordinates.

Before:
![clipping-before](https://cloud.githubusercontent.com/assets/10871998/8602932/185245f0-2643-11e5-84cd-fdecd7353de2.png)
After:
![clipping-after](https://cloud.githubusercontent.com/assets/10871998/8602935/1992f0ae-2643-11e5-8891-5f073c3c39e7.png)
