### PR TITLE
Add Vdp1 automated framebuffer testing and Coverity on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - compiler: gcc
       env: testenv="linux gcc"
       
-
     # linux clang
     - compiler: clang
       env: testenv="linux clang"
@@ -52,21 +51,40 @@ matrix:
       script:
         - cd ../src/runner
         - git clone git://github.com/lvandeve/lodepng.git
-        - cd lodepng
-        - cd ../../../build
+        - cd ../../build
         - cmake -DYAB_PORTS=runner -DSH2_DYNAREC=OFF -DYAB_WANT_C68K=OFF -DYAB_WANT_Q68=OFF -DYAB_WANT_OPENGL=OFF ..
         - make
         - cd src/runner
         # todo compile this instead
         - git clone git://github.com/d356/yabauseut-bin.git
         - cd yabauseut-bin
-        - git reset --hard 9875a6f113bc796b68bd484245e709a04548d7cc
+        - git reset --hard c3af00208ccf9554ddd91054629bcfd45f3a479a
         - cd ..
-        - ./yabause yabauseut-bin/YabauseUT.elf yabauseut-bin/vdp2_screenshots/
+        - ./yabause yabauseut-bin/YabauseUT.elf yabauseut-bin/vdp2_screenshots/ yabauseut-bin/vdp1_framebuffers/
+
+addons:
+  coverity_scan:
+    project:
+      name: "d356/yabause"
+      description: "Build submitted via Travis CI"
+    notification_email: username@example.com
+    build_command_prepend: "cmake ..;"
+    build_command: "make"
+    branch_pattern: coverity_scan
+
+env:
+  global:
+    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+    # via the "travis encrypt" command using the project repo's public key
+    - secure: "ACqDxwFJr0wwvAjyrHMyknxot9OJ4wg6F8pE+aEi6C1pL+VVlHfOUs0b+jREm+Icd2jZanv4UzPi3EIJxsIL82sbGkgFe0kILaE8UfycxYso7y10k+gwefI0cS3el+WcpyHX5rMablPE9FaDd4Cug8FsvJjwTsW88/JosCepn2IZ6HtMAheuNZnDi5D2nCEvJHkE1vXzGZrfgu6rfY2hXOv/wUqegx2XMJq0vGdOn9JE92UqRaLkfNZXlRsCLWre0isy/AO0QdRwmV9668aYrRFDtfEdoMy2xWuCNpeWWenxz5ZniPJrPaCOQlOtlPBgTzuu6HZoR0JLJKApa0IflkPByKdOLWXwOA7W4RWbonfHR5LCm2z3SO0MhkTk/c7UE3+a6GtfwH+0KAl+V6WQ0MfVhVwlY/UG+KhQbpJSLLP70H3zjGU+4Dbmm9Ogt3Je2AmxzHtmsuyyJUI7Z6gDmu3aUDYuLrPVSlIA96i/YoZkEdXJLUphwGHvDzT+vK8H1IBgXMVKumD3I0PHY1AonQaOaCJ5ihFPecGqqRiETQndNKkVYdNDLdCnEYKgLQFppqgfcainyAhyyK9wmqracPEoq09GTnv+je82hoj8Dm68xqLbWMKQAhm1ArPClNCOU43KR03gve6Cr6ebLq2rSQqEiaeQfIwULhKvdUxLYb4="
 
 language: cpp
 
+sudo: false
+
 before_install:
+  # only build the first port if running a coverity scan. otherwise coverity will attempt to analyze all the builds
+  - if ([[ "${TRAVIS_JOB_NUMBER##*.}" != "1" ]] && [[ "${TRAVIS_BRANCH}" == "coverity_scan" ]]); then false ; fi
   - cd yabause
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
         # todo compile this instead
         - git clone git://github.com/d356/yabauseut-bin.git
         - cd yabauseut-bin
-        - git reset --hard c3af00208ccf9554ddd91054629bcfd45f3a479a
+        - git reset --hard ac1bedadc51285f55a0caa9e6af6ab0d9d0118c8
         - cd ..
         - ./yabause yabauseut-bin/YabauseUT.elf yabauseut-bin/vdp2_screenshots/ yabauseut-bin/vdp1_framebuffers/
 

--- a/yabauseut/src/main.c
+++ b/yabauseut/src/main.c
@@ -136,7 +136,7 @@ void yabauseut_init()
 #ifdef BUILD_AUTOMATED_TESTING
 
 void (*auto_tests[])() =
-{ 
+{
    //sh2
    sh2_test,
    //sh2 slave
@@ -156,6 +156,7 @@ void (*auto_tests[])() =
    scsp_dsp_test,
    //smpc
    //vdp1
+   vdp1_framebuffer_tests,
    //vdp2
    vdp2_auto_tests,
    auto_test_all_finished

--- a/yabauseut/src/tests.c
+++ b/yabauseut/src/tests.c
@@ -157,6 +157,16 @@ void auto_test_take_screenshot(int frames_to_wait)
 
 //////////////////////////////////////////////////////////////////////////////
 
+void auto_test_get_framebuffer()
+{
+#ifdef BUILD_AUTOMATED_TESTING
+   auto_test_send_message("FRAMEBUFFER", "");
+#endif
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+
 void init_test(void)
 {
    // Put saturn in a minimalized state

--- a/yabauseut/src/tests.h
+++ b/yabauseut/src/tests.h
@@ -59,6 +59,7 @@ void auto_test_take_screenshot();
 void auto_test_section_start(char* test_section_name);
 void auto_test_sub_test_start(char* sub_test_name);
 void auto_test_section_end();
+void auto_test_get_framebuffer();
 
 extern screen_settings_struct test_disp_settings;
 extern font_struct test_disp_font;

--- a/yabauseut/src/vdp1.c
+++ b/yabauseut/src/vdp1.c
@@ -57,53 +57,83 @@ void vdp1_clip_test()
 
    u16* p = (u16 *)(0x25C00000 + gouraud_table_address);
 
+   auto_test_sub_test_start("Clipping test");
+
+   VDP1_REG_FBCR = 0;
+
+   vdp_start_draw_list();
+
+   sprite_struct quad;
+
+   quad.x = 0;
+   quad.y = 0;
+
+   vdp_local_coordinate(&quad);
+
+   //system clipping
+   quad.x = 319 - 8;
+   quad.y = 223 - 8;
+
+   vdp_system_clipping(&quad);
+
+   //user clipping
+   quad.x = 8;
+   quad.y = 8;
+   quad.x2 = 319 - 16;
+   quad.y2 = 223 - 16;
+
+   vdp_user_clipping(&quad);
+
+   //fullscreen polygon
+   quad.x = 319;
+   quad.y = 0;
+   quad.x2 = 319;
+   quad.y2 = 223;
+   quad.x3 = 0;
+   quad.y3 = 223;
+   quad.x4 = 0;
+   quad.y4 = 0;
+
+   quad.bank = RGB16(0x10, 0x10, 0x10);//gray
+
+   quad.gouraud_addr = gouraud_table_address;
+
+   quad.attr = (clipping_mode << 9) | 4;//use gouraud shading
+
+   //red, green, blue, and white
+   p[0] = RGB16(31, 0, 0);
+   p[1] = RGB16(0, 31, 0);
+   p[2] = RGB16(0, 0, 31);
+   p[3] = RGB16(31, 31, 31);
+
+   vdp_draw_polygon(&quad);
+
+   vdp_end_draw_list();
+
+   vdp_vsync();
+
+   VDP1_REG_FBCR = 3;
+
+   vdp_vsync();
+   vdp_vsync();
+
+#ifdef BUILD_AUTOMATED_TESTING
+
+   auto_test_get_framebuffer();
+
+#else
+
    for (;;)
    {
-      vdp_start_draw_list();
+      while (!(VDP2_REG_TVSTAT & 8)) 
+      {
+         ud_check(0);
+      }
 
-      sprite_struct quad;
-
-      //system clipping
-      quad.x = 319 - 8;
-      quad.y = 223 - 8;
-
-      vdp_system_clipping(&quad);
-
-      //user clipping
-      quad.x = 8;
-      quad.y = 8;
-      quad.x2 = 319 - 16;
-      quad.y2 = 223 - 16;
-
-      vdp_user_clipping(&quad);
-
-      //fullscreen polygon
-      quad.x = 319;
-      quad.y = 0;
-      quad.x2 = 319;
-      quad.y2 = 223;
-      quad.x3 = 0;
-      quad.y3 = 223;
-      quad.x4 = 0;
-      quad.y4 = 0;
-
-      quad.bank = RGB16(0x10, 0x10, 0x10);//gray
-
-      quad.gouraud_addr = gouraud_table_address;
-
-      quad.attr = (clipping_mode << 9) | 4;//use gouraud shading
-
-      //red, green, blue, and white
-      p[0] = RGB16(31, 0, 0);
-      p[1] = RGB16(0, 31, 0);
-      p[2] = RGB16(0, 0, 31);
-      p[3] = RGB16(31, 31, 31);
-
-      vdp_draw_polygon(&quad);
-
-      vdp_end_draw_list();
-
-      vdp_vsync();
+      while (VDP2_REG_TVSTAT & 8) 
+      {
+         
+      }
 
       if (per[0].but_push_once & PAD_A)
       {
@@ -120,7 +150,20 @@ void vdp1_clip_test()
 
       if (per[0].but_push_once & PAD_START)
          break;
+
+      if (per[0].but_push_once & PAD_X)
+      {
+         ar_menu();
+      }
+
+      if (per[0].but_push_once & PAD_Y)
+      {
+         reset_system();
+      }
    }
+
+#endif
+
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -131,3 +174,66 @@ void vdp1_misc_test()
 
 //////////////////////////////////////////////////////////////////////////////
 
+void vdp1_framebuffer_write_test()
+{
+   volatile u16* framebuffer_ptr = (volatile u16*)0x25C80000;
+   int i;
+
+   vdp_vsync();
+
+   VDP1_REG_FBCR = 3;
+
+   //we have to wait a little bit so we don't write to both framebuffers
+   vdp_wait_hblankout();
+
+   for (i = 0; i < 128; i += 4)
+   {
+      framebuffer_ptr[i + 0] = 0xdead;
+      framebuffer_ptr[i + 1] = 0xbeef;
+      framebuffer_ptr[i + 2] = 0xfeed;
+      framebuffer_ptr[i + 3] = 0xcafe;
+   }
+
+#ifdef BUILD_AUTOMATED_TESTING
+
+   auto_test_get_framebuffer();
+
+#else
+
+   for (;;)
+   {
+      while (!(VDP2_REG_TVSTAT & 8))
+      {
+         ud_check(0);
+      }
+
+      while (VDP2_REG_TVSTAT & 8) {}
+
+      if (per[0].but_push_once & PAD_START)
+         break;
+
+      if (per[0].but_push_once & PAD_X)
+      {
+         ar_menu();
+      }
+
+      if (per[0].but_push_once & PAD_Y)
+      {
+         reset_system();
+      }
+   }
+#endif
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void vdp1_framebuffer_tests()
+{
+   auto_test_section_start("Vdp1 framebuffer tests");
+
+   vdp1_clip_test();
+
+   auto_test_section_end();
+}
+
+//////////////////////////////////////////////////////////////////////////////

--- a/yabauseut/src/vdp1.h
+++ b/yabauseut/src/vdp1.h
@@ -24,4 +24,5 @@ void vdp1_test();
 void vdp1_draw_test();
 void vdp1_clip_test();
 void vdp1_misc_test();
+void vdp1_framebuffer_tests();
 #endif


### PR DESCRIPTION
The runner port can now compare Vdp1 framebuffer captures from actual hardware to Yabause's vidsoft Vdp1. 

[Coverity] (https://scan.coverity.com/) is a free service for open source projects that does analysis to look for bugs. The travis.yml file needs a few changes to work on this fork of Yabause. The project name needs to be changed to Yabause/yabause and the secure token needs to be changed to the repository owner's token, which can be generated on Coverity's website.

After signing up for Coverity, a scan can be started by pushing to the coverity_scan branch. I did not set up the master branch for scanning because there are a limited number of scans allowed per week, and there seems to be no way to prevent Coverity from scanning all 5 builds on Travis CI. When the coverity_scan branch is pushed, all builds except the first one will be stopped for this reason.