### PR TITLE
Build fixes for newer Cmake, linux, allow building without a C++ compiler

### DIFF
--- a/yabause/src/CMakeLists.txt
+++ b/yabause/src/CMakeLists.txt
@@ -4,6 +4,8 @@ include (CheckCSourceCompiles)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
 
+cmake_minimum_required(VERSION 2.8)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/CMakeTests)
 
 set(yabause_HEADERS

--- a/yabause/src/runner/CMakeLists.txt
+++ b/yabause/src/runner/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(yabause-runner)
 
+cmake_minimum_required(VERSION 2.8)
+
 yab_port_start()
 
 if ((NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lodepng/lodepng.h") OR (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lodepng/lodepng.cpp"))

--- a/yabauseut/CMakeLists.txt
+++ b/yabauseut/CMakeLists.txt
@@ -11,11 +11,6 @@ if(WANT_AUTOMATED_TESTING)
   add_definitions(-DBUILD_AUTOMATED_TESTING)
 endif()
 
-# Specify the cross compiler.
-CMAKE_FORCE_C_COMPILER("C:/Program Files (x86)/KPIT Cummins/GNUSHv10.02-ELF/sh-elf/bin/sh-elf-gcc.exe" GNU)
-CMAKE_FORCE_CXX_COMPILER("C:/Program Files (x86)/KPIT Cummins/GNUSHv10.02-ELF/sh-elf/bin/sh-elf-g++.exe" GNU)
-SET(CMAKE_FIND_ROOT_PATH "C:/Program Files (x86)/KPIT Cummins/GNUSHv10.02-ELF/sh-elf/bin/" "C:/Program Files (x86)/KPIT Cummins/GNUSHv10.02-ELF/Other Utilities/")
-
 find_path(IAPETUS_INCLUDE_DIR 
           NAMES iapetus.h
           PATHS ${IAPETUS_ROOT_PATH}/include
@@ -34,7 +29,7 @@ if (IAPETUS_INCLUDE_DIR STREQUAL "IAPETUS_INCLUDE_DIR-NOTFOUND")
    set(IAPETUS_INCLUDE_DIR ${source_dir}/src)
 endif(IAPETUS_INCLUDE_DIR STREQUAL "IAPETUS_INCLUDE_DIR-NOTFOUND")
 
-PROJECT(YabauseUT)
+PROJECT(YabauseUT C)
 
 include_directories(${IAPETUS_INCLUDE_DIR})
 

--- a/yabauseut/src/CMakeLists.txt
+++ b/yabauseut/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(YabauseUT)
+project(YabauseUT C)
 
 enable_language(ASM)
 set(YabauseUT_SOURCES


### PR DESCRIPTION
Some versions of Cmake seem to be more strict about having cmake_minimum_required() present.

The hard-coded paths in  yabauseut/CMakeLists.txt make it hard to compile on linux. These paths can be specified on the command line with the -D prefix.

By default Cmake wants a C++ compiler present. Adding "C" to project declarations makes it so that Cmake doesn't check for one and error if it isn't available.