### PR TITLE
Improve horizontal high resolution support

### DIFF
--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -3594,7 +3594,12 @@ void VIDSoftVdp1EraseFrameBuffer(void)
          for (i2 = (Vdp1Regs->EWLR & 0x1FF); i2 < h; i2++)
          {
             for (i = ((Vdp1Regs->EWLR >> 6) & 0x1F8); i < w; i++)
-               vdp1backframebuffer[(i2 * vdp1width) + i] = Vdp1Regs->EWDR & 0xFF;
+            {
+               int pos = (i2 * vdp1width) + i;
+
+               if (pos < 0x3FFFF)
+                  vdp1backframebuffer[pos] = Vdp1Regs->EWDR & 0xFF;
+            }
          }
       }
       Vdp1External.manualerase = 0;

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -166,7 +166,7 @@ GLuint fshader = 0;
 GLuint gl_shader_prog = 0;
 GLuint gl_texture_id = 0;
 #endif
-static int resxratio;
+static int vdp2_x_hires = 0;
 static int resyratio;
 int bilinear = 0;
 
@@ -708,7 +708,6 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info)
    int *mosaic_y, *mosaic_x;
    clipping_struct colorcalcwindow[2];
 
-   info->coordincx *= (float)resxratio;
    info->coordincy *= (float)resyratio;
 
    SetupScreenVars(info, &sinfo, info->PlaneAddr);
@@ -774,7 +773,6 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info)
          if (info->islinescroll & 0x4)
          {
             info->coordincx = (T1ReadLong(Vdp2Ram, info->linescrolltbl) & 0x7FF00) / (float)65536.0;
-            info->coordincx *= resxratio;
             if (need_increment)
                info->linescrolltbl += 4;
          }
@@ -787,7 +785,7 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info)
       ReadLineWindowClip(info->islinewindow, clip, &linewnd0addr, &linewnd1addr);
       y &= sinfo.ymask;
 
-      if (info->isverticalscroll)
+      if (info->isverticalscroll && (!vdp2_x_hires))//seems to be ignored in hi res
       {
          // this is *wrong*, vertical scroll use a different value per cell
          // info->verticalscrolltbl should be incremented by info->verticalscrollinc
@@ -807,11 +805,10 @@ static void FASTCALL Vdp2DrawScroll(vdp2draw_struct *info)
          /* I'm really not sure about this... but I think the way we handle
          high resolution gets in the way with window process. I may be wrong...
          This was added for Cotton Boomerang */
-         int resxi = i * resxratio;
 			int priority;
 
          // See if screen position is clipped, if it isn't, continue
-         if (!TestBothWindow(info->wctl, clip, resxi, j))
+         if (!TestBothWindow(info->wctl, clip, i, j))
          {
             continue;
          }
@@ -2227,9 +2224,8 @@ static int gouraudAdjust( int color, int tableValue )
 
 static void putpixel8(int x, int y) {
 
-    int x2 = x / 2;
     int y2 = y / vdp1interlace;
-    u8 * iPix = &vdp1backframebuffer[(y2 * vdp1width) + x2];
+    u8 * iPix = &vdp1backframebuffer[(y2 * vdp1width) + x];
     int mesh = cmd.CMDPMOD & 0x0100;
     int SPD = ((cmd.CMDPMOD & 0x40) != 0);//show the actual color of transparent pixels if 1 (they won't be drawn transparent)
 
@@ -2238,7 +2234,7 @@ static void putpixel8(int x, int y) {
 
     currentPixel &= 0xFF;
 
-    if(mesh && ((x2 ^ y2) & 1)) {
+    if(mesh && ((x ^ y2) & 1)) {
         return;
     }
 
@@ -2247,8 +2243,8 @@ static void putpixel8(int x, int y) {
 
         if (cmd.CMDPMOD & 0x0400) PushUserClipping((cmd.CMDPMOD >> 9) & 0x1);
 
-        clipped = ! (x2 >= vdp1clipxstart &&
-            x2 < vdp1clipxend &&
+        clipped = ! (x >= vdp1clipxstart &&
+            x < vdp1clipxend &&
             y2 >= vdp1clipystart &&
             y2 < vdp1clipyend);
 
@@ -3101,6 +3097,8 @@ void VIDSoftVdp2DrawEnd(void)
 
       for (i2 = 0; i2 < vdp2height; i2++)
       {
+         float framebuffer_readout_pos = 0;
+
          ReadLineWindowClip(islinewindow, clip, &linewnd0addr, &linewnd1addr);
 
          LoadLineParamsSprite(&info, i2);
@@ -3111,7 +3109,7 @@ void VIDSoftVdp2DrawEnd(void)
             info.titan_shadow_type = 0;
 
             // See if screen position is clipped, if it isn't, continue
-            if (!TestBothWindow(wctl, clip, i * resxratio, i2))
+            if (!TestBothWindow(wctl, clip, i, i2))
             {
                continue;
             }
@@ -3122,7 +3120,30 @@ void VIDSoftVdp2DrawEnd(void)
             }
             else
             {
-               x = i;
+               if (vdp1width == 1024 && vdp2_x_hires)
+               {
+                  //hi res vdp1 and hi res vdp2
+                  //pixels 1:1
+                  x = (int)framebuffer_readout_pos;
+                  framebuffer_readout_pos += 1;
+               }
+               else if (vdp1width == 512 && vdp2_x_hires)
+               {
+                  //low res vdp1,hi res vdp2
+                  //vdp1 pixel doubling
+                  x = (int)framebuffer_readout_pos;
+                  framebuffer_readout_pos += .5;
+               }
+               else if (vdp1width == 1024 && (!vdp2_x_hires))
+               {
+                  //hi res vdp1, low res vdp2
+                  //the vdp1 framebuffer is read out at half-res
+                  x = (int)framebuffer_readout_pos;
+                  framebuffer_readout_pos += 2;
+               }
+               else
+                  x = i;
+
                y = i2;
             }
 
@@ -3435,37 +3456,34 @@ void VIDSoftVdp2SetResolution(u16 TVMD)
    {
       case 0:
          vdp2width = 320;
-         resxratio=1;
          break;
       case 1:
          vdp2width = 352;
-         resxratio=1;
          break;
-      case 2: // 640
-         vdp2width = 320;
-         resxratio=2;
+      case 2:
+         vdp2width = 640;
          break;
-      case 3: // 704
-         vdp2width = 352;
-         resxratio=2;
+      case 3:
+         vdp2width = 704;
          break;
       case 4:
          vdp2width = 320;
-         resxratio=1;
          break;
       case 5:
          vdp2width = 352;
-         resxratio=1;
          break;
-      case 6: // 640
-         vdp2width = 320;
-         resxratio=2;
+      case 6:
+         vdp2width = 640;
          break;
-      case 7: // 704
-         vdp2width = 352;
-         resxratio=2;
+      case 7:
+         vdp2width = 704;
          break;
    }
+
+   if ((vdp2width == 704) || (vdp2width == 640))
+      vdp2_x_hires = 1;
+   else
+      vdp2_x_hires = 0;
 
    // Vertical Resolution
    switch ((TVMD >> 4) & 0x3)
@@ -3570,6 +3588,9 @@ void VIDSoftVdp1EraseFrameBuffer(void)
       }
       else
       {
+         w = Vdp1Regs->EWRR >> 9;
+         w *= 16;
+
          for (i2 = (Vdp1Regs->EWLR & 0x1FF); i2 < h; i2++)
          {
             for (i = ((Vdp1Regs->EWLR >> 6) & 0x1F8); i < w; i++)

--- a/yabauseut/src/vdp2.c
+++ b/yabauseut/src/vdp2.c
@@ -1301,11 +1301,21 @@ void vdp2_sprite_priority_shadow_test()
       write_tiles_4x(x_pos, 20, str, vdp2_tile_address, addresses[x]);//special color calc tiles
    }
 
+   int tvm = 0;
+   int hreso = 0;
+
    for (;;)
    {
       vdp_vsync();
 
-      VDP2_REG_SPCTL = (spccs << 12) | (spccn << 8) | (0 << 5) | 7;
+      VDP1_REG_TVMR = tvm;
+
+      VDP2_REG_TVMD = (1 << 15) | hreso;
+
+      if (tvm == 0)
+         VDP2_REG_SPCTL = (spccs << 12) | (spccn << 8) | (0 << 5) | 7;
+      else
+         VDP2_REG_SPCTL = (spccs << 12) | (spccn << 8) | (0 << 5) | 8;
 
       VDP2_REG_CCCTL = (1 << 6) | (1 << 0) | (1 << 3);
 
@@ -1379,6 +1389,24 @@ void vdp2_sprite_priority_shadow_test()
       {
          spccn++;
          spccn &= 7;
+      }
+
+      if (per[0].but_push_once & PAD_C)
+      {
+         tvm = !tvm;
+      }
+
+      if (per[0].but_push_once & PAD_X)
+      {
+         if (hreso == 2)
+            hreso = 0;
+         else
+            hreso = 2;
+      }
+
+      if (per[0].but_push_once & PAD_Y)
+      {
+         reset_system();
       }
 
       if (per[0].but_push_once & PAD_START)
@@ -1946,10 +1974,13 @@ void vdp2_line_window_test()
    }
 #else
 
+   int hreso = 0;
    
    for (;;)
    {
       vdp_vsync();
+
+      VDP2_REG_TVMD = (1 << 15) | hreso;
 
       vdp2_line_window_write_regs(v, line_window_table_address);
 
@@ -1970,6 +2001,19 @@ void vdp2_line_window_test()
       if (per[0].but_push_once & PAD_START)
       {
          break;
+      }
+
+      if (per[0].but_push_once & PAD_X)
+      {
+         if (hreso == 2)
+            hreso = 0;
+         else
+            hreso = 2;
+      }
+
+      if (per[0].but_push_once & PAD_Y)
+      {
+         reset_system();
       }
    }
 
@@ -2152,9 +2196,13 @@ void vdp2_line_scroll_test()
    }
 #else
 
+   int hreso = 0;
+
    for (;;)
    {
       vdp_vsync();
+
+      VDP2_REG_TVMD = (1 << 15) | hreso;
 
       counter++;
 
@@ -2177,6 +2225,19 @@ void vdp2_line_scroll_test()
       if (per[0].but_push_once & PAD_START)
       {
          break;
+      }
+
+      if (per[0].but_push_once & PAD_X)
+      {
+         if (hreso == 2)
+            hreso = 0;
+         else
+            hreso = 2;
+      }
+
+      if (per[0].but_push_once & PAD_Y)
+      {
+         reset_system();
       }
    }
 #endif


### PR DESCRIPTION
Burning Rangers, Cotton Boomerang, Nights, Scud and Winter Heat were tested and seem to work fine. High res support has been added to a few YabauseUT tests and Yabause matches the hardware for all those cases now. This patch does not change vertical resolution handling.