### PR TITLE
Improve per-pixel special priority

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,23 +45,6 @@ matrix:
         - cmake -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake -DYAB_PORTS= ..
         - make
 
-    # compile runner and run yabauseut tests
-    - compiler: gcc
-      env: testenv="compile runner and run yabauseut tests"
-      script:
-        - cd ../src/runner
-        - git clone git://github.com/lvandeve/lodepng.git
-        - cd ../../build
-        - cmake -DYAB_PORTS=runner -DSH2_DYNAREC=OFF -DYAB_WANT_C68K=OFF -DYAB_WANT_Q68=OFF -DYAB_WANT_OPENGL=OFF ..
-        - make
-        - cd src/runner
-        # todo compile this instead
-        - git clone git://github.com/d356/yabauseut-bin.git
-        - cd yabauseut-bin
-        - git reset --hard ac1bedadc51285f55a0caa9e6af6ab0d9d0118c8
-        - cd ..
-        - ./yabause yabauseut-bin/YabauseUT.elf yabauseut-bin/vdp2_screenshots/ yabauseut-bin/vdp1_framebuffers/
-
 addons:
   coverity_scan:
     project:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ build_script:
   - if ["%compiler_type%"]==["mingw32"] cmake --build .
 
   # force a release build and only show errors to shorten output
-  - if ["%compiler_type%"]==["vs12-x64"] msbuild yabause.sln /p:configuration=Release /clp:ErrorsOnly /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - if ["%compiler_type%"]==["vs12-x64"] msbuild yabause.sln /p:configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 # make a distributable package of the build output
 after_build:

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -647,6 +647,56 @@ static u8 FASTCALL GetAlpha(vdp2draw_struct * info, u32 color, u32 dot)
 
 //////////////////////////////////////////////////////////////////////////////
 
+int PixelIsSpecialPriority(int specialcode, int dot)
+{
+   dot &= 0xf;
+
+   if (specialcode & 0x01)
+   {
+      if (dot == 0 || dot == 1)
+         return 1;
+   }
+   if (specialcode & 0x02)
+   {
+      if (dot == 2 || dot == 3)
+         return 1;
+   }
+   if (specialcode & 0x04)
+   {
+      if (dot == 4 || dot == 5)
+         return 1;
+   }
+   if (specialcode & 0x08)
+   {
+      if (dot == 6 || dot == 7)
+         return 1;
+   }
+   if (specialcode & 0x10)
+   {
+      if (dot == 8 || dot == 9)
+         return 1;
+   }
+   if (specialcode & 0x20)
+   {
+      if (dot == 0xa || dot == 0xb)
+         return 1;
+   }
+   if (specialcode & 0x40)
+   {
+      if (dot == 0xc || dot == 0xd)
+         return 1;
+   }
+   if (specialcode & 0x80)
+   {
+      if (dot == 0xe || dot == 0xf)
+         return 1;
+   }
+
+   return 0;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info)
 {
    int i, j;
@@ -788,21 +838,16 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info)
             continue;
          }
 
-
          priority = info->priority;
 
          //per-pixel priority is on
          if (info->specialprimode == 2)
          {
-            //the special function in the pattern name
-            //data must be on as well
+            priority = info->priority & 0xE;
+
             if (info->specialfunction & 1)
             {
-               priority = info->priority & 0xE;
-
-               //everything but the specified dot
-               //makes the priority lsb 0
-               if ((info->specialcode & (1 << ((dot & 0xF) >> 1))) == 0)
+               if (PixelIsSpecialPriority(info->specialcode,dot))
                {
                   priority |= 1;
                }


### PR DESCRIPTION
Fixes Wonderboy in FBA Saturn.

I don't think per-pixel priority can be 100% fixed unless priority handling is moved so that it takes place after pixel generation.

Here is an example:
Nbg0 is drawn at priority 1. Then nbg1 is drawn at priority 0, and some pixels are raised to priority 1 using special priority. Since nbg1 is drawn after nbg0, the pixels raised to priority 1 will overwrite nbg0 pixels. However this is incorrect, since nbg0 has a higher priority than nbg1 when they have the same priority.