### PR TITLE
Fix SCU DSP flag handling bugs

### DIFF
--- a/yabause/src/runner/yui.c
+++ b/yabause/src/runner/yui.c
@@ -166,6 +166,7 @@ char* tests_expected_to_fail[] =
    //scu dsp
    "DSP Execution",
    "MVI Imm, [d]",
+   "DSP ALU Test",
    "DSP Timing",
    NULL
 };
@@ -217,8 +218,7 @@ int main(int argc, char *argv[])
 
       status = MappedMemoryReadByte(VDP2_VRAM + AUTO_TEST_STATUS_ADDRESS);
 
-      if (status != AUTO_TEST_NOT_RUNNING &&
-         status != AUTO_TEST_BUSY)
+      if (status == AUTO_TEST_FINISHED)
       {
          int i = 0;
 

--- a/yabauseut/src/dsp.h
+++ b/yabauseut/src/dsp.h
@@ -22,6 +22,7 @@
 void scu_dsp_test();
 void test_dsp();
 void test_mvi_imm_d();
+void dsp_test_alu();
 void test_dsp_timing();
 
 #define NOP()           0x00000000


### PR DESCRIPTION
These fixes correct flag handling bugs in the SCU DSP and can be verified with the included test. The test compares the ALU results to a table generated by hardware. The 11 different ALU instructions can be cycled through by pressing start. Incorrect values are marked red. The final 4 results of the sign flag in the RR test are incorrect because of a different bug in computing the RR result.

For an example here is the ADD instruction on hardware:
![20150817061846](https://cloud.githubusercontent.com/assets/10871998/9302870/eb30fe26-44a7-11e5-8fa3-b5d3acdc32bf.JPG)