### PR TITLE
Add thread libraries to runner port

### DIFF
--- a/yabause/src/runner/CMakeLists.txt
+++ b/yabause/src/runner/CMakeLists.txt
@@ -10,7 +10,9 @@ endif()
 
 include_directories(${PORT_INCLUDE_DIRS})
 
+find_package(Threads)
+
 add_executable(yabause-runner yui.cpp)
-target_link_libraries(yabause-runner yabause ${YABAUSE_LIBRARIES} ${PORT_LIBRARIES})
+target_link_libraries(yabause-runner yabause ${YABAUSE_LIBRARIES} ${PORT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 yab_port_success(yabause-runner)


### PR DESCRIPTION
This should fix the CircleCI linking issue.