### PR TITLE
Avoiding conditional directives that break statements

### DIFF
--- a/yabause/src/memory.c
+++ b/yabause/src/memory.c
@@ -1259,10 +1259,11 @@ int YabLoadStateStream(FILE *fp)
    }
 
 #ifdef WORDS_BIGENDIAN
-   if (endian == 1)
+   int test_endian = endian == 1;
 #else
-   if (endian == 0)
+   int test_endian = endian == 0;
 #endif
+   if (test_endian)
    {
       // should setup reading so it's byte-swapped
       YabSetError(YAB_ERR_OTHER, (void *)"Load State byteswapping not supported");


### PR DESCRIPTION
This change is only aesthetical, it's a suggestion based on code style guidelines from the Linux Kernel.
[Linux kernel coding style](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892)