### PR TITLE
Add a system for automated emulation regression testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,16 @@ matrix:
         - cmake -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake ..
         - make
 
+    # compile runner and run yabauseut tests
+    - compiler: gcc
+      script:
+        - cmake -DYAB_PORTS=runner -DSH2_DYNAREC=OFF -DYAB_WANT_C68K=OFF -DYAB_WANT_Q68=OFF -DYAB_WANT_OPENGL=OFF ..
+        - make
+        - cd src/runner
+        #todo compile this instead
+        - git clone git://github.com/d356/yabauseut-bin.git
+        - ./yabause yabauseut-bin/YabauseUT.elf
+
 language: cpp
 
 before_install:

--- a/yabause/src/CMakeLists.txt
+++ b/yabause/src/CMakeLists.txt
@@ -599,7 +599,7 @@ endif ()
 
 option(YAB_MULTIBUILD "Choose wether to build all ports or only a single one")
 set(YAB_PORT_BUILT FALSE)
-set(YAB_PORTS "gtk;qt;dreamcast;cocoa" CACHE STRING "List of ports to build")
+set(YAB_PORTS "gtk;qt;dreamcast;cocoa;runner" CACHE STRING "List of ports to build")
 foreach(PORT IN LISTS YAB_PORTS)
 	add_subdirectory(${PORT})
 endforeach(PORT)

--- a/yabause/src/android/jni/yui.c
+++ b/yabause/src/android/jni/yui.c
@@ -455,6 +455,7 @@ Java_org_yabause_android_YabauseRunnable_init( JNIEnv* env, jobject obj, jobject
     yinit.cartpath = GetCartridgePath();
     yinit.videoformattype = VIDEOFORMATTYPE_NTSC;
     yinit.frameskip = 0;
+    yinit.skip_load = 0;
 
     res = YabauseInit(&yinit);
 

--- a/yabause/src/cocoa/YabauseController.m
+++ b/yabause/src/cocoa/YabauseController.m
@@ -267,6 +267,7 @@ static void FlipToggle(NSMenuItem *item) {
         yinit.clocksync = 0;
         yinit.basetime = 0;
         yinit.usethreads = 0;
+        yinit.skip_load = 0;
 
         /* Set up the internal save ram if specified. */
         if([bram length] > 0) {

--- a/yabause/src/dreamcast/yui.c
+++ b/yabause/src/dreamcast/yui.c
@@ -96,6 +96,7 @@ int YuiInit(int sh2core)   {
     yinit.videoformattype = VIDEOFORMATTYPE_NTSC;
     yinit.clocksync = 0;
     yinit.basetime = 0;
+    yinit.skip_load = 0;
 
     if(YabauseInit(&yinit) != 0)
       return -1;

--- a/yabause/src/gtk/main.c
+++ b/yabause/src/gtk/main.c
@@ -164,6 +164,7 @@ static void yui_settings_init(void) {
 	yinit.cartpath = cartpath;
         yinit.videoformattype = VIDEOFORMATTYPE_NTSC;
 	yinit.osdcoretype = OSDCORE_DEFAULT;
+	yinit.skip_load = 0;
 }
 
 gchar * inifile;

--- a/yabause/src/qt/YabauseThread.cpp
+++ b/yabause/src/qt/YabauseThread.cpp
@@ -356,6 +356,7 @@ void YabauseThread::resetYabauseConf()
 	mYabauseConf.mpegpath = 0;
 	mYabauseConf.cartpath = 0;
 	mYabauseConf.videoformattype = VIDEOFORMATTYPE_NTSC;
+	mYabauseConf.skip_load = 0;
 }
 
 void YabauseThread::timerEvent( QTimerEvent* )

--- a/yabause/src/runner/CMakeLists.txt
+++ b/yabause/src/runner/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(yabause-runner)
+
+yab_port_start()
+
+include_directories(${PORT_INCLUDE_DIRS})
+
+add_executable(yabause-runner yui.c)
+target_link_libraries(yabause-runner yabause ${YABAUSE_LIBRARIES} ${PORT_LIBRARIES})
+
+yab_port_success(yabause-runner)

--- a/yabause/src/runner/yui.c
+++ b/yabause/src/runner/yui.c
@@ -1,0 +1,322 @@
+/*  Copyright 2003 Guillaume Duhamel
+    Copyright 2004-2010 Lawrence Sebald
+
+    This file is part of Yabause.
+
+    Yabause is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Yabause is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Yabause; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#include <stdio.h>
+
+#include "../yui.h"
+#include "../peripheral.h"
+#include "../cs0.h"
+#include "../m68kcore.h"
+#include "../m68kc68k.h"
+#include "../vidsoft.h"
+#include "../vdp2.h"
+#ifdef _MSC_VER
+#include <Windows.h>
+#endif
+
+#define AUTO_TEST_SELECT_ADDRESS 0x7F000
+#define AUTO_TEST_STATUS_ADDRESS 0x7F004
+#define AUTO_TEST_OUTPUT_ADDRESS 0x7F008
+#define AUTO_TEST_NOT_RUNNING 0
+#define AUTO_TEST_BUSY 1
+#define AUTO_TEST_FINISHED 2
+#define TEST_PASSED 1
+#define TEST_FAILED 2
+#define TEST_FAILED_EXPECTED 3
+
+#define VDP2_VRAM 0x25E00000
+
+SH2Interface_struct *SH2CoreList[] = {
+    &SH2Interpreter,
+    NULL
+};
+
+PerInterface_struct *PERCoreList[] = {
+    &PERDummy,
+    NULL
+};
+
+CDInterface *CDCoreList[] = {
+    &DummyCD,
+    NULL
+};
+
+SoundInterface_struct *SNDCoreList[] = {
+    &SNDDummy,
+    NULL
+};
+
+VideoInterface_struct *VIDCoreList[] = {
+    &VIDDummy,
+    NULL
+};
+
+M68K_struct * M68KCoreList[] = {
+    &M68KDummy,
+#ifdef HAVE_C68K
+    &M68KC68K,
+#endif
+#ifdef HAVE_Q68
+    &M68KQ68,
+#endif
+    NULL
+};
+
+struct ConsoleColor
+{
+   char ansi[12];
+   int windows;
+};
+
+struct ConsoleColor text_red = { "\033[22;31m",4 };
+struct ConsoleColor text_green = { "\033[22;32m", 2 };
+struct ConsoleColor text_white = { "\033[01;37m", 7 };
+struct ConsoleColor text_light_red = { "\033[01;31m", 0xc };
+
+void set_color(struct ConsoleColor color)
+{
+#ifndef _MSC_VER
+   printf("%s", color.ansi);
+#else
+   HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+   SetConsoleTextAttribute(hConsole, (WORD)color.windows);
+#endif
+}
+
+static const char *bios = "";
+static int emulate_bios = 0;
+
+void YuiErrorMsg(const char *error_text) {
+   fprintf(stderr, "Error: %s\n", error_text);
+}
+
+void YuiSwapBuffers(void) {
+}
+
+void get_test_strings(int *i, char *full_str, char *command)
+{
+   sprintf(full_str, "%s", Vdp2Ram + AUTO_TEST_OUTPUT_ADDRESS + *i);
+
+   *i = *i + (int)strlen(full_str) + 1;// + 1 because of null char
+
+   sprintf(command, "%s", Vdp2Ram + AUTO_TEST_OUTPUT_ADDRESS + *i);
+
+   *i = *i + (int)strlen(command) + 1;
+}
+
+void print_result(char* test_info, char* command, int status)
+{
+   set_color(text_white);
+
+   printf("%-32s ", test_info, command);
+
+   if (status == TEST_PASSED)
+   {
+      set_color(text_green);
+   }
+   else if (status == TEST_FAILED)
+   {
+      set_color(text_red);
+   }
+   else if (status == TEST_FAILED_EXPECTED)
+   {
+      set_color(text_light_red);
+      printf("%-20s", command);
+      set_color(text_green);
+      printf("%s", " (Not a regression)\n");
+      set_color(text_white);
+      return;
+   }
+
+   printf("%s\n", command);
+
+   set_color(text_white);
+}
+
+//add tests that currently don't work in yabause here
+char* tests_expected_to_fail[] =
+{
+   //slave sh2
+   "SCU Mask Cache Quirk",
+   "Slave VBlank",
+   //scu interrupt
+   "Timer 1 Interrupt",
+   "Pad Interrupt",
+   "Illegal DMA Interrupt",
+   //scu dma
+   "Misaligned DMA transfer",
+   "Indirect DMA transfer",
+   //scu dsp
+   "DSP Execution",
+   "MVI Imm, [d]",
+   "DSP Timing",
+   NULL
+};
+
+int main(int argc, char *argv[])
+{
+   yabauseinit_struct yinit = { 0 };
+   int current_test = 0;
+   int regressions = 0;
+   int tests_total = 0;
+   int tests_passed = 0;
+   int finished = 0;
+   int expected_failure_count = 0;
+   int tests_expected_to_fail_count = 0;
+
+   printf("Running tests...\n\n");
+
+   yinit.percoretype = PERCORE_DUMMY;
+   yinit.sh2coretype = SH2CORE_INTERPRETER;
+   yinit.vidcoretype = VIDCORE_DUMMY;
+   yinit.m68kcoretype = M68KCORE_DUMMY;
+   yinit.sndcoretype = SNDCORE_DUMMY;
+   yinit.cdcoretype = CDCORE_DUMMY;
+   yinit.carttype = CART_NONE;
+   yinit.regionid = REGION_AUTODETECT;
+   yinit.biospath = emulate_bios ? NULL : bios;
+   yinit.cdpath = NULL;
+   yinit.buppath = NULL;
+   yinit.mpegpath = NULL;
+   yinit.cartpath = NULL;
+   yinit.frameskip = 0;
+   yinit.videoformattype = VIDEOFORMATTYPE_NTSC;
+   yinit.clocksync = 0;
+   yinit.basetime = 0;
+   yinit.skip_load = 1;
+
+   if (YabauseInit(&yinit) != 0)
+      return -1;
+
+   MappedMemoryLoadExec(argv[1], 0);
+
+   MappedMemoryWriteByte(VDP2_VRAM + AUTO_TEST_SELECT_ADDRESS, current_test);
+
+   for (;;)
+   {
+      int status = 0;
+
+      PERCore->HandleEvents();
+
+      status = MappedMemoryReadByte(VDP2_VRAM + AUTO_TEST_STATUS_ADDRESS);
+
+      if (status != AUTO_TEST_NOT_RUNNING &&
+         status != AUTO_TEST_BUSY)
+      {
+         int i = 0;
+
+         for (;;)
+         {
+            char test_info[256] = { 0 };
+            char command[64] = { 0 };
+            char fail_command[64] = { 0 };
+
+            get_test_strings(&i, &test_info[0], &command[0]);
+            strncpy(fail_command, command, 4);
+
+            if (!strcmp(command, "MESSAGE"))
+            {
+               //write a message without doing anything else
+               printf("%-32s\n", test_info);
+            }
+            else if (!strcmp(command, "PASS"))
+            {
+               //sub-test passed, continue to next
+               print_result(&test_info[0], &command[0], TEST_PASSED);
+               tests_total++;
+               tests_passed++;
+               continue;
+            }
+            else if (!strcmp(fail_command, "FAIL"))
+            {
+               //sub-test failure, due to pre-existing
+               //emulation issues, not a regression
+               int found = 0;
+               int j = 0;
+               for (j = 0; tests_expected_to_fail[j] != NULL; j++)
+               {
+                  if (!strcmp(test_info, tests_expected_to_fail[j]))
+                  {
+                     print_result(&test_info[0], &command[0], TEST_FAILED_EXPECTED);
+                     tests_total++;
+                     expected_failure_count++;
+                     found = 1;
+                     break;
+                  }
+               }
+
+               if (found)
+               {
+                  continue;
+               }
+
+               //sub-test failure, regression
+               print_result(&test_info[0], &command[0], TEST_FAILED);
+               tests_total++;
+               regressions++;
+               continue;
+            }
+            else if (!strcmp(command, "NEXT"))
+            {
+               //all sub-tests finished, proceed to next main test
+               printf("\n");
+               current_test++;
+
+               YabauseDeInit();
+
+               if (YabauseInit(&yinit) != 0)
+                  return -1;
+
+               MappedMemoryLoadExec(argv[1], 0);
+               MappedMemoryWriteByte(VDP2_VRAM + AUTO_TEST_SELECT_ADDRESS, current_test);
+               break;
+
+            }
+            else if (!strcmp(command, "QUIT"))
+            {
+               //all tests completed, exit
+
+               if (regressions > 0)
+               {
+                  set_color(text_red);
+               }
+               else
+               {
+                  set_color(text_green);
+               }
+
+               printf("%d of %d tests passed. %d regressions. %d failures that are not regressions. \n", tests_passed, tests_total, regressions, expected_failure_count);
+
+               set_color(text_white);
+
+               finished = 1;
+               break;
+            }
+         }
+
+         if (finished)
+         {
+            break;
+         }
+      }
+   }
+
+   return regressions;
+}

--- a/yabause/src/yabause.c
+++ b/yabause/src/yabause.c
@@ -269,6 +269,11 @@ int YabauseInit(yabauseinit_struct *init)
 
    YabauseResetNoLoad();
 
+   if (init->skip_load)
+   {
+	   return 0;
+   }
+
    if (yabsys.usequickload || yabsys.emulatebios)
    {
       if (YabauseQuickLoadGame() != 0)

--- a/yabause/src/yabause.h
+++ b/yabause/src/yabause.h
@@ -46,6 +46,7 @@ typedef struct
    u32 basetime;   // Initial time in clocksync mode (0 = start w/ system time)
    int usethreads;
    int osdcoretype;
+   int skip_load;//skip loading in YabauseInit so tests can be run without a bios
 } yabauseinit_struct;
 
 #define CLKTYPE_26MHZ           0

--- a/yabauseut/CMakeLists.txt
+++ b/yabauseut/CMakeLists.txt
@@ -5,6 +5,12 @@ include(ExternalProject)
 
 SET(CMAKE_SYSTEM_NAME SegaSaturn)
 
+set(WANT_AUTOMATED_TESTING OFF CACHE BOOL "Build a version for automated testing")
+
+if(WANT_AUTOMATED_TESTING)
+  add_definitions(-DBUILD_AUTOMATED_TESTING)
+endif()
+
 # Specify the cross compiler.
 CMAKE_FORCE_C_COMPILER("C:/Program Files (x86)/KPIT Cummins/GNUSHv10.02-ELF/sh-elf/bin/sh-elf-gcc.exe" GNU)
 CMAKE_FORCE_CXX_COMPILER("C:/Program Files (x86)/KPIT Cummins/GNUSHv10.02-ELF/sh-elf/bin/sh-elf-g++.exe" GNU)

--- a/yabauseut/src/main.c
+++ b/yabauseut/src/main.c
@@ -30,6 +30,7 @@
 #include "vdp1.h"
 #include "vdp2.h"
 #include "main.h"
+#include "tests.h"
 
 menu_item_struct main_menu[] = {
 { "SH2 Test" , &sh2_test, },
@@ -132,11 +133,62 @@ void yabauseut_init()
    vdp_disp_on();
 }
 
+#ifdef BUILD_AUTOMATED_TESTING
+
+void (*auto_tests[])() =
+{ 
+   //sh2
+   sh2_test,
+   //sh2 slave
+   slavesh2_test,
+   //scu
+   scu_register_test,
+   scu_int_test,
+   scu_dma_test,
+   scu_dsp_test,
+   //cd block
+   //mpeg card
+   //cartridge
+   //68k
+   //scsp
+   scsp_timing_test,
+   scsp_misc_test,
+   //smpc
+   //vdp1
+   //vdp2
+   auto_test_all_finished
+};
+
+#endif
+
+//by resetting the system inbetween tests, tests can't cause other tests to
+//fail due to incomplete system state cleanup
+
+int auto_test_get_selection()
+{
+#ifdef BUILD_AUTOMATED_TESTING
+   volatile u8* ptr = (volatile u8 *)VDP2_RAM;
+   return ptr[AUTO_TEST_SELECT_ADDRESS];
+#endif
+   return 0;
+}
+
+void auto_test_do_selected_test(int selection)
+{
+#ifdef BUILD_AUTOMATED_TESTING
+   (*auto_tests[selection])();
+#endif
+}
+
 int main()
 {
    int choice;
 
+   int auto_test_selection = auto_test_get_selection();
+
    yabauseut_init();
+
+   auto_test_do_selected_test(auto_test_selection);
 
    // Display Main Menu
    for(;;)

--- a/yabauseut/src/tests.h
+++ b/yabauseut/src/tests.h
@@ -22,6 +22,13 @@
 
 #include <iapetus.h>
 
+#define AUTO_TEST_SELECT_ADDRESS 0x7F000
+#define AUTO_TEST_STATUS_ADDRESS 0x7F004
+#define AUTO_TEST_OUTPUT_ADDRESS 0x7F008
+#define AUTO_TEST_NOT_RUNNING 0
+#define AUTO_TEST_BUSY 1
+#define AUTO_TEST_FINISHED 2
+
 enum STAGESTAT
 {
    STAGESTAT_USERCUSTOM=-8,
@@ -47,6 +54,8 @@ void do_tests(const char *testname, int x, int y);
 void register_test(void (*func)(void), const char *name);
 void unregister_all_tests();
 void tests_disp_iapetus_error(enum IAPETUS_ERR err, char *file, int line);
+
+void auto_test_all_finished();
 
 extern screen_settings_struct test_disp_settings;
 extern font_struct test_disp_font;


### PR DESCRIPTION
This commit adds a method for checking for the presence of emulation regressions automatically. The "runner" port, which is a headless port of Yabause that communicates with YabauseUT and prints test output to the command line, is compiled and run at the same time as the regular builds on Travis CI. YabauseUT has been modified to have a interface for sending text to Yabause. The build output of the 5th build on Travis CI will show any regressions that have occurred. An example can be seen here:

https://travis-ci.org/d356/yabause/jobs/75701381

Currently a YabauseUT binary is fetched from GitHub but in the future it could be compiled on the fly. Tests that are expected to fail should be added to runner/yui.c to prevent Travis CI from saying that the build caused an error.