### PR TITLE
add msys2 x86_64 build to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,9 @@ environment:
     # included directx headers incompatible with mingw
       cmake_args: "-DYAB_NETWORK=ON -DYAB_WANT_GDBSTUB=ON"
 
+    # MSYS2 x86_64 build
+    - compiler_type: "msys2-mingw-w64-x86_64"
+
 shallow_clone: true
 
 init:
@@ -41,10 +44,10 @@ init:
 before_build:
   # fetch appropriate sdl lib for visual studio or mingw
   - cd c:\
-  - appveyor DownloadFile https://www.libsdl.org/release/%sdl_filename%
+  - if NOT ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] appveyor DownloadFile https://www.libsdl.org/release/%sdl_filename%
 
   # decompress it, shorten 7z output with FIND
-  - 7z x %sdl_filename%  | FIND /V "ing  "
+  - if NOT ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] 7z x %sdl_filename%  | FIND /V "ing  "
 
   # mingw version is a tar.gz, decompress again
   - if [%sdl_filename%]==[SDL2-devel-2.0.3-mingw.tar.gz] 7z x SDL2-devel-2.0.3-mingw.tar | FIND /V "ing  "
@@ -53,10 +56,19 @@ before_build:
   - cd C:\projects\yabause\yabause
   - mkdir build
   - cd build
-  - cmake -G "%generator%" %cmake_args% -DSDL2MAIN_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2main.lib -DSDL2_INCLUDE_DIR=C:/SDL2-2.0.3/include/ -DSDL2_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2.lib ..
+  - if NOT ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] cmake -G "%generator%" %cmake_args% -DSDL2MAIN_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2main.lib -DSDL2_INCLUDE_DIR=C:/SDL2-2.0.3/include/ -DSDL2_LIBRARY=C:/SDL2-2.0.3/lib/%sdl_arch%/SDL2.lib ..
+
+  #MSYS2
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] set MSYSTEM=MINGW64
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64;%PATH%
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-SDL2 mingw-w64-x86_64-binutils mingw64/mingw-w64-x86_64-qt5 mingw-w64-x86_64-crt-git mingw-w64-x86_64-headers-git mingw64/mingw-w64-x86_64-libwebp"
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "cd C:/projects/yabause/yabause/build ; cmake -G\"MSYS Makefiles\" -DDirectX_INCLUDE_DIR=C:/msys64/mingw64/x86_64-w64-mingw32/include -DYAB_WANT_DIRECTSOUND=OFF -DYAB_WANT_DIRECTINPUT=OFF -DYAB_NETWORK=ON -DYAB_WANT_GDBSTUB=ON -DMSYS2_BUILD=ON -DCMAKE_PREFIX_PATH=C:/msys64/mingw64/bin -DSDL2MAIN_LIBRARY=C:/msys64/mingw64/lib/libSDL2main.a .."
 
 build_script:
   - if ["%compiler_type%"]==["mingw32"] cmake --build .
+
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "cd C:/projects/yabause/yabause/build ; make "
 
   # force a release build and only show errors to shorten output
   - if ["%compiler_type%"]==["vs12-x64"] msbuild yabause.sln /p:configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/yabause/src/qt/CMakeLists.txt
+++ b/yabause/src/qt/CMakeLists.txt
@@ -256,7 +256,7 @@ endif()
 yab_port_success(yabause-qt)
 configure_file(yabause.desktop.in ${YAB_PORT_NAME}.desktop)
 
-if (WIN32)
+if (WIN32 AND NOT MSYS2_BUILD)
 	install(TARGETS yabause-qt DESTINATION ".")
 	if (GLUT_FOUND)
 		install(FILES ${GLUT_INCLUDE_DIR}/../freeglut.dll DESTINATION ".")

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -2580,7 +2580,7 @@ static int CheckDil(int y, Vdp1 * regs)
    return 0;
 }
 
-INLINE int IsUserClipped(int x, int y, Vdp1* regs)
+static INLINE int IsUserClipped(int x, int y, Vdp1* regs)
 {
    return !(x >= regs->userclipX1 &&
       x <= regs->userclipX2 &&
@@ -2588,7 +2588,7 @@ INLINE int IsUserClipped(int x, int y, Vdp1* regs)
       y <= regs->userclipY2);
 }
 
-INLINE int IsSystemClipped(int x, int y, Vdp1* regs)
+static INLINE int IsSystemClipped(int x, int y, Vdp1* regs)
 {
    return !(x >= 0 &&
       x <= regs->systemclipX2 &&

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -242,7 +242,7 @@ extern int vdp1cob;
 #define IS_ZERO(a) ( (a) < EPS && (a) > -EPS)
 
 // AXB = |A||B|sin
-INLINE float cross2d( float veca[2], float vecb[2] )
+static INLINE float cross2d( float veca[2], float vecb[2] )
 {
    return (veca[0]*vecb[1])-(vecb[0]*veca[1]);
 }


### PR DESCRIPTION
The cpack script needs to be modified so it is currently disabled for this build. Also Direct X is disabled for this build due to a compile error involving dxerr. Dxerr is actually deprecated and doesn't work in Visual Studio 2015 either so it should probably be replaced with FormatMessage.