### PR TITLE
Improve special priority and add optional multi-threading to vidsoft

### DIFF
--- a/yabause/src/CMakeLists.txt
+++ b/yabause/src/CMakeLists.txt
@@ -647,6 +647,24 @@ endif()
 if (YAB_WANT_OPENSL)
     set(HAVE_OPENSL ON)
 endif()
+
+if (YAB_WANT_VIDSOFT_RENDER_THREADING OR YAB_WANT_VIDSOFT_LAYER_THREADING)
+
+    find_package(OpenMP)
+
+    if (OPENMP_FOUND)
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+        if (YAB_WANT_VIDSOFT_RENDER_THREADING)
+            add_definitions(-DWANT_VIDSOFT_RENDER_THREADING)
+            message(STATUS "Using vidsoft render threading")
+        endif()
+        if (YAB_WANT_VIDSOFT_LAYER_THREADING)
+            add_definitions(-DWANT_VIDSOFT_LAYER_THREADING)
+            message(STATUS "Using vidsoft layer threading")
+        endif()
+    endif()
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 if (YAB_NETWORK AND UNIX)

--- a/yabause/src/titan/titan.c
+++ b/yabause/src/titan/titan.c
@@ -18,6 +18,7 @@
 */
 
 #include "titan.h"
+#include "../vidshared.h"
 
 #include <stdlib.h>
 
@@ -25,20 +26,31 @@
 typedef u32 (*TitanBlendFunc)(u32 top, u32 bottom);
 typedef int FASTCALL (*TitanTransFunc)(u32 pixel);
 
+struct PixelData
+{
+   u32 pixel;
+   u8 priority;
+   u8 linescreen;
+   u8 shadow_type;
+   u8 shadow_enabled;
+};
+
 static struct TitanContext {
    int inited;
-   u32 * vdp2framebuffer[8];
+   struct PixelData * vdp2framebuffer[8];
    u32 * linescreen[4];
    int vdp2width;
    int vdp2height;
    TitanBlendFunc blend;
    TitanTransFunc trans;
+   struct PixelData * backscreen;
 } tt_context = {
    0,
    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL },
    { NULL, NULL, NULL, NULL },
    320,
-   224
+   224,
+   NULL,NULL,NULL
 };
 
 #if defined WORDS_BIGENDIAN
@@ -135,28 +147,85 @@ static INLINE int FASTCALL TitanTransBit(u32 pixel)
    return pixel & 0x80000000;
 }
 
-static u32 TitanDigPixel(int priority, int pos)
+static u32 TitanDigPixel(int pos, int y)
 {
-   u32 pixel = 0;
-   while((priority > -1) && (! pixel))
-   {
-      pixel = tt_context.vdp2framebuffer[priority][pos];
-      priority--;
-   }
-   tt_context.vdp2framebuffer[priority + 1][pos] = 0;
-   if (priority == -1) return pixel;
+   struct PixelData pixel_stack[8] = { 0 };
 
-   if (tt_context.trans(pixel))
+   int pixel_stack_pos = 0;
+
+   int priority;
+
+   //sort the pixels from highest to lowest priority
+   for (priority = 7; priority > 0; priority--)
    {
-      u32 bottom = TitanDigPixel(priority, pos);
-      pixel = tt_context.blend(pixel, bottom);
+      int which_layer;
+
+      for (which_layer = TITAN_SPRITE; which_layer >= 0; which_layer--)
+      {
+         if (tt_context.vdp2framebuffer[which_layer][pos].priority == priority)
+         {
+            pixel_stack[pixel_stack_pos] = tt_context.vdp2framebuffer[which_layer][pos];
+            pixel_stack_pos++;
+         }
+      }
    }
-   else while (priority > 0)
+
+   pixel_stack[pixel_stack_pos] = tt_context.backscreen[pos];
+
+   if (!tt_context.trans)
    {
-      tt_context.vdp2framebuffer[priority][pos] = 0;
-      priority--;
+      return 0;
    }
-   return pixel;
+
+   if (pixel_stack[0].linescreen)
+   {
+      pixel_stack[0].pixel = tt_context.blend(pixel_stack[0].pixel, tt_context.linescreen[pixel_stack[0].linescreen][y]);
+   }
+
+   if ((pixel_stack[0].shadow_type == TITAN_MSB_SHADOW) && ((pixel_stack[0].pixel & 0xFFFFFF) == 0))
+   {
+      //transparent sprite shadow
+      if (pixel_stack[1].shadow_enabled)
+      {
+         pixel_stack[0].pixel = TitanBlendPixelsTop(0x20000000, pixel_stack[1].pixel);
+      }
+      else
+      {
+         pixel_stack[0].pixel = pixel_stack[1].pixel;
+      }
+   }
+   else if (pixel_stack[0].shadow_type == TITAN_MSB_SHADOW && ((pixel_stack[0].pixel & 0xFFFFFF) != 0))
+   {
+      if (tt_context.trans(pixel_stack[0].pixel))
+      {
+         u32 bottom = pixel_stack[1].pixel;
+         pixel_stack[0].pixel = tt_context.blend(pixel_stack[0].pixel, bottom);
+      }
+
+      //sprite self-shadowing
+      pixel_stack[0].pixel = TitanBlendPixelsTop(0x20000000, pixel_stack[0].pixel);
+   }
+   else if (pixel_stack[0].shadow_type == TITAN_NORMAL_SHADOW)
+   {
+      if (pixel_stack[1].shadow_enabled)
+      {
+         pixel_stack[0].pixel = TitanBlendPixelsTop(0x20000000, pixel_stack[1].pixel);
+      }
+      else
+      {
+         pixel_stack[0].pixel = pixel_stack[1].pixel;
+      }
+   }
+   else
+   {
+      if (tt_context.trans(pixel_stack[0].pixel))
+      {
+         u32 bottom = pixel_stack[1].pixel;
+         pixel_stack[0].pixel = tt_context.blend(pixel_stack[0].pixel, bottom);
+      }
+   }
+
+   return pixel_stack[0].pixel;
 }
 
 /* public */
@@ -168,7 +237,7 @@ int TitanInit()
    {
       for(i = 0;i < 8;i++)
       {
-         if ((tt_context.vdp2framebuffer[i] = (u32 *)calloc(sizeof(u32), 704 * 512)) == NULL)
+         if ((tt_context.vdp2framebuffer[i] = (struct PixelData *)calloc(sizeof(struct PixelData), 704 * 512)) == NULL)
             return -1;
       }
 
@@ -178,6 +247,9 @@ int TitanInit()
          if ((tt_context.linescreen[i] = (u32 *)calloc(sizeof(u32), 512)) == NULL)
             return -1;
       }
+
+      if ((tt_context.backscreen = (struct PixelData  *)calloc(sizeof(struct PixelData), 704 * 512)) == NULL)
+         return -1;
 
       tt_context.inited = 1;
    }
@@ -189,6 +261,14 @@ int TitanInit()
       memset(tt_context.linescreen[i], 0, sizeof(u32) * 512);
 
    return 0;
+}
+
+void TitanErase()
+{
+   int i = 0;
+
+   for (i = 0; i < 8; i++)
+      memset(tt_context.vdp2framebuffer[i], 0, sizeof(struct PixelData) * 704 * 512);
 }
 
 int TitanDeInit()
@@ -237,11 +317,11 @@ void TitanSetBlendingMode(int blend_mode)
 
 void TitanPutBackHLine(s32 y, u32 color)
 {
-   u32 * buffer = tt_context.vdp2framebuffer[0] + (y * tt_context.vdp2width);
+   struct PixelData* buffer = &tt_context.backscreen[(y * tt_context.vdp2width)];
    int i;
 
    for (i = 0; i < tt_context.vdp2width; i++)
-      buffer[i] = color;
+      buffer[i].pixel = color;
 }
 
 void TitanPutLineHLine(int linescreen, s32 y, u32 color)
@@ -254,18 +334,17 @@ void TitanPutLineHLine(int linescreen, s32 y, u32 color)
    }
 }
 
-void TitanPutPixel(int priority, s32 x, s32 y, u32 color, int linescreen)
+void TitanPutPixel(int priority, s32 x, s32 y, u32 color, int linescreen, vdp2draw_struct* info)
 {
    if (priority == 0) return;
 
    {
       int pos = (y * tt_context.vdp2width) + x;
-      u32 * buffer = tt_context.vdp2framebuffer[priority] + pos;
-      if (linescreen)
-         color = tt_context.blend(color, tt_context.linescreen[linescreen][y]);
-      if (tt_context.trans(color) && *buffer)
-         color = tt_context.blend(color, *buffer);
-      *buffer = color;
+      tt_context.vdp2framebuffer[info->titan_which_layer][pos].pixel = color;
+      tt_context.vdp2framebuffer[info->titan_which_layer][pos].priority = priority;
+      tt_context.vdp2framebuffer[info->titan_which_layer][pos].linescreen = linescreen;
+      tt_context.vdp2framebuffer[info->titan_which_layer][pos].shadow_enabled = info->titan_shadow_enabled;
+      tt_context.vdp2framebuffer[info->titan_which_layer][pos].shadow_type = info->titan_shadow_type;
    }
 }
 
@@ -274,36 +353,41 @@ void TitanPutHLine(int priority, s32 x, s32 y, s32 width, u32 color)
    if (priority == 0) return;
 
    {
-      u32 * buffer = tt_context.vdp2framebuffer[priority] + (y * tt_context.vdp2width) + x;
+      struct PixelData * buffer = &tt_context.vdp2framebuffer[priority][ (y * tt_context.vdp2width) + x];
       int i;
 
       for (i = 0; i < width; i++)
-         buffer[i] = color;
-   }
-}
-
-void TitanPutShadow(int priority, s32 x, s32 y)
-{
-   if (priority == 0) return;
-
-   {
-      int pos = (y * tt_context.vdp2width) + x;
-      u32 * buffer = tt_context.vdp2framebuffer[priority] + pos;
-      *buffer = *buffer ? TitanBlendPixelsTop(0x20000000, *buffer) : 0x20000000;
+         buffer[i].pixel = color;
    }
 }
 
 void TitanRender(pixel_t * dispbuffer)
 {
    u32 dot;
-   int i;
+   int x, y;
 
-   for (i = 0; i < (tt_context.vdp2width * tt_context.vdp2height); i++)
+   if (!tt_context.inited)
    {
-      dot = TitanDigPixel(7, i);
-      if (dot)
+      return;
+   }
+   
+#ifdef WANT_VIDSOFT_RENDER_THREADING
+#pragma omp parallel for private(x,y,dot)
+#endif
+   for (y = 0; y < tt_context.vdp2height; y++)
+   {
+      for (x = 0; x < tt_context.vdp2width; x++)
       {
-         dispbuffer[i] = TitanFixAlpha(dot);
+         int i = (y * tt_context.vdp2width) + x;
+
+         dispbuffer[i] = 0;
+
+         dot = TitanDigPixel(i, y);
+
+         if (dot)
+         {
+            dispbuffer[i] = TitanFixAlpha(dot);
+         }
       }
    }
 }

--- a/yabause/src/titan/titan.h
+++ b/yabause/src/titan/titan.h
@@ -21,13 +21,25 @@
 #define TITAN_H
 
 #include "../core.h"
+#include "../vidshared.h"
 
 #define TITAN_BLEND_TOP     0
 #define TITAN_BLEND_BOTTOM  1
 #define TITAN_BLEND_ADD     2
 
+#define TITAN_SPRITE 5
+#define TITAN_RBG0 4
+#define TITAN_NBG0 3
+#define TITAN_NBG1 2
+#define TITAN_NBG2 1
+#define TITAN_NBG3 0
+
+#define TITAN_NORMAL_SHADOW 1
+#define TITAN_MSB_SHADOW 2
+
 int TitanInit();
 int TitanDeInit();
+void TitanErase();
 
 void TitanSetResolution(int width, int height);
 void TitanGetResolution(int * width, int * height);
@@ -38,10 +50,8 @@ void TitanPutBackHLine(s32 y, u32 color);
 
 void TitanPutLineHLine(int linescreen, s32 y, u32 color);
 
-void TitanPutPixel(int priority, s32 x, s32 y, u32 color, int linescreen);
+void TitanPutPixel(int priority, s32 x, s32 y, u32 color, int linescreen, vdp2draw_struct* info);
 void TitanPutHLine(int priority, s32 x, s32 y, s32 width, u32 color);
-
-void TitanPutShadow(int priority, s32 x, s32 y);
 
 void TitanRender(pixel_t * dispbuffer);
 

--- a/yabause/src/vidshared.h
+++ b/yabause/src/vidshared.h
@@ -143,6 +143,9 @@ typedef struct
    int specialprimode;
    float maxzoom;
    int linecheck_mask;
+   int titan_which_layer;
+   int titan_shadow_type;
+   int titan_shadow_enabled;
 
    float coordincx, coordincy;
    void FASTCALL (* PlaneAddr)(void *, int);


### PR DESCRIPTION
This PR fixes the special priority case mentioned in my previous PR by moving blending and priority to after the pixels have been generated. This also makes it possible to multi-thread the rendering in two places. Both kinds of multi-threading can be enabled with -DYAB_WANT_VIDSOFT_RENDER_THREADING=ON and -DYAB_WANT_VIDSOFT_LAYER_THREADING=ON . RENDER_THREADING threads the blending and pixel sorting. LAYER_THREADING generates the layers in different threads. The multi-threading requires OpenMP, which is included with GCC, LLVM and Visual Studio. 

I haven't updated the images for the tests yet, so the CircleCI build will fail at the moment.

![20150913102147](https://cloud.githubusercontent.com/assets/10871998/9837323/f1a94b8e-5a08-11e5-8f8f-9d5e5de2d26d.png)