### PR TITLE
Fixed black screen on OSX Cocoa for integrated GPU

### DIFF
--- a/yabause/src/cocoa/YabauseGLView.m
+++ b/yabause/src/cocoa/YabauseGLView.m
@@ -33,7 +33,7 @@
 - (id)initWithFrame:(NSRect)frameRect
 {
     NSOpenGLPixelFormatAttribute attrs[] = {
-        NSOpenGLPFAWindow,
+        NSOpenGLPFAOpenGLProfile, (NSOpenGLPixelFormatAttribute)NSOpenGLProfileVersion3_2Core,
         NSOpenGLPFANoRecovery,
         NSOpenGLPFAColorSize, 32,
         NSOpenGLPFADepthSize, 32,


### PR DESCRIPTION
This was only a problem for people with integrated gpu’s.
As OpenGL on OSX per default makes use of the legacy profiler, you have to specifically say you want to use the CORE profiler to be able to use anything OpenGL related above version 2.1.

The same problem occurs on the Qt version, but i haven't been able to fix it there yet...