### PR TITLE
Add a test demonstrating the Vdp2 scroll screens in tile mode.

### DIFF
--- a/yabauseut/src/vdp2.c
+++ b/yabauseut/src/vdp2.c
@@ -19,6 +19,8 @@
 
 #include "tests.h"
 
+extern vdp2_settings_struct vdp2_settings;
+
 void vdp2_nbg0_test ();
 void vdp2_nbg1_test ();
 void vdp2_nbg2_test ();
@@ -26,6 +28,7 @@ void vdp2_nbg3_test ();
 void vdp2_rbg0_test ();
 void vdp2_rbg1_test ();
 void vdp2_window_test ();
+void vdp2_all_scroll_test();
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -103,6 +106,188 @@ void vdp2_test()
 //   register_test(&Vdp2RBG0Test, "RBG0 bitmap");
    register_test(&vdp2_window_test, "Window test");
    do_tests("VDP2 Screen tests", 0, 0);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void load_font_8x8_to_vdp2_vram_1bpp_to_4bpp(u32 tile_start_address)
+{
+   int x, y;
+   int chr;
+   volatile u8 *dest = (volatile u8 *)(VDP2_RAM + tile_start_address);
+
+   for (chr = 0; chr < 128; chr++)//128 ascii chars total
+   {
+      for (y = 0; y < 8; y++)
+      {
+         u8 scanline = font_8x8[(chr * 8) + y];//get one scanline
+
+         for (x = 0; x < 8; x++)
+         {
+            //get the corresponding bit for the x pos
+            u8 bit = (scanline >> (x ^ 7)) & 1;
+
+            if ((x & 1) == 0) 
+               bit *= 16;
+            
+            dest[(chr * 32) + (y * 4) + (x / 2)] |= bit;
+         }
+      }
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void write_str_as_pattern_name_data(int x_pos, int y_pos, const char* str, int palette, u32 base, u32 tile_start_address)
+{
+   int x;
+
+   int len = strlen(str);
+
+   for (x = 0; x < len; x++)
+   {
+      int name = str[x];
+
+      int offset = x + x_pos;
+
+      volatile u32 *p = (volatile u32 *)(VDP2_RAM + base);
+      p[(y_pos * 32 * 2) + offset] = (tile_start_address >> 5) | name | (palette << 16);
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void vdp2_scroll_test_set_scroll(int pos)
+{
+   //scroll the first two layers a little slower
+   //than 1px per frame in the x direction
+   *(volatile u32 *)0x25F80070 = pos << 15;
+   VDP2_REG_SCYIN0 = pos;
+
+   *(volatile u32 *)0x25F80080 = -(pos << 15);
+   VDP2_REG_SCYIN1 = pos;
+
+   VDP2_REG_SCXN2 = pos;
+   VDP2_REG_SCYN2 = pos;
+
+   VDP2_REG_SCXN3 = -pos;
+   VDP2_REG_SCYN3 = pos;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void vdp2_scroll_test_set_map(screen_settings_struct* settings, int which)
+{
+   int i;
+
+   for (i = 0; i < 4; i++)
+   {
+      settings->map[i] = which;
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void vdp2_all_scroll_test()
+{
+   int i;
+   
+   vdp_rbg0_deinit();
+
+   VDP2_REG_CYCA0U = 0x0123; // NBG0, NBG1, NBG2, NBG3 Pattern name data read 
+   VDP2_REG_CYCB0U = 0x4567; // NBG0, NBG1, NBG2, NBG3 Character pattern read
+
+   const u32 tile_address = 0x40000;
+
+   load_font_8x8_to_vdp2_vram_1bpp_to_4bpp(tile_address);
+
+   screen_settings_struct settings;
+
+   settings.color = 0;
+   settings.is_bitmap = 0;
+   settings.char_size = 0;
+   settings.pattern_name_size = 0;
+   settings.plane_size = 0;
+   vdp2_scroll_test_set_map(&settings, 0);
+   settings.transparent_bit = 0;
+   settings.map_offset = 0;
+   vdp_nbg0_init(&settings);
+
+   vdp2_scroll_test_set_map(&settings, 1);
+   vdp_nbg1_init(&settings);
+
+   vdp2_scroll_test_set_map(&settings, 2);
+   vdp_nbg2_init(&settings);
+
+   vdp2_scroll_test_set_map(&settings, 3);
+   vdp_nbg3_init(&settings);
+
+   vdp_set_default_palette();
+
+   //set pattern name data to the empty font tile
+   for (i = 0; i < 256; i++)
+   {                                     
+      write_str_as_pattern_name_data(0, i, "                                                                ", 0, 0x000000, tile_address);
+   }
+
+   for (i = 0; i < 64; i += 4)
+   {
+      write_str_as_pattern_name_data(0, i,     "A button: Start scrolling. NBG0. Testing NBG0. This is NBG0.... ", 3, 0x000000, tile_address);
+      write_str_as_pattern_name_data(0, i + 1, "B button: Stop scrolling.  NBG1. Testing NBG1. This is NBG1.... ", 4, 0x004000, tile_address);
+      write_str_as_pattern_name_data(0, i + 2, "C button: Reset.           NBG2. Testing NBG2. This is NBG2.... ", 5, 0x008000, tile_address);
+      write_str_as_pattern_name_data(0, i + 3, "Start:    Exit.            NBG3. Testing NBG3. This is NBG3.... ", 6, 0x00C000, tile_address);
+   }
+
+   vdp_disp_on();
+
+   int do_scroll = 0;
+   int scroll_pos = 0;
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      if (do_scroll)
+      {
+         scroll_pos++;
+         vdp2_scroll_test_set_scroll(scroll_pos);
+      }
+
+      if (per[0].but_push_once & PAD_A)
+      {
+         do_scroll = 1;
+      }
+
+      if (per[0].but_push_once & PAD_B)
+      {
+         do_scroll = 0;
+      }
+
+      if (per[0].but_push_once & PAD_C)
+      {
+         do_scroll = 0;
+         scroll_pos = 0;
+         vdp2_scroll_test_set_scroll(scroll_pos);
+      }
+
+      if (per[0].but_push_once & PAD_START)
+         break;
+   }
+
+   //restore settings so the menus don't break
+
+   vdp_nbg0_deinit();
+   vdp_nbg1_deinit();
+   vdp_nbg2_deinit();
+   vdp_nbg3_deinit();
+
+   vdp_rbg0_init(&test_disp_settings);
+
+   //clear the vram we used
+   for (i = 0; i < 0x11000; i++)
+   {
+      vdp2_ram[i] = 0;
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This test demonstrates the regular scroll screens in tile mode by uploading a font to vram and setting the pattern name data to show messages.  The screens are then scrolled in different directions when the user presses the A button. This test has not been made accessible from the menu but adding a call to vdp2_all_scroll_test() somewhere should load it correctly.

![scroll-1](https://cloud.githubusercontent.com/assets/10871998/8635145/58950038-27e4-11e5-8c25-3c0c0c0bd7ec.jpg)
![scroll-2](https://cloud.githubusercontent.com/assets/10871998/8635146/589636e2-27e4-11e5-9f7e-0e18cc43d38e.jpg)