### PR TITLE
Prevent null pointer dereference in cs2.c

### DIFF
--- a/yabause/src/cs2.c
+++ b/yabause/src/cs2.c
@@ -334,6 +334,12 @@ u32 FASTCALL Cs2ReadLong(u32 addr) {
                      {
                         // Transfer Data
                         const u8 *ptr = &Cs2Area->datatranspartition->block[Cs2Area->datanumsecttrans]->data[Cs2Area->datatransoffset];
+
+                        if (Cs2Area->datatranspartition->block[Cs2Area->datanumsecttrans] == NULL)
+                        {
+                           CDLOG("cs2\t: datatranspartition->block[Cs2Area->datanumsecttrans] was NULL");
+                           return 0;
+                        }
 #ifdef WORDS_BIGENDIAN
                         val = *((const u32 *) ptr);
 #else


### PR DESCRIPTION
Cs2Area->datatranspartition->block[Cs2Area->datanumsecttrans] can be NULL when loading savestates in games such as Burning Rangers, especially during load times. This PR prevents a null pointer dereference that will crash the emulator and logs the error to the CD log. The game doesn't seem to be negatively affected by simply returning 0 and continues normally.