### PR TITLE
Implement some SCSP DSP register writes and a disassembler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,9 @@ matrix:
         - cd src/runner
         #todo compile this instead
         - git clone git://github.com/d356/yabauseut-bin.git
+        - cd yabauseut-bin
+        - git reset --hard 784c45eed5b48442089a99f01a6fee0650764c76
+        - cd ..
         - ./yabause yabauseut-bin/YabauseUT.elf
 
 language: cpp

--- a/yabause/src/qt/QtYabause.h
+++ b/yabause/src/qt/QtYabause.h
@@ -35,6 +35,7 @@ extern "C"
 	#include "../cs0.h"
 	#include "../cdbase.h"
 	#include "../scsp.h"
+	#include "../scspdsp.h"
 	#include "../scu.h"
 	#include "../sndal.h"
 #ifdef HAVE_DIRECTSOUND

--- a/yabause/src/qt/ui/UIDebugSCSPDSP.cpp
+++ b/yabause/src/qt/ui/UIDebugSCSPDSP.cpp
@@ -20,6 +20,12 @@
 #include "../CommonDialogs.h"
 #include "UIYabause.h"
 
+int SCSPDSPDis(u32 addr, char *string)
+{
+   ScspDspDisasm((u8)addr, string);
+   return 1;
+}
+
 void SCSPDSPBreakpointHandler (u32 addr)
 {
    UIYabause* ui = QtYabause::mainWindow( false );
@@ -40,6 +46,8 @@ UIDebugSCSPDSP::UIDebugSCSPDSP( YabauseThread *mYabauseThread, QWidget* p )
    size = lwDisassembledCode->minimumSize();
    size.setWidth(lwRegisters->fontMetrics().averageCharWidth() * 80);
    lwDisassembledCode->setMinimumSize(size);
+   lwDisassembledCode->setDisassembleFunction(SCSPDSPDis);
+   lwDisassembledCode->setEndAddress(128);
 }
 
 void UIDebugSCSPDSP::updateRegList()

--- a/yabause/src/scspdsp.c
+++ b/yabause/src/scspdsp.c
@@ -20,3 +20,189 @@
 #include "scsp.h"
 #include "scspdsp.h"
 
+struct ScspDsp scsp_dsp;
+
+void ScspDspDisasm(u8 addr, char *outstring)
+{
+   union ScspDspInstruction instruction;
+
+   instruction.all = scsp_dsp.mpro[addr];
+
+   sprintf(outstring, "%02X: ", addr);
+   outstring += strlen(outstring);
+
+   if (instruction.all == 0)
+   {
+      sprintf(outstring, "nop ", addr);
+      outstring += strlen(outstring);
+      return;
+   }
+
+   if (instruction.part.nofl)
+   {
+      sprintf(outstring, "nofl ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.coef)
+   {
+      sprintf(outstring, "coef %02X ", instruction.part.coef & 0x3F);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.masa)
+   {
+      sprintf(outstring, "masa %02X ", instruction.part.masa & 0x1F);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.adreb)
+   {
+      sprintf(outstring, "adreb ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.nxadr)
+   {
+      sprintf(outstring, "nxadr ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.table)
+   {
+      sprintf(outstring, "table ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.mwt)
+   {
+      sprintf(outstring, "mwt ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.mrd)
+   {
+      sprintf(outstring, "mrd ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.ewt)
+   {
+      sprintf(outstring, "ewt ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.ewa)
+   {
+      sprintf(outstring, "ewa %01X ", instruction.part.ewa & 0xf);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.adrl)
+   {
+      sprintf(outstring, "adrl ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.frcl)
+   {
+      sprintf(outstring, "frcl ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.shift)
+   {
+      sprintf(outstring, "shift %d ", instruction.part.shift & 3);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.yrl)
+   {
+      sprintf(outstring, "yrl ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.negb)
+   {
+      sprintf(outstring, "negb ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.zero)
+   {
+      sprintf(outstring, "zero ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.bsel)
+   {
+      sprintf(outstring, "bsel ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.xsel)
+   {
+      sprintf(outstring, "xsel ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.ysel)
+   {
+      sprintf(outstring, "ysel %d ", instruction.part.ysel & 3);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.ira)
+   {
+      sprintf(outstring, "ira %02X ", instruction.part.ira & 0x3F);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.iwt)
+   {
+      sprintf(outstring, "iwt ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.iwa)
+   {
+      sprintf(outstring, "iwa %02X ", instruction.part.iwa & 0x1F);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.tra)
+   {
+      sprintf(outstring, "tra %02X ", instruction.part.tra & 0x7F);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.twt)
+   {
+      sprintf(outstring, "twt ");
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.twa)
+   {
+      sprintf(outstring, "twa %02X ", instruction.part.twa & 0x7F);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.unknown)
+   {
+      sprintf(outstring, "unknown ", addr);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.unknown2)
+   {
+      sprintf(outstring, "unknown2 ", addr);
+      outstring += strlen(outstring);
+   }
+
+   if (instruction.part.unknown3)
+   {
+      sprintf(outstring, "unknown3 %d", instruction.part.unknown3 & 3);
+      outstring += strlen(outstring);
+   }
+}

--- a/yabause/src/scspdsp.c
+++ b/yabause/src/scspdsp.c
@@ -20,8 +20,6 @@
 #include "scsp.h"
 #include "scspdsp.h"
 
-struct ScspDsp scsp_dsp;
-
 void ScspDspDisasm(u8 addr, char *outstring)
 {
    union ScspDspInstruction instruction;
@@ -33,7 +31,7 @@ void ScspDspDisasm(u8 addr, char *outstring)
 
    if (instruction.all == 0)
    {
-      sprintf(outstring, "nop ", addr);
+      sprintf(outstring, "nop ");
       outstring += strlen(outstring);
       return;
    }
@@ -46,13 +44,13 @@ void ScspDspDisasm(u8 addr, char *outstring)
 
    if (instruction.part.coef)
    {
-      sprintf(outstring, "coef %02X ", instruction.part.coef & 0x3F);
+      sprintf(outstring, "coef %02X ", (unsigned int)(instruction.part.coef & 0x3F));
       outstring += strlen(outstring);
    }
 
    if (instruction.part.masa)
    {
-      sprintf(outstring, "masa %02X ", instruction.part.masa & 0x1F);
+      sprintf(outstring, "masa %02X ", (unsigned int)(instruction.part.masa & 0x1F));
       outstring += strlen(outstring);
    }
 
@@ -94,7 +92,7 @@ void ScspDspDisasm(u8 addr, char *outstring)
 
    if (instruction.part.ewa)
    {
-      sprintf(outstring, "ewa %01X ", instruction.part.ewa & 0xf);
+      sprintf(outstring, "ewa %01X ", (unsigned int)(instruction.part.ewa & 0xf));
       outstring += strlen(outstring);
    }
 
@@ -112,7 +110,7 @@ void ScspDspDisasm(u8 addr, char *outstring)
 
    if (instruction.part.shift)
    {
-      sprintf(outstring, "shift %d ", instruction.part.shift & 3);
+      sprintf(outstring, "shift %d ", (int)(instruction.part.shift & 3));
       outstring += strlen(outstring);
    }
 
@@ -148,13 +146,13 @@ void ScspDspDisasm(u8 addr, char *outstring)
 
    if (instruction.part.ysel)
    {
-      sprintf(outstring, "ysel %d ", instruction.part.ysel & 3);
+      sprintf(outstring, "ysel %d ", (int)(instruction.part.ysel & 3));
       outstring += strlen(outstring);
    }
 
    if (instruction.part.ira)
    {
-      sprintf(outstring, "ira %02X ", instruction.part.ira & 0x3F);
+      sprintf(outstring, "ira %02X ", (int)(instruction.part.ira & 0x3F));
       outstring += strlen(outstring);
    }
 
@@ -166,13 +164,13 @@ void ScspDspDisasm(u8 addr, char *outstring)
 
    if (instruction.part.iwa)
    {
-      sprintf(outstring, "iwa %02X ", instruction.part.iwa & 0x1F);
+      sprintf(outstring, "iwa %02X ", (unsigned int)(instruction.part.iwa & 0x1F));
       outstring += strlen(outstring);
    }
 
    if (instruction.part.tra)
    {
-      sprintf(outstring, "tra %02X ", instruction.part.tra & 0x7F);
+      sprintf(outstring, "tra %02X ", (unsigned int)(instruction.part.tra & 0x7F));
       outstring += strlen(outstring);
    }
 
@@ -184,25 +182,25 @@ void ScspDspDisasm(u8 addr, char *outstring)
 
    if (instruction.part.twa)
    {
-      sprintf(outstring, "twa %02X ", instruction.part.twa & 0x7F);
+      sprintf(outstring, "twa %02X ", (unsigned int)(instruction.part.twa & 0x7F));
       outstring += strlen(outstring);
    }
 
    if (instruction.part.unknown)
    {
-      sprintf(outstring, "unknown ", addr);
+      sprintf(outstring, "unknown ");
       outstring += strlen(outstring);
    }
 
    if (instruction.part.unknown2)
    {
-      sprintf(outstring, "unknown2 ", addr);
+      sprintf(outstring, "unknown2 ");
       outstring += strlen(outstring);
    }
 
    if (instruction.part.unknown3)
    {
-      sprintf(outstring, "unknown3 %d", instruction.part.unknown3 & 3);
+      sprintf(outstring, "unknown3 %d", (int)(instruction.part.unknown3 & 3));
       outstring += strlen(outstring);
    }
 }

--- a/yabause/src/scspdsp.h
+++ b/yabause/src/scspdsp.h
@@ -22,4 +22,103 @@
 
 #include "core.h"
 
+struct ScspDsp
+{
+   u64 mpro[128];
+   u16 coef[64];
+   u16 madrs[32];
+};
+
+//dsp instruction format
+
+//bits 63-48
+//|nofl |                coef               |     ?     |            masa             |adreb|nxadr|
+//|  F  |  E  |  D  |  C  |  B  |  A  |  9  |  8  |  7  |  6  |  5  |  4  |  3  |  2  |  1  |  0  |
+
+//bits 47-32
+//|table| mwt | mrd | ewt |          ewa          |adrl |frcl |   shift   | yrl |negb |zero |bsel |
+//|  F  |  E  |  D  |  C  |  B  |  A  |  9  |  8  |  7  |  6  |  5  |  4  |  3  |  2  |  1  |  0  |
+
+//bits 31-16
+//|xsel |    ysel   |  ?  |                ira                | iwt |             iwa             |
+//|  F  |  E  |  D  |  C  |  B  |  A  |  9  |  8  |  7  |  6  |  5  |  4  |  3  |  2  |  1  |  0  |
+
+//bits 15-0
+//|  ?  |                   tra                   | twt |                   twa                   |
+//|  F  |  E  |  D  |  C  |  B  |  A  |  9  |  8  |  7  |  6  |  5  |  4  |  3  |  2  |  1  |  0  |
+
+#ifdef WORDS_BIGENDIAN
+union ScspDspInstruction {
+   struct {
+      u64 nofl : 1;
+      u64 coef : 6;
+      u64 unknown3 : 2;
+      u64 masa : 5;
+      u64 adreb : 1;
+      u64 nxadr : 1;
+      u64 table : 1;
+      u64 mwt : 1;
+      u64 mrd : 1;
+      u64 ewt : 1;
+      u64 ewa : 4;
+      u64 adrl : 1;
+      u64 frcl : 1;
+      u64 shift : 2;
+      u64 yrl : 1;
+      u64 negb : 1;
+      u64 zero : 1;
+      u64 bsel : 1;
+      u64 xsel : 1;
+      u64 ysel : 2;
+      u64 unknown2 : 1;
+      u64 ira : 6;
+      u64 iwt : 1;
+      u64 iwa : 5;
+      u64 unknown : 1;
+      u64 tra : 7;
+      u64 twt : 1;
+      u64 twa : 7;
+   } part;
+   u32 all;
+};
+#else
+union ScspDspInstruction {
+   struct {
+      u64 twa : 7;
+      u64 twt : 1;
+      u64 tra : 7;
+      u64 unknown : 1;
+      u64 iwa : 5;
+      u64 iwt : 1;
+      u64 ira : 6;
+      u64 unknown2 : 1;
+      u64 ysel : 2;
+      u64 xsel : 1;
+      u64 bsel : 1;
+      u64 zero : 1;
+      u64 negb : 1;
+      u64 yrl : 1;
+      u64 shift : 2;
+      u64 frcl : 1;
+      u64 adrl : 1;
+      u64 ewa : 4;
+      u64 ewt : 1;
+      u64 mrd : 1;
+      u64 mwt : 1;
+      u64 table : 1;
+      u64 nxadr : 1;
+      u64 adreb : 1;
+      u64 masa : 5;
+      u64 unknown3 : 2;
+      u64 coef : 6;
+      u64 nofl : 1;
+   } part;
+   u64 all;
+};
+#endif
+
+void ScspDspDisasm(u8 addr, char *outstring);
+
+extern struct ScspDsp scsp_dsp;
+
 #endif

--- a/yabause/src/scspdsp.h
+++ b/yabause/src/scspdsp.h
@@ -22,12 +22,12 @@
 
 #include "core.h"
 
-struct ScspDsp
+typedef struct
 {
    u64 mpro[128];
    u16 coef[64];
    u16 madrs[32];
-};
+}ScspDsp;
 
 //dsp instruction format
 
@@ -119,6 +119,6 @@ union ScspDspInstruction {
 
 void ScspDspDisasm(u8 addr, char *outstring);
 
-extern struct ScspDsp scsp_dsp;
+extern ScspDsp scsp_dsp;
 
 #endif

--- a/yabause/src/yabause.c
+++ b/yabause/src/yabause.c
@@ -39,6 +39,7 @@
 #include "m68kcore.h"
 #include "peripheral.h"
 #include "scsp.h"
+#include "scspdsp.h"
 #include "scu.h"
 #include "sh2core.h"
 #include "smpc.h"
@@ -93,6 +94,8 @@
 yabsys_struct yabsys;
 const char *bupfilename = NULL;
 u64 tickfreq;
+//todo this ought to be in scspdsp.c
+ScspDsp scsp_dsp;
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/yabauseut/src/main.c
+++ b/yabauseut/src/main.c
@@ -153,6 +153,7 @@ void (*auto_tests[])() =
    //scsp
    scsp_timing_test,
    scsp_misc_test,
+   scsp_dsp_test,
    //smpc
    //vdp1
    //vdp2

--- a/yabauseut/src/scsp.h
+++ b/yabauseut/src/scsp.h
@@ -23,6 +23,7 @@
 void scsp_test();
 void scsp_timing_test();
 void scsp_misc_test();
+void scsp_dsp_test();
 
 void scu_interrupt_test(void);
 void scsp_timer_a_test();


### PR DESCRIPTION
Writes and reads for coef, madrs and mpro now work. The disassembler doesn't attempt to regenerate the original program, but just print out which bits are set in each instruction. 

Also checkout a specific yabauseut binary to prevent build breakage.