### PR TITLE
qt/vidsoft: add integer video scaling option in windowed mode

### DIFF
--- a/yabause/src/qt/ui/UISettings.cpp
+++ b/yabause/src/qt/ui/UISettings.cpp
@@ -455,6 +455,9 @@ void UISettings::loadSettings()
 	cbFullscreen->setChecked( s->value( "Video/Fullscreen", false ).toBool() );
 	cbVideoFormat->setCurrentIndex( cbVideoFormat->findData( s->value( "Video/VideoFormat", mVideoFormats.at( 0 ).id ).toInt() ) );
 
+   cbEnableIntegerPixelScaling->setChecked(s->value("Video/EnableIntegerPixelScaling", false).toBool());
+   sbIntegerPixelScalingMultiplier->setValue(s->value("Video/IntegerPixelScalingMultiplier", 2).toInt());
+
 	// sound
 	cbSoundCore->setCurrentIndex( cbSoundCore->findData( s->value( "Sound/SoundCore", QtYabause::defaultSNDCore().id ).toInt() ) );
 
@@ -536,6 +539,9 @@ void UISettings::saveSettings()
 	s->setValue( "Video/Fullscreen", cbFullscreen->isChecked() );
 	s->setValue( "Video/Bilinear", cbBilinear->isChecked() );
 	s->setValue( "Video/VideoFormat", cbVideoFormat->itemData( cbVideoFormat->currentIndex() ).toInt() );
+
+   s->setValue("Video/EnableIntegerPixelScaling", cbEnableIntegerPixelScaling->isChecked());
+   s->setValue("Video/IntegerPixelScalingMultiplier", sbIntegerPixelScalingMultiplier->value());
 
 	s->setValue( "General/ClockSync", cbClockSync->isChecked() );
 	s->setValue( "General/FixedBaseTime", dteBaseTime->dateTime().toString(Qt::ISODate));

--- a/yabause/src/qt/ui/UISettings.ui
+++ b/yabause/src/qt/ui/UISettings.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="twPages">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="wGeneral">
       <attribute name="title">
@@ -213,8 +213,8 @@
        <string>Video</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout2">
-       <item row="0" column="0" colspan="3">
-        <widget class="QLabel" name="lVideoCore">
+       <item row="16" column="0" colspan="3">
+        <widget class="QLabel" name="lVideoFormat">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -222,15 +222,12 @@
           </font>
          </property>
          <property name="text">
-          <string>Video Core</string>
+          <string>Video Format</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
          </property>
         </widget>
-       </item>
-       <item row="1" column="0" colspan="3">
-        <widget class="QComboBox" name="cbVideoCore"/>
        </item>
        <item row="3" column="0" colspan="3">
         <widget class="QLabel" name="lOSDCore">
@@ -248,37 +245,8 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="3">
-        <widget class="QComboBox" name="cbOSDCore"/>
-       </item>
-       <item row="5" column="0" colspan="3">
-        <widget class="QLabel" name="lWinResolution">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Window Resolution</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-        </widget>
-       </item>
        <item row="6" column="0" colspan="3">
         <widget class="QComboBox" name="cbAspectRatio"/>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="lWinWidth">
-         <property name="text">
-          <string>Width</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QLineEdit" name="leWinWidth"/>
        </item>
        <item row="8" column="0">
         <widget class="QLabel" name="lWinHeight">
@@ -287,40 +255,24 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
-        <widget class="QLineEdit" name="leWinHeight"/>
+       <item row="1" column="0" colspan="3">
+        <widget class="QComboBox" name="cbVideoCore"/>
        </item>
-       <item row="16" column="0" colspan="3">
-        <widget class="QLabel" name="lVideoFormat">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Video Format</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-        </widget>
+       <item row="7" column="1">
+        <widget class="QLineEdit" name="leWinWidth"/>
        </item>
        <item row="17" column="0" colspan="3">
         <widget class="QComboBox" name="cbVideoFormat"/>
        </item>
-       <item row="18" column="0" colspan="3">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="10" column="0" colspan="3">
+        <widget class="QComboBox" name="cbFullscreenResolution"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="cbBilinear">
+         <property name="text">
+          <string>Bilinear Filtering (Restart required)</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>2</height>
-          </size>
-         </property>
-        </spacer>
+        </widget>
        </item>
        <item row="9" column="0">
         <widget class="QLabel" name="lFullScreenResolution">
@@ -338,6 +290,61 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="0" colspan="3">
+        <widget class="QLabel" name="lWinResolution">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Window Resolution</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="3">
+        <widget class="QComboBox" name="cbOSDCore"/>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="lWinWidth">
+         <property name="text">
+          <string>Width</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QLabel" name="lVideoCore">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Video Core</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="0" colspan="3">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>2</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
        <item row="12" column="0">
         <widget class="QCheckBox" name="cbFullscreen">
          <property name="text">
@@ -345,13 +352,32 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0" colspan="3">
-        <widget class="QComboBox" name="cbFullscreenResolution"/>
+       <item row="8" column="1">
+        <widget class="QLineEdit" name="leWinHeight"/>
        </item>
-       <item row="2" column="0">
-        <widget class="QCheckBox" name="cbBilinear">
+       <item row="18" column="0">
+        <widget class="QCheckBox" name="cbEnableIntegerPixelScaling">
          <property name="text">
-          <string>Bilinear Filtering (Restart required)</string>
+          <string>Use integer pixel scaling</string>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="1">
+        <widget class="QSpinBox" name="sbIntegerPixelScalingMultiplier">
+         <property name="maximumSize">
+          <size>
+           <width>40</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="minimum">
+          <number>2</number>
+         </property>
+         <property name="maximum">
+          <number>4</number>
+         </property>
+         <property name="singleStep">
+          <number>2</number>
          </property>
         </widget>
        </item>
@@ -937,8 +963,8 @@
   </connection>
  </connections>
  <buttongroups>
+  <buttongroup name="bgShowMenubar"/>
   <buttongroup name="bgShowLogWindow"/>
   <buttongroup name="bgShowToolbar"/>
-  <buttongroup name="bgShowMenubar"/>
  </buttongroups>
 </ui>

--- a/yabause/src/qt/ui/UIYabause.h
+++ b/yabause/src/qt/ui/UIYabause.h
@@ -129,6 +129,8 @@ protected slots:
 	void toggleFullscreen( int width, int height, bool f, int videoFormat );
 	void fullscreenRequested( bool fullscreen );
 	void refreshStatesActions();
+   void adjustHeight(int & height);
+   void resizeIntegerScaling();
 	// file menu
 	void on_aFileSettings_triggered();
 	void on_aFileOpenISO_triggered();

--- a/yabause/src/vdp1.c
+++ b/yabause/src/vdp1.c
@@ -1383,6 +1383,7 @@ void VIDDummyVdp2DrawScreens(void);
 void VIDDummyGetGlSize(int *width, int *height);
 void VIDDummVdp1ReadFrameBuffer(u32 type, u32 addr, void * out);
 void VIDDummVdp1WriteFrameBuffer(u32 type, u32 addr, u32 val);
+void VIDDummyGetNativeResolution(int *width, int * height, int *interlace);
 
 VideoInterface_struct VIDDummy = {
 VIDCORE_DUMMY,
@@ -1409,7 +1410,8 @@ VIDDummyVdp2Reset,
 VIDDummyVdp2DrawStart,
 VIDDummyVdp2DrawEnd,
 VIDDummyVdp2DrawScreens,
-VIDDummyGetGlSize
+VIDDummyGetGlSize,
+VIDDummyGetNativeResolution
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1554,4 +1556,13 @@ void VIDDummVdp1ReadFrameBuffer(u32 type, u32 addr, void * out)
 
 void VIDDummVdp1WriteFrameBuffer(u32 type, u32 addr, u32 val)
 {
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void VIDDummyGetNativeResolution(int *width, int * height, int * interlace)
+{
+   *width = 0;
+   *height = 0;
+   *interlace = 0;
 }

--- a/yabause/src/vdp1.h
+++ b/yabause/src/vdp1.h
@@ -85,6 +85,7 @@ typedef struct
    void (*Vdp2DrawEnd)(void);
    void (*Vdp2DrawScreens)(void);
    void (*GetGlSize)(int *width, int *height);
+   void (*GetNativeResolution)(int *width, int *height, int * interlace);
 } VideoInterface_struct;
 
 extern VideoInterface_struct *VIDCore;

--- a/yabause/src/vidogl.c
+++ b/yabause/src/vidogl.c
@@ -85,6 +85,7 @@ void VIDOGLVdp2DrawEnd(void);
 void VIDOGLVdp2DrawScreens(void);
 void VIDOGLVdp2SetResolution(u16 TVMD);
 void YglGetGlSize(int *width, int *height);
+void VIDOGLGetNativeResolution(int *width, int *height, int*interlace);
 void VIDOGLVdp1ReadFrameBuffer(u32 type, u32 addr, void * out);
 
 VideoInterface_struct VIDOGL = {
@@ -112,7 +113,8 @@ VIDOGLVdp2Reset,
 VIDOGLVdp2DrawStart,
 VIDOGLVdp2DrawEnd,
 VIDOGLVdp2DrawScreens,
-YglGetGlSize
+YglGetGlSize,
+VIDOGLGetNativeResolution,
 };
 
 float vdp1wratio=1;
@@ -5459,6 +5461,13 @@ void YglGetGlSize(int *width, int *height)
 {
    *width = GlWidth;
    *height = GlHeight;
+}
+
+void VIDOGLGetNativeResolution(int *width, int *height, int*interlace)
+{
+   *width = 0;
+   *height = 0;
+   *interlace = 0;
 }
 
 vdp2rotationparameter_struct * FASTCALL vdp2rGetKValue2W( vdp2rotationparameter_struct * param, int index )

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -100,6 +100,7 @@ void VIDSoftGetGlSize(int *width, int *height);
 void VIDSoftVdp1SwapFrameBuffer(void);
 void VIDSoftVdp1EraseFrameBuffer(Vdp1* regs, u8 * back_framebuffer);
 void VidsoftDrawSprite(Vdp2 * vdp2_regs, u8 * sprite_window_mask, u8* vdp1_front_framebuffer, u8 * vdp2_ram, Vdp1* vdp1_regs, Vdp2* vdp2_lines, u8*color_ram);
+void VIDSoftGetNativeResolution(int *width, int *height, int*interlace);
 
 VideoInterface_struct VIDSoft = {
 VIDCORE_SOFT,
@@ -131,6 +132,7 @@ VIDSoftVdp2DrawStart,
 VIDSoftVdp2DrawEnd,
 VIDSoftVdp2DrawScreens,
 VIDSoftGetGlSize,
+VIDSoftGetNativeResolution
 };
 
 pixel_t *dispbuffer=NULL;
@@ -1530,7 +1532,7 @@ static void LoadLineParamsNBG0(vdp2draw_struct * info, screeninfo_struct * sinfo
    if (regs == NULL) return;
    ReadVdp2ColorOffset(regs, info, 0x1, 0x1);
    info->specialprimode = regs->SFPRMD & 0x3;
-   info->enable = regs->BGON & 0x1;
+   info->enable = regs->BGON & 0x1 || regs->BGON & 0x20;//nbg0 or rbg1
    GeneratePlaneAddrTable(info, sinfo->planetbl, info->PlaneAddr, regs);//sonic 2, 2 player mode
 }
 
@@ -4157,4 +4159,11 @@ void VIDSoftGetGlSize(int *width, int *height)
    *width = vdp2width;
    *height = vdp2height;
 #endif
+}
+
+void VIDSoftGetNativeResolution(int *width, int *height, int* interlace)
+{
+   *width = vdp2width;
+   *height = vdp2height;
+   *interlace = vdp2_interlace;
 }


### PR DESCRIPTION
This option automatically resizes the window to force pixels to have the native aspect ratio. Either 2x or 4x scaling is possible. This option is under Settings -> Video.
![integer-scaling](https://cloud.githubusercontent.com/assets/10871998/14062721/cf208a08-f37f-11e5-8bf5-093e979f2b86.png)
