### PR TITLE
Improve smpc intback timing

### DIFF
--- a/yabause/src/smpc.c
+++ b/yabause/src/smpc.c
@@ -46,6 +46,7 @@
 Smpc * SmpcRegs;
 u8 * SmpcRegsT;
 SmpcInternal * SmpcInternalVars;
+int intback_wait_for_line = 0;
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -508,6 +509,16 @@ static void SmpcRESDISA(void) {
 
 void SmpcExec(s32 t) {
    if (SmpcInternalVars->timing > 0) {
+
+      if (intback_wait_for_line)
+      {
+         if (yabsys.LineCount == 207)
+         {
+            SmpcInternalVars->timing = -1;
+            intback_wait_for_line = 0;
+         }
+      }
+
       SmpcInternalVars->timing -= t;
       if (SmpcInternalVars->timing <= 0) {
          switch(SmpcRegs->COMREG) {
@@ -622,21 +633,30 @@ static void SmpcSetTiming(void) {
          SmpcInternalVars->timing = 1; // this has to be tested on a real saturn
          return;
       case 0x10:
-         if (SmpcInternalVars->intback)
-            SmpcInternalVars->timing = 20; // this will need to be verified
+         if (SmpcInternalVars->intback)//continue was issued
+         {
+            SmpcInternalVars->timing = 16000;
+            intback_wait_for_line = 1;
+         }
          else {
             // Calculate timing based on what data is being retrieved
 
-            SmpcInternalVars->timing = 1;
-
-            // If retrieving non-peripheral data, add 0.2 milliseconds
-            if (SmpcRegs->IREG[0] == 0x01)
-               SmpcInternalVars->timing += 2;
-
-            // If retrieving peripheral data, add 15 milliseconds
-            if (SmpcRegs->IREG[1] & 0x8)
-               SmpcInternalVars->timing += 16000; // Strangely enough, this works better
-//               SmpcInternalVars->timing += 150;
+            if ((SmpcRegs->IREG[0] == 0x01) && (SmpcRegs->IREG[1] & 0x8))
+            {
+               //status followed by peripheral data
+               SmpcInternalVars->timing = 250;
+            }
+            else if ((SmpcRegs->IREG[0] == 0x01) && ((SmpcRegs->IREG[1] & 0x8) == 0))
+            {
+               //status only
+               SmpcInternalVars->timing = 250;
+            }
+            else if ((SmpcRegs->IREG[0] == 0) && (SmpcRegs->IREG[1] & 0x8))
+            {
+               //peripheral only
+               SmpcInternalVars->timing = 16000;
+               intback_wait_for_line = 1;
+            }
          }
          return;
       case 0x17:

--- a/yabauseut/src/smpc.c
+++ b/yabauseut/src/smpc.c
@@ -58,6 +58,295 @@ void disable_iapetus_handler()
 
 //////////////////////////////////////////////////////////////////////////////
 
+volatile int hblank_timer = 0;
+volatile int issue_intback = 0;
+
+volatile int lines_since_vblank_out = 0;
+volatile int lines_since_vblank_in = 0;
+
+volatile int result_pos = 0;
+volatile int system_manager_occured = 0;
+
+volatile int frame_count = 0;
+volatile int stored_timer = 0;
+
+struct ResultType
+{
+   int type;
+   int since_vblank_out;
+   int since_vblank_in;
+   int free_timer;
+   int frame;
+   int total_time;
+};
+
+volatile struct ResultType results[64] = { { 0 } };
+
+char * result_types[] = 
+{
+   "bad       ",
+   "intb issue",
+   "sys interu",
+   "in no data",
+   "data remai"
+};
+
+#define RESULT_START 1
+#define RESULT_SYS_MAN 2
+#define RESULT_NO_DATA 3
+#define RESULT_DATA_REM 4
+
+#define TEST_STATUS_ONLY 1
+#define TEST_STATUS_PERIPHERAL 2
+#define TEST_PERIPHERAL_ONLY 3
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_test_vblank_out_handler()
+{
+   lines_since_vblank_out = 0;
+   frame_count++;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_test_hblank_in_handler()
+{
+   hblank_timer++;
+   lines_since_vblank_out++;
+   lines_since_vblank_in++;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_test_vblank_in_handler()
+{
+   lines_since_vblank_in = 0;
+   issue_intback = 1;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void reset_result(int pos)
+{
+   volatile struct ResultType * r = &results[pos];
+   r->type = 0;
+   r->since_vblank_out = 0;
+   r->since_vblank_in = 0;
+   r->free_timer = 0;
+   r->frame = 0;
+   r->total_time = 0;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+inline void set_result(int type)
+{
+   volatile struct ResultType * r = &results[result_pos];
+
+   r->type = type;
+   r->since_vblank_out = lines_since_vblank_out;
+   r->since_vblank_in = lines_since_vblank_in;
+   r->free_timer = hblank_timer;
+   r->frame = frame_count;
+   r->total_time = hblank_timer - stored_timer;
+   result_pos++;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_test_system_manager_handler()
+{
+   set_result(RESULT_SYS_MAN);
+
+   system_manager_occured = 1;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void intback_write_iregs(int status, int p2md, int p1md, int pen, int ope)
+{
+   SMPC_REG_IREG(0) = status;
+   SMPC_REG_IREG(1) = (p2md << 6) | (p1md << 4) | (pen << 3) | (ope << 0);
+   SMPC_REG_IREG(2) = 0xF0;
+   SMPC_REG_IREG(6) = 0xFE;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_intback_disable_interrupts()
+{
+   interrupt_set_level_mask(0xF);
+   bios_change_scu_interrupt_mask(0xFFFFFFFF, MASK_VBLANKOUT | MASK_HBLANKIN | MASK_VBLANKIN | MASK_SYSTEMMANAGER);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_intback_set_interrupts()
+{
+   bios_set_scu_interrupt(0x47, smpc_test_system_manager_handler);
+   bios_set_scu_interrupt(0x40, smpc_test_vblank_in_handler);
+   bios_set_scu_interrupt(0x41, smpc_test_vblank_out_handler);
+   bios_set_scu_interrupt(0x42, smpc_test_hblank_in_handler);
+   bios_change_scu_interrupt_mask(~(MASK_VBLANKOUT | MASK_HBLANKIN | MASK_VBLANKIN | MASK_SYSTEMMANAGER), 0);
+   interrupt_set_level_mask(0x1);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void reset_test_vars()
+{
+   int i;
+   for (i = 0; i < 64; i++)
+      reset_result(i);
+
+   hblank_timer = 0;
+   issue_intback = 0;
+
+   lines_since_vblank_out = 0;
+   lines_since_vblank_in = 0;
+
+   result_pos = 0;
+   system_manager_occured = 0;
+
+   frame_count = 0;
+   stored_timer = 0;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_intback_issue_timing_test_main(int test_type, int vblank_line)
+{
+   smpc_intback_disable_interrupts();
+
+   reset_test_vars();
+
+   test_disp_font.transparent = 0;
+
+   smpc_intback_set_interrupts();
+
+   for (;;)
+   {
+      if (issue_intback && (lines_since_vblank_in == vblank_line))
+      {
+         issue_intback = 0;
+
+         if (test_type == TEST_STATUS_PERIPHERAL)
+            intback_write_iregs(1, 0, 0, 1, 0);
+         else if (test_type == TEST_PERIPHERAL_ONLY)
+            intback_write_iregs(0, 0, 0, 1, 0);
+         else if (test_type == TEST_STATUS_ONLY)
+            intback_write_iregs(1, 0, 0, 0, 0);
+
+         stored_timer = hblank_timer;
+
+         set_result(RESULT_START);
+
+         smpc_issue_command(SMPC_CMD_INTBACK);
+      }
+
+      if (system_manager_occured)
+      {
+         system_manager_occured = 0;
+
+         if (SMPC_REG_SR & (1 << 5))
+         {
+            set_result(RESULT_DATA_REM);
+            SMPC_REG_IREG(0) = 0x80;
+
+         }
+         else
+         {
+            set_result(RESULT_NO_DATA);
+         }
+      }
+
+      if (result_pos > 48)
+         break;
+   }
+
+   // Re-enable Peripheral Handler
+   per_init();
+
+   int i;
+   int j = 2;
+   int previous_frame = -1;
+
+   for (i = 0; i < 64; i++)
+   {
+      if (results[i].frame < 3)
+         continue;
+
+      if (results[i].frame != previous_frame)
+         j++;
+
+      previous_frame = results[i].frame;
+
+      vdp_printf(&test_disp_font, 0, 8 * j, 15,
+         "%s | %03d | %03d | %04d | %02d | %03d",
+         result_types[results[i].type],
+         results[i].since_vblank_out,
+         results[i].since_vblank_in,
+         results[i].free_timer,
+         results[i].frame,
+         results[i].total_time);
+
+      j++;
+
+      if (j > 27)
+         break;
+   }
+
+   for (;;)
+   {
+      vdp_vsync();
+
+      if (per[0].but_push_once & PAD_A)
+      {
+         break;
+      }
+
+      if (per[0].but_push_once & PAD_START)
+      {
+         reset_system();
+      }
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void smpc_intback_issue_timing_test()
+{
+   int line = 0;
+
+   vdp_printf(&test_disp_font, 0, 2 * 8, 15, "           | vbo | vbi | hbla | fr | lin", line);
+
+   int increment = 4;
+
+   for (line = 0; line < 41; line += increment)
+   {
+      vdp_printf(&test_disp_font, 0, 0, 15,"peripheral only, %d lines from vblank in    ", line);
+      smpc_intback_issue_timing_test_main(TEST_PERIPHERAL_ONLY, line);
+   }
+
+   for (line = 0; line < 41; line += increment)
+   {
+      vdp_printf(&test_disp_font, 0, 0, 15, "status before, %d lines from vblank in  ", line);
+      smpc_intback_issue_timing_test_main(TEST_STATUS_PERIPHERAL, line);
+   }
+
+   for (line = 0; line < 41; line += increment)
+   {
+      vdp_printf(&test_disp_font, 0, 0, 15, "status only, %d lines from vblank in  ", line);
+      smpc_intback_issue_timing_test_main(TEST_STATUS_ONLY, line);
+   }
+
+   test_disp_font.transparent = 1;
+   gui_clear_scr(&test_disp_font);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
 void smpc_cmd_test()
 {
 	// Intback IREG test


### PR DESCRIPTION
The INTBACK system manager interrupt seems to always happen around lines 207-209 of a display, regardless of when the command is issued after VBLANK-in. When SMPC status and peripheral data are requested at the same time, the status is returned after about 4 lines, and then the peripheral data is returned the next frame around lines 207-209 if a continue request is issued. 

These changes fix the controls in Megaman X4 and Virtua Racing.