### PR TITLE
Build and test YabauseUT on CircleCI using Docker

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  services:
+    - docker
+
+checkout:
+  post:
+    - cd .. && git clone https://github.com/d356/yabauseut-docker.git
+
+test:
+  override:
+    - cd .. && cp -r yabause yabauseut-docker && cd yabauseut-docker && docker build .


### PR DESCRIPTION
CircleCI is a continuous integration service that allows the usage of Docker images and is free for open source projects. As far as I know, CircleCI is the only one that allows this. 

With Docker, a container can be created with a pre-compiled sh-elf-gcc on it suitable for compiling Saturn binaries.

The Dockerfile that creates the sh toolchain can be seen here: https://github.com/d356/sh2-gcc-docker/blob/master/sh2-gcc/Dockerfile

That Dockerfile results in a pre-built container that is stored on Dockerhub.

That base container is fetched from Dockerhub and used in another Dockerfile that compiles Iapetus, YabauseUT, yabause-runner, and then runs the tests.

The second Dockerfile can be seen here: https://github.com/d356/yabauseut-docker/blob/master/Dockerfile

CircleCI automatically clones the Yabause repository, and then the commands in circle.yml are run to build the container, which runs all the mentioned tasks.

The output on CircleCI should look like this: http://pastebin.com/54BdrMuK