### PR TITLE
68k: add musashi as a 68k core option

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ before_build:
   - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;C:\msys64;%PATH%
   - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
   - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-SDL2 mingw-w64-x86_64-binutils mingw64/mingw-w64-x86_64-qt5 mingw-w64-x86_64-crt-git mingw-w64-x86_64-headers-git mingw64/mingw-w64-x86_64-libwebp"
-  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "cd C:/projects/yabause/yabause/build ; cmake -G\"MSYS Makefiles\" -DDirectX_INCLUDE_DIR=C:/msys64/mingw64/x86_64-w64-mingw32/include -DYAB_WANT_DIRECTSOUND=OFF -DYAB_WANT_DIRECTINPUT=OFF -DYAB_NETWORK=ON -DYAB_WANT_GDBSTUB=ON -DMSYS2_BUILD=ON -DCMAKE_PREFIX_PATH=C:/msys64/mingw64/bin -DSDL2MAIN_LIBRARY=C:/msys64/mingw64/lib/libSDL2main.a .."
+  - if ["%compiler_type%"]==["msys2-mingw-w64-x86_64"] C:\msys64\usr\bin\bash -lc "cd C:/projects/yabause/yabause/build ; cmake -G\"MSYS Makefiles\" -DDirectX_INCLUDE_DIR=C:/msys64/mingw64/x86_64-w64-mingw32/include -DYAB_WANT_MUSASHI=OFF -DYAB_WANT_DIRECTSOUND=OFF -DYAB_WANT_DIRECTINPUT=OFF -DYAB_NETWORK=ON -DYAB_WANT_GDBSTUB=ON -DMSYS2_BUILD=ON -DCMAKE_PREFIX_PATH=C:/msys64/mingw64/bin -DSDL2MAIN_LIBRARY=C:/msys64/mingw64/lib/libSDL2main.a .."
 
 build_script:
   - if ["%compiler_type%"]==["mingw32"] cmake --build .

--- a/yabause/src/CMakeLists.txt
+++ b/yabause/src/CMakeLists.txt
@@ -485,6 +485,52 @@ if (YAB_WANT_C68K)
 	endif()
 endif(YAB_WANT_C68K)
 
+option(YAB_WANT_MUSASHI "Enable musashi 68k" ON)
+#TODO cross compile builds m68kmake for the target platform instead
+#of the native one, making it impossible to generate the core
+if (YAB_WANT_MUSASHI AND NOT CMAKE_CROSSCOMPILING)
+    set (MUSASHI_GENERATED_SOURCES 
+        ${CMAKE_CURRENT_BINARY_DIR}/m68kopac.c 
+        ${CMAKE_CURRENT_BINARY_DIR}/m68kopdm.c 
+        ${CMAKE_CURRENT_BINARY_DIR}/m68kopnz.c 
+        ${CMAKE_CURRENT_BINARY_DIR}/m68kops.c)
+
+    set (MUSASHI_GENERATED_HEADERS
+        ${CMAKE_CURRENT_BINARY_DIR}/m68kops.h)
+
+    add_executable(m68kmake musashi/m68kmake.c)
+    add_custom_command(OUTPUT ${MUSASHI_GENERATED_SOURCES} ${MUSASHI_GENERATED_HEADERS}
+                       COMMAND m68kmake ${CMAKE_CURRENT_BINARY_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/musashi/m68k_in.c
+                       DEPENDS m68kmake
+                       COMMENT "Generating musashi 68k core"
+                       VERBATIM)
+
+    add_definitions(-DHAVE_MUSASHI=1)
+
+	include_directories(
+      ${CMAKE_CURRENT_BINARY_DIR}/
+      ${CMAKE_CURRENT_SOURCE_DIR}/musashi
+    )
+
+	set(yabause_SOURCES ${yabause_SOURCES} 
+      ${MUSASHI_GENERATED_SOURCES}
+      musashi/m68kdasm.c
+      musashi/m68kcpu.c
+      m68kmusashi.c
+      )
+
+	set(yabause_HEADERS 
+      ${yabause_HEADERS} 
+      musashi/m68k.h
+      musashi/m68kcpu.h
+      ${MUSASHI_GENERATED_HEADERS}
+      m68kmusashi.h
+      )
+
+    add_custom_target(musashi ALL
+      DEPENDS ${MUSASHI_GENERATED_FILES})
+endif(YAB_WANT_MUSASHI AND NOT CMAKE_CROSSCOMPILING)
+
 # q68
 option(YAB_WANT_Q68 "enable q68 compilation" OFF)
 if (YAB_WANT_Q68)
@@ -634,6 +680,10 @@ if (YAB_WANT_C68K)
 	add_dependencies(yabause c68kinc)
 endif(YAB_WANT_C68K)
 
+if (YAB_WANT_MUSASHI)
+	add_dependencies(yabause musashi)
+endif(YAB_WANT_MUSASHI)
+
 macro(yab_port_start)
 	if (YAB_PORT_BUILT AND NOT YAB_MULTIBUILD)
 		return()
@@ -669,6 +719,9 @@ endforeach(PORT)
 # this is stupid, but CMake automatic definitions are based on variables...
 if (YAB_WANT_C68K)
 	set(HAVE_C68K ON)
+endif()
+if (YAB_WANT_MUSASHI)
+	set(HAVE_MUSASHI ON)
 endif()
 if (YAB_WANT_Q68)
 	set(HAVE_Q68 ON)

--- a/yabause/src/m68kcore.h
+++ b/yabause/src/m68kcore.h
@@ -26,6 +26,7 @@
 #define M68KCORE_DUMMY    0
 #define M68KCORE_C68K     1
 #define M68KCORE_Q68      2
+#define M68KCORE_MUSASHI  3
 
 typedef u32 FASTCALL M68K_READ(const u32 adr);
 typedef void FASTCALL M68K_WRITE(const u32 adr, u32 data);
@@ -75,5 +76,6 @@ int M68KInit(int coreid);
 extern M68K_struct M68KDummy;
 extern M68K_struct M68KC68K;
 extern M68K_struct M68KQ68;
+extern M68K_struct M68KMusashi;
 
 #endif

--- a/yabause/src/m68kmusashi.c
+++ b/yabause/src/m68kmusashi.c
@@ -1,0 +1,202 @@
+/*  Copyright 2007 Guillaume Duhamel
+
+This file is part of Yabause.
+
+Yabause is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Yabause is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Yabause; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+/*! \file m68kmusashi.c
+\brief Musashi 68000 interface.
+*/
+
+#include "m68kmusashi.h"
+#include "musashi/m68k.h"
+#include "m68kcore.h"
+#include "musashi/m68kcpu.h"
+
+struct ReadWriteFuncs
+{
+   M68K_READ  *r_8;
+   M68K_READ  *r_16;
+   M68K_WRITE *w_8;
+   M68K_WRITE *w_16;
+}rw_funcs;
+
+static int M68KMusashiInit(void) {
+
+   m68k_init();
+   m68k_set_cpu_type(M68K_CPU_TYPE_68000);
+
+   return 0;
+}
+
+static void M68KMusashiDeInit(void) {
+}
+
+static void M68KMusashiReset(void) {
+   m68k_pulse_reset();
+}
+
+static s32 FASTCALL M68KMusashiExec(s32 cycle) {
+   return m68k_execute(cycle);
+}
+
+static void M68KMusashiSync(void) {
+}
+
+static u32 M68KMusashiGetDReg(u32 num) {
+   return m68k_get_reg(NULL, M68K_REG_D0 + num);
+}
+
+static u32 M68KMusashiGetAReg(u32 num) {
+   return m68k_get_reg(NULL, M68K_REG_A0 + num);
+}
+
+static u32 M68KMusashiGetPC(void) {
+   return m68k_get_reg(NULL, M68K_REG_PC);
+}
+
+static u32 M68KMusashiGetSR(void) {
+   return m68k_get_reg(NULL, M68K_REG_SR);
+}
+
+static u32 M68KMusashiGetUSP(void) {
+   return m68k_get_reg(NULL, M68K_REG_USP);
+}
+
+static u32 M68KMusashiGetMSP(void) {
+   return m68k_get_reg(NULL, M68K_REG_MSP);
+}
+
+static void M68KMusashiSetDReg(u32 num, u32 val) {
+   m68k_set_reg(M68K_REG_D0 + num, val);
+}
+
+static void M68KMusashiSetAReg(u32 num, u32 val) {
+   m68k_set_reg(M68K_REG_A0 + num, val);
+}
+
+static void M68KMusashiSetPC(u32 val) {
+   m68k_set_reg(M68K_REG_PC, val);
+}
+
+static void M68KMusashiSetSR(u32 val) {
+   m68k_set_reg(M68K_REG_SR, val);
+}
+
+static void M68KMusashiSetUSP(u32 val) {
+   m68k_set_reg(M68K_REG_USP, val);
+}
+
+static void M68KMusashiSetMSP(u32 val) {
+   m68k_set_reg(M68K_REG_MSP, val);
+}
+
+static void M68KMusashiSetFetch(u32 low_adr, u32 high_adr, pointer fetch_adr) {
+}
+
+static void FASTCALL M68KMusashiSetIRQ(s32 level) {
+   if (level > 0)
+      m68k_set_irq(level);
+}
+
+static void FASTCALL M68KMusashiWriteNotify(u32 address, u32 size) {
+}
+
+unsigned int  m68k_read_memory_8(unsigned int address)
+{
+   return rw_funcs.r_8(address);
+}
+
+unsigned int  m68k_read_memory_16(unsigned int address)
+{
+   return rw_funcs.r_16(address);
+}
+
+unsigned int  m68k_read_memory_32(unsigned int address)
+{
+   u16 val1 = rw_funcs.r_16(address);
+
+   return (val1 << 16 | rw_funcs.r_16(address + 2));
+}
+
+void m68k_write_memory_8(unsigned int address, unsigned int value)
+{
+   rw_funcs.w_8(address, value);
+}
+
+void m68k_write_memory_16(unsigned int address, unsigned int value)
+{
+   rw_funcs.w_16(address, value);
+}
+
+void m68k_write_memory_32(unsigned int address, unsigned int value)
+{
+   rw_funcs.w_16(address, value >> 16 );
+   rw_funcs.w_16(address + 2, value & 0xffff);
+}
+
+static void M68KMusashiSetReadB(M68K_READ *Func) {
+   rw_funcs.r_8 = Func;
+}
+
+static void M68KMusashiSetReadW(M68K_READ *Func) {
+   rw_funcs.r_16 = Func;
+}
+
+static void M68KMusashiSetWriteB(M68K_WRITE *Func) {
+   rw_funcs.w_8 = Func;
+}
+
+static void M68KMusashiSetWriteW(M68K_WRITE *Func) {
+   rw_funcs.w_16 = Func;
+}
+
+static void M68KMusashiSaveState(FILE *fp) {
+}
+
+static void M68KMusashiLoadState(FILE *fp) {
+}
+
+M68K_struct M68KMusashi = {
+   3,
+   "Musashi Interface",
+   M68KMusashiInit,
+   M68KMusashiDeInit,
+   M68KMusashiReset,
+   M68KMusashiExec,
+   M68KMusashiSync,
+   M68KMusashiGetDReg,
+   M68KMusashiGetAReg,
+   M68KMusashiGetPC,
+   M68KMusashiGetSR,
+   M68KMusashiGetUSP,
+   M68KMusashiGetMSP,
+   M68KMusashiSetDReg,
+   M68KMusashiSetAReg,
+   M68KMusashiSetPC,
+   M68KMusashiSetSR,
+   M68KMusashiSetUSP,
+   M68KMusashiSetMSP,
+   M68KMusashiSetFetch,
+   M68KMusashiSetIRQ,
+   M68KMusashiWriteNotify,
+   M68KMusashiSetReadB,
+   M68KMusashiSetReadW,
+   M68KMusashiSetWriteB,
+   M68KMusashiSetWriteW,
+   M68KMusashiSaveState,
+   M68KMusashiLoadState
+};

--- a/yabause/src/m68kmusashi.h
+++ b/yabause/src/m68kmusashi.h
@@ -1,0 +1,27 @@
+/*  Copyright 2007 Guillaume Duhamel
+
+This file is part of Yabause.
+
+Yabause is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+Yabause is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Yabause; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef M68KMUSASHI_H
+#define M68KMUSASHI_H
+
+#include "m68kcore.h"
+
+extern M68K_struct M68KMusashi;
+
+#endif

--- a/yabause/src/musashi/m68k.h
+++ b/yabause/src/musashi/m68k.h
@@ -1,0 +1,358 @@
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.4
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright 1998-2001 Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef M68K__HEADER
+#define M68K__HEADER
+
+
+/* ======================================================================== */
+/* ============================= CONFIGURATION ============================ */
+/* ======================================================================== */
+
+/* Import the configuration for this build */
+#include "m68kconf.h"
+
+
+/* ======================================================================== */
+/* ============================ GENERAL DEFINES =========================== */
+
+/* ======================================================================== */
+
+/* There are 7 levels of interrupt to the 68K.
+ * A transition from < 7 to 7 will cause a non-maskable interrupt (NMI).
+ */
+#define M68K_IRQ_NONE 0
+#define M68K_IRQ_1    1
+#define M68K_IRQ_2    2
+#define M68K_IRQ_3    3
+#define M68K_IRQ_4    4
+#define M68K_IRQ_5    5
+#define M68K_IRQ_6    6
+#define M68K_IRQ_7    7
+
+
+/* Special interrupt acknowledge values.
+ * Use these as special returns from the interrupt acknowledge callback
+ * (specified later in this header).
+ */
+
+/* Causes an interrupt autovector (0x18 + interrupt level) to be taken.
+ * This happens in a real 68K if VPA or AVEC is asserted during an interrupt
+ * acknowledge cycle instead of DTACK.
+ */
+#define M68K_INT_ACK_AUTOVECTOR    0xffffffff
+
+/* Causes the spurious interrupt vector (0x18) to be taken
+ * This happens in a real 68K if BERR is asserted during the interrupt
+ * acknowledge cycle (i.e. no devices responded to the acknowledge).
+ */
+#define M68K_INT_ACK_SPURIOUS      0xfffffffe
+
+
+/* CPU types for use in m68k_set_cpu_type() */
+enum
+{
+	M68K_CPU_TYPE_INVALID,
+	M68K_CPU_TYPE_68000,
+	M68K_CPU_TYPE_68010,
+	M68K_CPU_TYPE_68EC020,
+	M68K_CPU_TYPE_68020,
+	M68K_CPU_TYPE_68030,	/* Supported by disassembler ONLY */
+	M68K_CPU_TYPE_68040		/* Supported by disassembler ONLY */
+};
+
+/* Registers used by m68k_get_reg() and m68k_set_reg() */
+typedef enum
+{
+	/* Real registers */
+	M68K_REG_D0,		/* Data registers */
+	M68K_REG_D1,
+	M68K_REG_D2,
+	M68K_REG_D3,
+	M68K_REG_D4,
+	M68K_REG_D5,
+	M68K_REG_D6,
+	M68K_REG_D7,
+	M68K_REG_A0,		/* Address registers */
+	M68K_REG_A1,
+	M68K_REG_A2,
+	M68K_REG_A3,
+	M68K_REG_A4,
+	M68K_REG_A5,
+	M68K_REG_A6,
+	M68K_REG_A7,
+	M68K_REG_PC,		/* Program Counter */
+	M68K_REG_SR,		/* Status Register */
+	M68K_REG_SP,		/* The current Stack Pointer (located in A7) */
+	M68K_REG_USP,		/* User Stack Pointer */
+	M68K_REG_ISP,		/* Interrupt Stack Pointer */
+	M68K_REG_MSP,		/* Master Stack Pointer */
+	M68K_REG_SFC,		/* Source Function Code */
+	M68K_REG_DFC,		/* Destination Function Code */
+	M68K_REG_VBR,		/* Vector Base Register */
+	M68K_REG_CACR,		/* Cache Control Register */
+	M68K_REG_CAAR,		/* Cache Address Register */
+
+	/* Assumed registers */
+	/* These are cheat registers which emulate the 1-longword prefetch
+	 * present in the 68000 and 68010.
+	 */
+	M68K_REG_PREF_ADDR,	/* Last prefetch address */
+	M68K_REG_PREF_DATA,	/* Last prefetch data */
+
+	/* Convenience registers */
+	M68K_REG_PPC,		/* Previous value in the program counter */
+	M68K_REG_IR,		/* Instruction register */
+	M68K_REG_CPU_TYPE	/* Type of CPU being run */
+} m68k_register_t;
+
+/* ======================================================================== */
+/* ====================== FUNCTIONS CALLED BY THE CPU ===================== */
+/* ======================================================================== */
+
+/* You will have to implement these functions */
+
+/* read/write functions called by the CPU to access memory.
+ * while values used are 32 bits, only the appropriate number
+ * of bits are relevant (i.e. in write_memory_8, only the lower 8 bits
+ * of value should be written to memory).
+ *
+ * NOTE: I have separated the immediate and PC-relative memory fetches
+ *       from the other memory fetches because some systems require
+ *       differentiation between PROGRAM and DATA fetches (usually
+ *       for security setups such as encryption).
+ *       This separation can either be achieved by setting
+ *       M68K_SEPARATE_READS in m68kconf.h and defining
+ *       the read functions, or by setting M68K_EMULATE_FC and
+ *       making a function code callback function.
+ *       Using the callback offers better emulation coverage
+ *       because you can also monitor whether the CPU is in SYSTEM or
+ *       USER mode, but it is also slower.
+ */
+
+/* Read from anywhere */
+unsigned int  m68k_read_memory_8(unsigned int address);
+unsigned int  m68k_read_memory_16(unsigned int address);
+unsigned int  m68k_read_memory_32(unsigned int address);
+
+/* Read data immediately following the PC */
+unsigned int  m68k_read_immediate_16(unsigned int address);
+unsigned int  m68k_read_immediate_32(unsigned int address);
+
+/* Read data relative to the PC */
+unsigned int  m68k_read_pcrelative_8(unsigned int address);
+unsigned int  m68k_read_pcrelative_16(unsigned int address);
+unsigned int  m68k_read_pcrelative_32(unsigned int address);
+
+/* Memory access for the disassembler */
+unsigned int m68k_read_disassembler_8  (unsigned int address);
+unsigned int m68k_read_disassembler_16 (unsigned int address);
+unsigned int m68k_read_disassembler_32 (unsigned int address);
+
+/* Write to anywhere */
+void m68k_write_memory_8(unsigned int address, unsigned int value);
+void m68k_write_memory_16(unsigned int address, unsigned int value);
+void m68k_write_memory_32(unsigned int address, unsigned int value);
+
+/* Special call to simulate undocumented 68k behavior when move.l with a
+ * predecrement destination mode is executed.
+ * To simulate real 68k behavior, first write the high word to
+ * [address+2], and then write the low word to [address].
+ *
+ * Enable this functionality with M68K_SIMULATE_PD_WRITES in m68kconf.h.
+ */
+void m68k_write_memory_32_pd(unsigned int address, unsigned int value);
+
+
+
+/* ======================================================================== */
+/* ============================== CALLBACKS =============================== */
+/* ======================================================================== */
+
+/* These functions allow you to set callbacks to the host when specific events
+ * occur.  Note that you must enable the corresponding value in m68kconf.h
+ * in order for these to do anything useful.
+ * Note: I have defined default callbacks which are used if you have enabled
+ * the corresponding #define in m68kconf.h but either haven't assigned a
+ * callback or have assigned a callback of NULL.
+ */
+
+/* Set the callback for an interrupt acknowledge.
+ * You must enable M68K_EMULATE_INT_ACK in m68kconf.h.
+ * The CPU will call the callback with the interrupt level being acknowledged.
+ * The host program must return either a vector from 0x02-0xff, or one of the
+ * special interrupt acknowledge values specified earlier in this header.
+ * If this is not implemented, the CPU will always assume an autovectored
+ * interrupt, and will automatically clear the interrupt request when it
+ * services the interrupt.
+ * Default behavior: return M68K_INT_ACK_AUTOVECTOR.
+ */
+void m68k_set_int_ack_callback(int  (*callback)(int int_level));
+
+
+/* Set the callback for a breakpoint acknowledge (68010+).
+ * You must enable M68K_EMULATE_BKPT_ACK in m68kconf.h.
+ * The CPU will call the callback with whatever was in the data field of the
+ * BKPT instruction for 68020+, or 0 for 68010.
+ * Default behavior: do nothing.
+ */
+void m68k_set_bkpt_ack_callback(void (*callback)(unsigned int data));
+
+
+/* Set the callback for the RESET instruction.
+ * You must enable M68K_EMULATE_RESET in m68kconf.h.
+ * The CPU calls this callback every time it encounters a RESET instruction.
+ * Default behavior: do nothing.
+ */
+void m68k_set_reset_instr_callback(void  (*callback)(void));
+
+
+/* Set the callback for informing of a large PC change.
+ * You must enable M68K_MONITOR_PC in m68kconf.h.
+ * The CPU calls this callback with the new PC value every time the PC changes
+ * by a large value (currently set for changes by longwords).
+ * Default behavior: do nothing.
+ */
+void m68k_set_pc_changed_callback(void  (*callback)(unsigned int new_pc));
+
+
+/* Set the callback for CPU function code changes.
+ * You must enable M68K_EMULATE_FC in m68kconf.h.
+ * The CPU calls this callback with the function code before every memory
+ * access to set the CPU's function code according to what kind of memory
+ * access it is (supervisor/user, program/data and such).
+ * Default behavior: do nothing.
+ */
+void m68k_set_fc_callback(void  (*callback)(unsigned int new_fc));
+
+
+/* Set a callback for the instruction cycle of the CPU.
+ * You must enable M68K_INSTRUCTION_HOOK in m68kconf.h.
+ * The CPU calls this callback just before fetching the opcode in the
+ * instruction cycle.
+ * Default behavior: do nothing.
+ */
+void m68k_set_instr_hook_callback(void  (*callback)(void));
+
+
+
+/* ======================================================================== */
+/* ====================== FUNCTIONS TO ACCESS THE CPU ===================== */
+/* ======================================================================== */
+
+/* Use this function to set the CPU type you want to emulate.
+ * Currently supported types are: M68K_CPU_TYPE_68000, M68K_CPU_TYPE_68010,
+ * M68K_CPU_TYPE_EC020, and M68K_CPU_TYPE_68020.
+ */
+void m68k_set_cpu_type(unsigned int cpu_type);
+
+/* Do whatever initialisations the core requires.  Should be called
+ * at least once at init time.
+ */
+void m68k_init(void);
+
+/* Pulse the RESET pin on the CPU.
+ * You *MUST* reset the CPU at least once to initialize the emulation
+ * Note: If you didn't call m68k_set_cpu_type() before resetting
+ *       the CPU for the first time, the CPU will be set to
+ *       M68K_CPU_TYPE_68000.
+ */
+void m68k_pulse_reset(void);
+
+/* execute num_cycles worth of instructions.  returns number of cycles used */
+int m68k_execute(int num_cycles);
+
+/* These functions let you read/write/modify the number of cycles left to run
+ * while m68k_execute() is running.
+ * These are useful if the 68k accesses a memory-mapped port on another device
+ * that requires immediate processing by another CPU.
+ */
+int m68k_cycles_run(void);              /* Number of cycles run so far */
+int m68k_cycles_remaining(void);        /* Number of cycles left */
+void m68k_modify_timeslice(int cycles); /* Modify cycles left */
+void m68k_end_timeslice(void);          /* End timeslice now */
+
+/* Set the IPL0-IPL2 pins on the CPU (IRQ).
+ * A transition from < 7 to 7 will cause a non-maskable interrupt (NMI).
+ * Setting IRQ to 0 will clear an interrupt request.
+ */
+void m68k_set_irq(unsigned int int_level);
+
+
+/* Halt the CPU as if you pulsed the HALT pin. */
+void m68k_pulse_halt(void);
+
+
+/* Context switching to allow multiple CPUs */
+
+/* Get the size of the cpu context in bytes */
+unsigned int m68k_context_size(void);
+
+/* Get a cpu context */
+unsigned int m68k_get_context(void* dst);
+
+/* set the current cpu context */
+void m68k_set_context(void* dst);
+
+/* Register the CPU state information */
+void m68k_state_register(const char *type);
+
+
+/* Peek at the internals of a CPU context.  This can either be a context
+ * retrieved using m68k_get_context() or the currently running context.
+ * If context is NULL, the currently running CPU context will be used.
+ */
+unsigned int m68k_get_reg(void* context, m68k_register_t reg);
+
+/* Poke values into the internals of the currently running CPU context */
+void m68k_set_reg(m68k_register_t reg, unsigned int value);
+
+/* Check if an instruction is valid for the specified CPU type */
+unsigned int m68k_is_valid_instruction(unsigned int instruction, unsigned int cpu_type);
+
+/* Disassemble 1 instruction using the epecified CPU type at pc.  Stores
+ * disassembly in str_buff and returns the size of the instruction in bytes.
+ */
+unsigned int m68k_disassemble(char* str_buff, unsigned int pc, unsigned int cpu_type);
+
+
+/* ======================================================================== */
+/* ============================== MAME STUFF ============================== */
+/* ======================================================================== */
+
+#if M68K_COMPILE_FOR_MAME == OPT_ON
+#include "m68kmame.h"
+#endif /* M68K_COMPILE_FOR_MAME */
+
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */
+
+#endif /* M68K__HEADER */

--- a/yabause/src/musashi/m68k_in.c
+++ b/yabause/src/musashi/m68k_in.c
@@ -1,0 +1,10372 @@
+/*
+must fix:
+	callm
+	chk
+*/
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.4
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright 1998-2001 Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/* Special thanks to Bart Trzynadlowski for his insight into the
+ * undocumented features of this chip:
+ *
+ * http://dynarec.com/~bart/files/68knotes.txt
+ */
+
+
+/* Input file for m68kmake
+ * -----------------------
+ *
+ * All sections begin with 80 X's in a row followed by an end-of-line
+ * sequence.
+ * After this, m68kmake will expect to find one of the following section
+ * identifiers:
+ *    M68KMAKE_PROTOTYPE_HEADER      - header for opcode handler prototypes
+ *    M68KMAKE_PROTOTYPE_FOOTER      - footer for opcode handler prototypes
+ *    M68KMAKE_TABLE_HEADER          - header for opcode handler jumptable
+ *    M68KMAKE_TABLE_FOOTER          - footer for opcode handler jumptable
+ *    M68KMAKE_TABLE_BODY            - the table itself
+ *    M68KMAKE_OPCODE_HANDLER_HEADER - header for opcode handler implementation
+ *    M68KMAKE_OPCODE_HANDLER_FOOTER - footer for opcode handler implementation
+ *    M68KMAKE_OPCODE_HANDLER_BODY   - body section for opcode handler implementation
+ *
+ * NOTE: M68KMAKE_OPCODE_HANDLER_BODY must be last in the file and
+ *       M68KMAKE_TABLE_BODY must be second last in the file.
+ *
+ * The M68KMAKE_OPHANDLER_BODY section contains the opcode handler
+ * primitives themselves.  Each opcode handler begins with:
+ *    M68KMAKE_OP(A, B, C, D)
+ *
+ * where A is the opcode handler name, B is the size of the operation,
+ * C denotes any special processing mode, and D denotes a specific
+ * addressing mode.
+ * For C and D where nothing is specified, use "."
+ *
+ * Example:
+ *     M68KMAKE_OP(abcd, 8, rr, .)   abcd, size 8, register to register, default EA
+ *     M68KMAKE_OP(abcd, 8, mm, ax7) abcd, size 8, memory to memory, register X is A7
+ *     M68KMAKE_OP(tst, 16, ., pcix) tst, size 16, PCIX addressing
+ *
+ * All opcode handler primitives end with a closing curly brace "}" at column 1
+ *
+ * NOTE: Do not place a M68KMAKE_OP() directive inside the opcode handler,
+ *       and do not put a closing curly brace at column 1 unless it is
+ *       marking the end of the handler!
+ *
+ * Inside the handler, m68kmake will recognize M68KMAKE_GET_OPER_xx_xx,
+ * M68KMAKE_GET_EA_xx_xx, and M68KMAKE_CC directives, and create multiple
+ * opcode handlers to handle variations in the opcode handler.
+ * Note: M68KMAKE_CC will only be interpreted in condition code opcodes.
+ * As well, M68KMAKE_GET_EA_xx_xx and M68KMAKE_GET_OPER_xx_xx will only
+ * be interpreted on instructions where the corresponding table entry
+ * specifies multiple effective addressing modes.
+ * Example:
+ * clr       32  .     .     0100001010......  A+-DXWL...  U U U   12   6   4
+ *
+ * This table entry says that the clr.l opcde has 7 variations (A+-DXWL).
+ * It is run in user or supervisor mode for all CPUs, and uses 12 cycles for
+ * 68000, 6 cycles for 68010, and 4 cycles for 68020.
+ */
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_PROTOTYPE_HEADER
+
+#ifndef M68KOPS__HEADER
+#define M68KOPS__HEADER
+
+/* ======================================================================== */
+/* ============================ OPCODE HANDLERS =========================== */
+/* ======================================================================== */
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_PROTOTYPE_FOOTER
+
+
+/* Build the opcode handler table */
+void m68ki_build_opcode_table(void);
+
+extern void (*m68ki_instruction_jump_table[0x10000])(void); /* opcode handler jump table */
+extern unsigned char m68ki_cycles[][0x10000];
+
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */
+
+#endif /* M68KOPS__HEADER */
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_TABLE_HEADER
+
+/* ======================================================================== */
+/* ========================= OPCODE TABLE BUILDER ========================= */
+/* ======================================================================== */
+
+#include "m68kops.h"
+
+#define NUM_CPU_TYPES 3
+
+void  (*m68ki_instruction_jump_table[0x10000])(void); /* opcode handler jump table */
+unsigned char m68ki_cycles[NUM_CPU_TYPES][0x10000]; /* Cycles used by CPU type */
+
+/* This is used to generate the opcode handler jump table */
+typedef struct
+{
+	void (*opcode_handler)(void);        /* handler function */
+	unsigned int  mask;                  /* mask on opcode */
+	unsigned int  match;                 /* what to match after masking */
+	unsigned char cycles[NUM_CPU_TYPES]; /* cycles each cpu type takes */
+} opcode_handler_struct;
+
+
+/* Opcode handler table */
+static opcode_handler_struct m68k_opcode_handler_table[] =
+{
+/*   function                      mask    match    000  010  020 */
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_TABLE_FOOTER
+
+	{0, 0, 0, {0, 0, 0}}
+};
+
+
+/* Build the opcode handler jump table */
+void m68ki_build_opcode_table(void)
+{
+	opcode_handler_struct *ostruct;
+	int cycle_cost;
+	int instr;
+	int i;
+	int j;
+	int k;
+
+	for(i = 0; i < 0x10000; i++)
+	{
+		/* default to illegal */
+		m68ki_instruction_jump_table[i] = m68k_op_illegal;
+		for(k=0;k<NUM_CPU_TYPES;k++)
+			m68ki_cycles[k][i] = 0;
+	}
+
+	ostruct = m68k_opcode_handler_table;
+	while(ostruct->mask != 0xff00)
+	{
+		for(i = 0;i < 0x10000;i++)
+		{
+			if((i & ostruct->mask) == ostruct->match)
+			{
+				m68ki_instruction_jump_table[i] = ostruct->opcode_handler;
+				for(k=0;k<NUM_CPU_TYPES;k++)
+					m68ki_cycles[k][i] = ostruct->cycles[k];
+			}
+		}
+		ostruct++;
+	}
+	while(ostruct->mask == 0xff00)
+	{
+		for(i = 0;i <= 0xff;i++)
+		{
+			m68ki_instruction_jump_table[ostruct->match | i] = ostruct->opcode_handler;
+			for(k=0;k<NUM_CPU_TYPES;k++)
+				m68ki_cycles[k][ostruct->match | i] = ostruct->cycles[k];
+		}
+		ostruct++;
+	}
+	while(ostruct->mask == 0xf1f8)
+	{
+		for(i = 0;i < 8;i++)
+		{
+			for(j = 0;j < 8;j++)
+			{
+				instr = ostruct->match | (i << 9) | j;
+				m68ki_instruction_jump_table[instr] = ostruct->opcode_handler;
+				for(k=0;k<NUM_CPU_TYPES;k++)
+					m68ki_cycles[k][instr] = ostruct->cycles[k];
+				// For all shift operations with known shift distance (encoded in instruction word)
+				if((instr & 0xf000) == 0xe000 && (!(instr & 0x20)))
+				{
+					// On the 68000 and 68010 shift distance affect execution time.
+					// Add the cycle cost of shifting; 2 times the shift distance
+					cycle_cost = ((((i-1)&7)+1)<<1);
+					m68ki_cycles[0][instr] += cycle_cost;
+					m68ki_cycles[1][instr] += cycle_cost;
+					// On the 68020 shift distance does not affect execution time
+					m68ki_cycles[2][instr] += 0;
+				}
+			}
+		}
+		ostruct++;
+	}
+	while(ostruct->mask == 0xfff0)
+	{
+		for(i = 0;i <= 0x0f;i++)
+		{
+			m68ki_instruction_jump_table[ostruct->match | i] = ostruct->opcode_handler;
+			for(k=0;k<NUM_CPU_TYPES;k++)
+				m68ki_cycles[k][ostruct->match | i] = ostruct->cycles[k];
+		}
+		ostruct++;
+	}
+	while(ostruct->mask == 0xf1ff)
+	{
+		for(i = 0;i <= 0x07;i++)
+		{
+			m68ki_instruction_jump_table[ostruct->match | (i << 9)] = ostruct->opcode_handler;
+			for(k=0;k<NUM_CPU_TYPES;k++)
+				m68ki_cycles[k][ostruct->match | (i << 9)] = ostruct->cycles[k];
+		}
+		ostruct++;
+	}
+	while(ostruct->mask == 0xfff8)
+	{
+		for(i = 0;i <= 0x07;i++)
+		{
+			m68ki_instruction_jump_table[ostruct->match | i] = ostruct->opcode_handler;
+			for(k=0;k<NUM_CPU_TYPES;k++)
+				m68ki_cycles[k][ostruct->match | i] = ostruct->cycles[k];
+		}
+		ostruct++;
+	}
+	while(ostruct->mask == 0xffff)
+	{
+		m68ki_instruction_jump_table[ostruct->match] = ostruct->opcode_handler;
+		for(k=0;k<NUM_CPU_TYPES;k++)
+			m68ki_cycles[k][ostruct->match] = ostruct->cycles[k];
+		ostruct++;
+	}
+}
+
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_OPCODE_HANDLER_HEADER
+
+#include "m68kcpu.h"
+
+/* ======================================================================== */
+/* ========================= INSTRUCTION HANDLERS ========================= */
+/* ======================================================================== */
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_OPCODE_HANDLER_FOOTER
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_TABLE_BODY
+
+The following table is arranged as follows:
+
+name:        Opcode mnemonic
+
+size:        Operation size
+
+spec proc:   Special processing mode:
+                 .:    normal
+                 s:    static operand
+                 r:    register operand
+                 rr:   register to register
+                 mm:   memory to memory
+                 er:   effective address to register
+                 re:   register to effective address
+                 dd:   data register to data register
+                 da:   data register to address register
+                 aa:   address register to address register
+                 cr:   control register to register
+                 rc:   register to control register
+                 toc:  to condition code register
+                 tos:  to status register
+                 tou:  to user stack pointer
+                 frc:  from condition code register
+                 frs:  from status register
+                 fru:  from user stack pointer
+                 * for move.x, the special processing mode is a specific
+                   destination effective addressing mode.
+
+spec ea:     Specific effective addressing mode:
+                 .:    normal
+                 i:    immediate
+                 d:    data register
+                 a:    address register
+                 ai:   address register indirect
+                 pi:   address register indirect with postincrement
+                 pd:   address register indirect with predecrement
+                 di:   address register indirect with displacement
+                 ix:   address register indirect with index
+                 aw:   absolute word address
+                 al:   absolute long address
+                 pcdi: program counter relative with displacement
+                 pcix: program counter relative with index
+                 a7:   register specified in instruction is A7
+                 ax7:  register field X of instruction is A7
+                 ay7:  register field Y of instruction is A7
+                 axy7: register fields X and Y of instruction are A7
+
+bit pattern: Pattern to recognize this opcode.  "." means don't care.
+
+allowed ea:  List of allowed addressing modes:
+                 .: not present
+                 A: address register indirect
+                 +: ARI (address register indirect) with postincrement
+                 -: ARI with predecrement
+                 D: ARI with displacement
+                 X: ARI with index
+                 W: absolute word address
+                 L: absolute long address
+                 d: program counter indirect with displacement
+                 x: program counter indirect with index
+                 I: immediate
+mode:        CPU operating mode for each cpu type.  U = user or supervisor,
+             S = supervisor only, "." = opcode not present.
+
+cpu cycles:  Base number of cycles required to execute this opcode on the
+             specified CPU type.
+             Use "." if CPU does not have this opcode.
+
+
+
+              spec  spec                    allowed ea  mode   cpu cycles
+name    size  proc   ea   bit pattern       A+-DXWLdxI  0 1 2  000 010 020  comments
+======  ====  ====  ====  ================  ==========  = = =  === === ===  =============
+M68KMAKE_TABLE_START
+1010       0  .     .     1010............  ..........  U U U    4   4   4
+1111       0  .     .     1111............  ..........  U U U    4   4   4
+abcd       8  rr    .     1100...100000...  ..........  U U U    6   6   4
+abcd       8  mm    ax7   1100111100001...  ..........  U U U   18  18  16
+abcd       8  mm    ay7   1100...100001111  ..........  U U U   18  18  16
+abcd       8  mm    axy7  1100111100001111  ..........  U U U   18  18  16
+abcd       8  mm    .     1100...100001...  ..........  U U U   18  18  16
+add        8  er    d     1101...000000...  ..........  U U U    4   4   2
+add        8  er    .     1101...000......  A+-DXWLdxI  U U U    4   4   2
+add       16  er    d     1101...001000...  ..........  U U U    4   4   2
+add       16  er    a     1101...001001...  ..........  U U U    4   4   2
+add       16  er    .     1101...001......  A+-DXWLdxI  U U U    4   4   2
+add       32  er    d     1101...010000...  ..........  U U U    6   6   2
+add       32  er    a     1101...010001...  ..........  U U U    6   6   2
+add       32  er    .     1101...010......  A+-DXWLdxI  U U U    6   6   2
+add        8  re    .     1101...100......  A+-DXWL...  U U U    8   8   4
+add       16  re    .     1101...101......  A+-DXWL...  U U U    8   8   4
+add       32  re    .     1101...110......  A+-DXWL...  U U U   12  12   4
+adda      16  .     d     1101...011000...  ..........  U U U    8   8   2
+adda      16  .     a     1101...011001...  ..........  U U U    8   8   2
+adda      16  .     .     1101...011......  A+-DXWLdxI  U U U    8   8   2
+adda      32  .     d     1101...111000...  ..........  U U U    6   6   2
+adda      32  .     a     1101...111001...  ..........  U U U    6   6   2
+adda      32  .     .     1101...111......  A+-DXWLdxI  U U U    6   6   2
+addi       8  .     d     0000011000000...  ..........  U U U    8   8   2
+addi       8  .     .     0000011000......  A+-DXWL...  U U U   12  12   4
+addi      16  .     d     0000011001000...  ..........  U U U    8   8   2
+addi      16  .     .     0000011001......  A+-DXWL...  U U U   12  12   4
+addi      32  .     d     0000011010000...  ..........  U U U   16  14   2
+addi      32  .     .     0000011010......  A+-DXWL...  U U U   20  20   4
+addq       8  .     d     0101...000000...  ..........  U U U    4   4   2
+addq       8  .     .     0101...000......  A+-DXWL...  U U U    8   8   4
+addq      16  .     d     0101...001000...  ..........  U U U    4   4   2
+addq      16  .     a     0101...001001...  ..........  U U U    4   4   2
+addq      16  .     .     0101...001......  A+-DXWL...  U U U    8   8   4
+addq      32  .     d     0101...010000...  ..........  U U U    8   8   2
+addq      32  .     a     0101...010001...  ..........  U U U    8   8   2
+addq      32  .     .     0101...010......  A+-DXWL...  U U U   12  12   4
+addx       8  rr    .     1101...100000...  ..........  U U U    4   4   2
+addx      16  rr    .     1101...101000...  ..........  U U U    4   4   2
+addx      32  rr    .     1101...110000...  ..........  U U U    8   6   2
+addx       8  mm    ax7   1101111100001...  ..........  U U U   18  18  12
+addx       8  mm    ay7   1101...100001111  ..........  U U U   18  18  12
+addx       8  mm    axy7  1101111100001111  ..........  U U U   18  18  12
+addx       8  mm    .     1101...100001...  ..........  U U U   18  18  12
+addx      16  mm    .     1101...101001...  ..........  U U U   18  18  12
+addx      32  mm    .     1101...110001...  ..........  U U U   30  30  12
+and        8  er    d     1100...000000...  ..........  U U U    4   4   2
+and        8  er    .     1100...000......  A+-DXWLdxI  U U U    4   4   2
+and       16  er    d     1100...001000...  ..........  U U U    4   4   2
+and       16  er    .     1100...001......  A+-DXWLdxI  U U U    4   4   2
+and       32  er    d     1100...010000...  ..........  U U U    6   6   2
+and       32  er    .     1100...010......  A+-DXWLdxI  U U U    6   6   2
+and        8  re    .     1100...100......  A+-DXWL...  U U U    8   8   4
+and       16  re    .     1100...101......  A+-DXWL...  U U U    8   8   4
+and       32  re    .     1100...110......  A+-DXWL...  U U U   12  12   4
+andi      16  toc   .     0000001000111100  ..........  U U U   20  16  12
+andi      16  tos   .     0000001001111100  ..........  S S S   20  16  12
+andi       8  .     d     0000001000000...  ..........  U U U    8   8   2
+andi       8  .     .     0000001000......  A+-DXWL...  U U U   12  12   4
+andi      16  .     d     0000001001000...  ..........  U U U    8   8   2
+andi      16  .     .     0000001001......  A+-DXWL...  U U U   12  12   4
+andi      32  .     d     0000001010000...  ..........  U U U   14  14   2
+andi      32  .     .     0000001010......  A+-DXWL...  U U U   20  20   4
+asr        8  s     .     1110...000000...  ..........  U U U    6   6   6
+asr       16  s     .     1110...001000...  ..........  U U U    6   6   6
+asr       32  s     .     1110...010000...  ..........  U U U    8   8   6
+asr        8  r     .     1110...000100...  ..........  U U U    6   6   6
+asr       16  r     .     1110...001100...  ..........  U U U    6   6   6
+asr       32  r     .     1110...010100...  ..........  U U U    8   8   6
+asr       16  .     .     1110000011......  A+-DXWL...  U U U    8   8   5
+asl        8  s     .     1110...100000...  ..........  U U U    6   6   8
+asl       16  s     .     1110...101000...  ..........  U U U    6   6   8
+asl       32  s     .     1110...110000...  ..........  U U U    8   8   8
+asl        8  r     .     1110...100100...  ..........  U U U    6   6   8
+asl       16  r     .     1110...101100...  ..........  U U U    6   6   8
+asl       32  r     .     1110...110100...  ..........  U U U    8   8   8
+asl       16  .     .     1110000111......  A+-DXWL...  U U U    8   8   6
+bcc        8  .     .     0110............  ..........  U U U   10  10   6
+bcc       16  .     .     0110....00000000  ..........  U U U   10  10   6
+bcc       32  .     .     0110....11111111  ..........  . . U    .   .   6
+bchg       8  r     .     0000...101......  A+-DXWL...  U U U    8   8   4
+bchg      32  r     d     0000...101000...  ..........  U U U    8   8   4
+bchg       8  s     .     0000100001......  A+-DXWL...  U U U   12  12   4
+bchg      32  s     d     0000100001000...  ..........  U U U   12  12   4
+bclr       8  r     .     0000...110......  A+-DXWL...  U U U    8  10   4
+bclr      32  r     d     0000...110000...  ..........  U U U   10  10   4
+bclr       8  s     .     0000100010......  A+-DXWL...  U U U   12  12   4
+bclr      32  s     d     0000100010000...  ..........  U U U   14  14   4
+bfchg     32  .     d     1110101011000...  ..........  . . U    .   .  12  timing not quite correct
+bfchg     32  .     .     1110101011......  A..DXWL...  . . U    .   .  20
+bfclr     32  .     d     1110110011000...  ..........  . . U    .   .  12
+bfclr     32  .     .     1110110011......  A..DXWL...  . . U    .   .  20
+bfexts    32  .     d     1110101111000...  ..........  . . U    .   .   8
+bfexts    32  .     .     1110101111......  A..DXWLdx.  . . U    .   .  15
+bfextu    32  .     d     1110100111000...  ..........  . . U    .   .   8
+bfextu    32  .     .     1110100111......  A..DXWLdx.  . . U    .   .  15
+bfffo     32  .     d     1110110111000...  ..........  . . U    .   .  18
+bfffo     32  .     .     1110110111......  A..DXWLdx.  . . U    .   .  28
+bfins     32  .     d     1110111111000...  ..........  . . U    .   .  10
+bfins     32  .     .     1110111111......  A..DXWL...  . . U    .   .  17
+bfset     32  .     d     1110111011000...  ..........  . . U    .   .  12
+bfset     32  .     .     1110111011......  A..DXWL...  . . U    .   .  20
+bftst     32  .     d     1110100011000...  ..........  . . U    .   .   6
+bftst     32  .     .     1110100011......  A..DXWLdx.  . . U    .   .  13
+bkpt       0  .     .     0100100001001...  ..........  . U U    .  10  10
+bra        8  .     .     01100000........  ..........  U U U   10  10  10
+bra       16  .     .     0110000000000000  ..........  U U U   10  10  10
+bra       32  .     .     0110000011111111  ..........  U U U    .   .  10
+bset      32  r     d     0000...111000...  ..........  U U U    8   8   4
+bset       8  r     .     0000...111......  A+-DXWL...  U U U    8   8   4
+bset       8  s     .     0000100011......  A+-DXWL...  U U U   12  12   4
+bset      32  s     d     0000100011000...  ..........  U U U   12  12   4
+bsr        8  .     .     01100001........  ..........  U U U   18  18   7
+bsr       16  .     .     0110000100000000  ..........  U U U   18  18   7
+bsr       32  .     .     0110000111111111  ..........  . . U    .   .   7
+btst       8  r     .     0000...100......  A+-DXWLdxI  U U U    4   4   4
+btst      32  r     d     0000...100000...  ..........  U U U    6   6   4
+btst       8  s     .     0000100000......  A+-DXWLdx.  U U U    8   8   4
+btst      32  s     d     0000100000000...  ..........  U U U   10  10   4
+callm     32  .     .     0000011011......  A..DXWLdx.  . . U    .   .  60  not properly emulated
+cas        8  .     .     0000101011......  A+-DXWL...  . . U    .   .  12
+cas       16  .     .     0000110011......  A+-DXWL...  . . U    .   .  12
+cas       32  .     .     0000111011......  A+-DXWL...  . . U    .   .  12
+cas2      16  .     .     0000110011111100  ..........  . . U    .   .  12
+cas2      32  .     .     0000111011111100  ..........  . . U    .   .  12
+chk       16  .     d     0100...110000...  ..........  U U U   10   8   8
+chk       16  .     .     0100...110......  A+-DXWLdxI  U U U   10   8   8
+chk       32  .     d     0100...100000...  ..........  . . U    .   .   8
+chk       32  .     .     0100...100......  A+-DXWLdxI  . . U    .   .   8
+chk2cmp2   8  .     pcdi  0000000011111010  ..........  . . U    .   .  23
+chk2cmp2   8  .     pcix  0000000011111011  ..........  . . U    .   .  23
+chk2cmp2   8  .     .     0000000011......  A..DXWL...  . . U    .   .  18
+chk2cmp2  16  .     pcdi  0000001011111010  ..........  . . U    .   .  23
+chk2cmp2  16  .     pcix  0000001011111011  ..........  . . U    .   .  23
+chk2cmp2  16  .     .     0000001011......  A..DXWL...  . . U    .   .  18
+chk2cmp2  32  .     pcdi  0000010011111010  ..........  . . U    .   .  23
+chk2cmp2  32  .     pcix  0000010011111011  ..........  . . U    .   .  23
+chk2cmp2  32  .     .     0000010011......  A..DXWL...  . . U    .   .  18
+clr        8  .     d     0100001000000...  ..........  U U U    4   4   2
+clr        8  .     .     0100001000......  A+-DXWL...  U U U    8   4   4
+clr       16  .     d     0100001001000...  ..........  U U U    4   4   2
+clr       16  .     .     0100001001......  A+-DXWL...  U U U    8   4   4
+clr       32  .     d     0100001010000...  ..........  U U U    6   6   2
+clr       32  .     .     0100001010......  A+-DXWL...  U U U   12   6   4
+cmp        8  .     d     1011...000000...  ..........  U U U    4   4   2
+cmp        8  .     .     1011...000......  A+-DXWLdxI  U U U    4   4   2
+cmp       16  .     d     1011...001000...  ..........  U U U    4   4   2
+cmp       16  .     a     1011...001001...  ..........  U U U    4   4   2
+cmp       16  .     .     1011...001......  A+-DXWLdxI  U U U    4   4   2
+cmp       32  .     d     1011...010000...  ..........  U U U    6   6   2
+cmp       32  .     a     1011...010001...  ..........  U U U    6   6   2
+cmp       32  .     .     1011...010......  A+-DXWLdxI  U U U    6   6   2
+cmpa      16  .     d     1011...011000...  ..........  U U U    6   6   4
+cmpa      16  .     a     1011...011001...  ..........  U U U    6   6   4
+cmpa      16  .     .     1011...011......  A+-DXWLdxI  U U U    6   6   4
+cmpa      32  .     d     1011...111000...  ..........  U U U    6   6   4
+cmpa      32  .     a     1011...111001...  ..........  U U U    6   6   4
+cmpa      32  .     .     1011...111......  A+-DXWLdxI  U U U    6   6   4
+cmpi       8  .     d     0000110000000...  ..........  U U U    8   8   2
+cmpi       8  .     .     0000110000......  A+-DXWL...  U U U    8   8   2
+cmpi       8  .     pcdi  0000110000111010  ..........  . . U    .   .   7
+cmpi       8  .     pcix  0000110000111011  ..........  . . U    .   .   9
+cmpi      16  .     d     0000110001000...  ..........  U U U    8   8   2
+cmpi      16  .     .     0000110001......  A+-DXWL...  U U U    8   8   2
+cmpi      16  .     pcdi  0000110001111010  ..........  . . U    .   .   7
+cmpi      16  .     pcix  0000110001111011  ..........  . . U    .   .   9
+cmpi      32  .     d     0000110010000...  ..........  U U U   14  12   2
+cmpi      32  .     .     0000110010......  A+-DXWL...  U U U   12  12   2
+cmpi      32  .     pcdi  0000110010111010  ..........  . . U    .   .   7
+cmpi      32  .     pcix  0000110010111011  ..........  . . U    .   .   9
+cmpm       8  .     ax7   1011111100001...  ..........  U U U   12  12   9
+cmpm       8  .     ay7   1011...100001111  ..........  U U U   12  12   9
+cmpm       8  .     axy7  1011111100001111  ..........  U U U   12  12   9
+cmpm       8  .     .     1011...100001...  ..........  U U U   12  12   9
+cmpm      16  .     .     1011...101001...  ..........  U U U   12  12   9
+cmpm      32  .     .     1011...110001...  ..........  U U U   20  20   9
+cpbcc     32  .     .     1111...01.......  ..........  . . U    .   .   4  unemulated
+cpdbcc    32  .     .     1111...001001...  ..........  . . U    .   .   4  unemulated
+cpgen     32  .     .     1111...000......  ..........  . . U    .   .   4  unemulated
+cpscc     32  .     .     1111...001......  ..........  . . U    .   .   4  unemulated
+cptrapcc  32  .     .     1111...001111...  ..........  . . U    .   .   4  unemulated
+dbt       16  .     .     0101000011001...  ..........  U U U   12  12   6
+dbf       16  .     .     0101000111001...  ..........  U U U   12  12   6
+dbcc      16  .     .     0101....11001...  ..........  U U U   12  12   6
+divs      16  .     d     1000...111000...  ..........  U U U  158 122  56
+divs      16  .     .     1000...111......  A+-DXWLdxI  U U U  158 122  56
+divu      16  .     d     1000...011000...  ..........  U U U  140 108  44
+divu      16  .     .     1000...011......  A+-DXWLdxI  U U U  140 108  44
+divl      32  .     d     0100110001000...  ..........  . . U    .   .  84
+divl      32  .     .     0100110001......  A+-DXWLdxI  . . U    .   .  84
+eor        8  .     d     1011...100000...  ..........  U U U    4   4   2
+eor        8  .     .     1011...100......  A+-DXWL...  U U U    8   8   4
+eor       16  .     d     1011...101000...  ..........  U U U    4   4   2
+eor       16  .     .     1011...101......  A+-DXWL...  U U U    8   8   4
+eor       32  .     d     1011...110000...  ..........  U U U    8   6   2
+eor       32  .     .     1011...110......  A+-DXWL...  U U U   12  12   4
+eori      16  toc   .     0000101000111100  ..........  U U U   20  16  12
+eori      16  tos   .     0000101001111100  ..........  S S S   20  16  12
+eori       8  .     d     0000101000000...  ..........  U U U    8   8   2
+eori       8  .     .     0000101000......  A+-DXWL...  U U U   12  12   4
+eori      16  .     d     0000101001000...  ..........  U U U    8   8   2
+eori      16  .     .     0000101001......  A+-DXWL...  U U U   12  12   4
+eori      32  .     d     0000101010000...  ..........  U U U   16  14   2
+eori      32  .     .     0000101010......  A+-DXWL...  U U U   20  20   4
+exg       32  dd    .     1100...101000...  ..........  U U U    6   6   2
+exg       32  aa    .     1100...101001...  ..........  U U U    6   6   2
+exg       32  da    .     1100...110001...  ..........  U U U    6   6   2
+ext       16  .     .     0100100010000...  ..........  U U U    4   4   4
+ext       32  .     .     0100100011000...  ..........  U U U    4   4   4
+extb      32  .     .     0100100111000...  ..........  . . U    .   .   4
+illegal    0  .     .     0100101011111100  ..........  U U U    4   4   4
+jmp       32  .     .     0100111011......  A..DXWLdx.  U U U    4   4   0
+jsr       32  .     .     0100111010......  A..DXWLdx.  U U U   12  12   0
+lea       32  .     .     0100...111......  A..DXWLdx.  U U U    0   0   2
+link      16  .     a7    0100111001010111  ..........  U U U   16  16   5
+link      16  .     .     0100111001010...  ..........  U U U   16  16   5
+link      32  .     a7    0100100000001111  ..........  . . U    .   .   6
+link      32  .     .     0100100000001...  ..........  . . U    .   .   6
+lsr        8  s     .     1110...000001...  ..........  U U U    6   6   4
+lsr       16  s     .     1110...001001...  ..........  U U U    6   6   4
+lsr       32  s     .     1110...010001...  ..........  U U U    8   8   4
+lsr        8  r     .     1110...000101...  ..........  U U U    6   6   6
+lsr       16  r     .     1110...001101...  ..........  U U U    6   6   6
+lsr       32  r     .     1110...010101...  ..........  U U U    8   8   6
+lsr       16  .     .     1110001011......  A+-DXWL...  U U U    8   8   5
+lsl        8  s     .     1110...100001...  ..........  U U U    6   6   4
+lsl       16  s     .     1110...101001...  ..........  U U U    6   6   4
+lsl       32  s     .     1110...110001...  ..........  U U U    8   8   4
+lsl        8  r     .     1110...100101...  ..........  U U U    6   6   6
+lsl       16  r     .     1110...101101...  ..........  U U U    6   6   6
+lsl       32  r     .     1110...110101...  ..........  U U U    8   8   6
+lsl       16  .     .     1110001111......  A+-DXWL...  U U U    8   8   5
+move       8  d     d     0001...000000...  ..........  U U U    4   4   2
+move       8  d     .     0001...000......  A+-DXWLdxI  U U U    4   4   2
+move       8  ai    d     0001...010000...  ..........  U U U    8   8   4
+move       8  ai    .     0001...010......  A+-DXWLdxI  U U U    8   8   4
+move       8  pi    d     0001...011000...  ..........  U U U    8   8   4
+move       8  pi    .     0001...011......  A+-DXWLdxI  U U U    8   8   4
+move       8  pi7   d     0001111011000...  ..........  U U U    8   8   4
+move       8  pi7   .     0001111011......  A+-DXWLdxI  U U U    8   8   4
+move       8  pd    d     0001...100000...  ..........  U U U    8   8   5
+move       8  pd    .     0001...100......  A+-DXWLdxI  U U U    8   8   5
+move       8  pd7   d     0001111100000...  ..........  U U U    8   8   5
+move       8  pd7   .     0001111100......  A+-DXWLdxI  U U U    8   8   5
+move       8  di    d     0001...101000...  ..........  U U U   12  12   5
+move       8  di    .     0001...101......  A+-DXWLdxI  U U U   12  12   5
+move       8  ix    d     0001...110000...  ..........  U U U   14  14   7
+move       8  ix    .     0001...110......  A+-DXWLdxI  U U U   14  14   7
+move       8  aw    d     0001000111000...  ..........  U U U   12  12   4
+move       8  aw    .     0001000111......  A+-DXWLdxI  U U U   12  12   4
+move       8  al    d     0001001111000...  ..........  U U U   16  16   6
+move       8  al    .     0001001111......  A+-DXWLdxI  U U U   16  16   6
+move      16  d     d     0011...000000...  ..........  U U U    4   4   2
+move      16  d     a     0011...000001...  ..........  U U U    4   4   2
+move      16  d     .     0011...000......  A+-DXWLdxI  U U U    4   4   2
+move      16  ai    d     0011...010000...  ..........  U U U    8   8   4
+move      16  ai    a     0011...010001...  ..........  U U U    8   8   4
+move      16  ai    .     0011...010......  A+-DXWLdxI  U U U    8   8   4
+move      16  pi    d     0011...011000...  ..........  U U U    8   8   4
+move      16  pi    a     0011...011001...  ..........  U U U    8   8   4
+move      16  pi    .     0011...011......  A+-DXWLdxI  U U U    8   8   4
+move      16  pd    d     0011...100000...  ..........  U U U    8   8   5
+move      16  pd    a     0011...100001...  ..........  U U U    8   8   5
+move      16  pd    .     0011...100......  A+-DXWLdxI  U U U    8   8   5
+move      16  di    d     0011...101000...  ..........  U U U   12  12   5
+move      16  di    a     0011...101001...  ..........  U U U   12  12   5
+move      16  di    .     0011...101......  A+-DXWLdxI  U U U   12  12   5
+move      16  ix    d     0011...110000...  ..........  U U U   14  14   7
+move      16  ix    a     0011...110001...  ..........  U U U   14  14   7
+move      16  ix    .     0011...110......  A+-DXWLdxI  U U U   14  14   7
+move      16  aw    d     0011000111000...  ..........  U U U   12  12   4
+move      16  aw    a     0011000111001...  ..........  U U U   12  12   4
+move      16  aw    .     0011000111......  A+-DXWLdxI  U U U   12  12   4
+move      16  al    d     0011001111000...  ..........  U U U   16  16   6
+move      16  al    a     0011001111001...  ..........  U U U   16  16   6
+move      16  al    .     0011001111......  A+-DXWLdxI  U U U   16  16   6
+move      32  d     d     0010...000000...  ..........  U U U    4   4   2
+move      32  d     a     0010...000001...  ..........  U U U    4   4   2
+move      32  d     .     0010...000......  A+-DXWLdxI  U U U    4   4   2
+move      32  ai    d     0010...010000...  ..........  U U U   12  12   4
+move      32  ai    a     0010...010001...  ..........  U U U   12  12   4
+move      32  ai    .     0010...010......  A+-DXWLdxI  U U U   12  12   4
+move      32  pi    d     0010...011000...  ..........  U U U   12  12   4
+move      32  pi    a     0010...011001...  ..........  U U U   12  12   4
+move      32  pi    .     0010...011......  A+-DXWLdxI  U U U   12  12   4
+move      32  pd    d     0010...100000...  ..........  U U U   12  14   5
+move      32  pd    a     0010...100001...  ..........  U U U   12  14   5
+move      32  pd    .     0010...100......  A+-DXWLdxI  U U U   12  14   5
+move      32  di    d     0010...101000...  ..........  U U U   16  16   5
+move      32  di    a     0010...101001...  ..........  U U U   16  16   5
+move      32  di    .     0010...101......  A+-DXWLdxI  U U U   16  16   5
+move      32  ix    d     0010...110000...  ..........  U U U   18  18   7
+move      32  ix    a     0010...110001...  ..........  U U U   18  18   7
+move      32  ix    .     0010...110......  A+-DXWLdxI  U U U   18  18   7
+move      32  aw    d     0010000111000...  ..........  U U U   16  16   4
+move      32  aw    a     0010000111001...  ..........  U U U   16  16   4
+move      32  aw    .     0010000111......  A+-DXWLdxI  U U U   16  16   4
+move      32  al    d     0010001111000...  ..........  U U U   20  20   6
+move      32  al    a     0010001111001...  ..........  U U U   20  20   6
+move      32  al    .     0010001111......  A+-DXWLdxI  U U U   20  20   6
+movea     16  .     d     0011...001000...  ..........  U U U    4   4   2
+movea     16  .     a     0011...001001...  ..........  U U U    4   4   2
+movea     16  .     .     0011...001......  A+-DXWLdxI  U U U    4   4   2
+movea     32  .     d     0010...001000...  ..........  U U U    4   4   2
+movea     32  .     a     0010...001001...  ..........  U U U    4   4   2
+movea     32  .     .     0010...001......  A+-DXWLdxI  U U U    4   4   2
+move      16  frc   d     0100001011000...  ..........  . U U    .   4   4
+move      16  frc   .     0100001011......  A+-DXWL...  . U U    .   8   4
+move      16  toc   d     0100010011000...  ..........  U U U   12  12   4
+move      16  toc   .     0100010011......  A+-DXWLdxI  U U U   12  12   4
+move      16  frs   d     0100000011000...  ..........  U S S    6   4   8 U only for 000
+move      16  frs   .     0100000011......  A+-DXWL...  U S S    8   8   8 U only for 000
+move      16  tos   d     0100011011000...  ..........  S S S   12  12   8
+move      16  tos   .     0100011011......  A+-DXWLdxI  S S S   12  12   8
+move      32  fru   .     0100111001101...  ..........  S S S    4   6   2
+move      32  tou   .     0100111001100...  ..........  S S S    4   6   2
+movec     32  cr    .     0100111001111010  ..........  . S S    .  12   6
+movec     32  rc    .     0100111001111011  ..........  . S S    .  10  12
+movem     16  re    pd    0100100010100...  ..........  U U U    8   8   4
+movem     16  re    .     0100100010......  A..DXWL...  U U U    4   4   4  cycles for hypothetical d addressing mode (020 unverified)
+movem     32  re    pd    0100100011100...  ..........  U U U    8   8   4
+movem     32  re    .     0100100011......  A..DXWL...  U U U    0   0   4  cycles for hypothetical d addressing mode (020 unverified)
+movem     16  er    pi    0100110010011...  ..........  U U U   12  12   8
+movem     16  er    pcdi  0100110010111010  ..........  U U U   16  16   9
+movem     16  er    pcix  0100110010111011  ..........  U U U   18  18  11
+movem     16  er    .     0100110010......  A..DXWL...  U U U    8   8   8  cycles for hypothetical d addressing mode (020 unverified)
+movem     32  er    pi    0100110011011...  ..........  U U U   12  12   8
+movem     32  er    pcdi  0100110011111010  ..........  U U U   16  16   9
+movem     32  er    pcix  0100110011111011  ..........  U U U   18  18  11
+movem     32  er    .     0100110011......  A..DXWL...  U U U    4   4   8  cycles for hypothetical d addressing mode (020 unverified)
+movep     16  er    .     0000...100001...  ..........  U U U   16  16  12
+movep     32  er    .     0000...101001...  ..........  U U U   24  24  18
+movep     16  re    .     0000...110001...  ..........  U U U   16  16  11
+movep     32  re    .     0000...111001...  ..........  U U U   24  24  17
+moveq     32  .     .     0111...0........  ..........  U U U    4   4   2
+moves      8  .     .     0000111000......  A+-DXWL...  . S S    .  14   5
+moves     16  .     .     0000111001......  A+-DXWL...  . S S    .  14   5
+moves     32  .     .     0000111010......  A+-DXWL...  . S S    .  16   5
+muls      16  .     d     1100...111000...  ..........  U U U   54  32  27
+muls      16  .     .     1100...111......  A+-DXWLdxI  U U U   54  32  27
+mulu      16  .     d     1100...011000...  ..........  U U U   54  30  27
+mulu      16  .     .     1100...011......  A+-DXWLdxI  U U U   54  30  27
+mull      32  .     d     0100110000000...  ..........  . . U    .   .  43
+mull      32  .     .     0100110000......  A+-DXWLdxI  . . U    .   .  43
+nbcd       8  .     d     0100100000000...  ..........  U U U    6   6   6
+nbcd       8  .     .     0100100000......  A+-DXWL...  U U U    8   8   6
+neg        8  .     d     0100010000000...  ..........  U U U    4   4   2
+neg        8  .     .     0100010000......  A+-DXWL...  U U U    8   8   4
+neg       16  .     d     0100010001000...  ..........  U U U    4   4   2
+neg       16  .     .     0100010001......  A+-DXWL...  U U U    8   8   4
+neg       32  .     d     0100010010000...  ..........  U U U    6   6   2
+neg       32  .     .     0100010010......  A+-DXWL...  U U U   12  12   4
+negx       8  .     d     0100000000000...  ..........  U U U    4   4   2
+negx       8  .     .     0100000000......  A+-DXWL...  U U U    8   8   4
+negx      16  .     d     0100000001000...  ..........  U U U    4   4   2
+negx      16  .     .     0100000001......  A+-DXWL...  U U U    8   8   4
+negx      32  .     d     0100000010000...  ..........  U U U    6   6   2
+negx      32  .     .     0100000010......  A+-DXWL...  U U U   12  12   4
+nop        0  .     .     0100111001110001  ..........  U U U    4   4   2
+not        8  .     d     0100011000000...  ..........  U U U    4   4   2
+not        8  .     .     0100011000......  A+-DXWL...  U U U    8   8   4
+not       16  .     d     0100011001000...  ..........  U U U    4   4   2
+not       16  .     .     0100011001......  A+-DXWL...  U U U    8   8   4
+not       32  .     d     0100011010000...  ..........  U U U    6   6   2
+not       32  .     .     0100011010......  A+-DXWL...  U U U   12  12   4
+or         8  er    d     1000...000000...  ..........  U U U    4   4   2
+or         8  er    .     1000...000......  A+-DXWLdxI  U U U    4   4   2
+or        16  er    d     1000...001000...  ..........  U U U    4   4   2
+or        16  er    .     1000...001......  A+-DXWLdxI  U U U    4   4   2
+or        32  er    d     1000...010000...  ..........  U U U    6   6   2
+or        32  er    .     1000...010......  A+-DXWLdxI  U U U    6   6   2
+or         8  re    .     1000...100......  A+-DXWL...  U U U    8   8   4
+or        16  re    .     1000...101......  A+-DXWL...  U U U    8   8   4
+or        32  re    .     1000...110......  A+-DXWL...  U U U   12  12   4
+ori       16  toc   .     0000000000111100  ..........  U U U   20  16  12
+ori       16  tos   .     0000000001111100  ..........  S S S   20  16  12
+ori        8  .     d     0000000000000...  ..........  U U U    8   8   2
+ori        8  .     .     0000000000......  A+-DXWL...  U U U   12  12   4
+ori       16  .     d     0000000001000...  ..........  U U U    8   8   2
+ori       16  .     .     0000000001......  A+-DXWL...  U U U   12  12   4
+ori       32  .     d     0000000010000...  ..........  U U U   16  14   2
+ori       32  .     .     0000000010......  A+-DXWL...  U U U   20  20   4
+pack      16  rr    .     1000...101000...  ..........  . . U    .   .   6
+pack      16  mm    ax7   1000111101001...  ..........  . . U    .   .  13
+pack      16  mm    ay7   1000...101001111  ..........  . . U    .   .  13
+pack      16  mm    axy7  1000111101001111  ..........  . . U    .   .  13
+pack      16  mm    .     1000...101001...  ..........  . . U    .   .  13
+pea       32  .     .     0100100001......  A..DXWLdx.  U U U    6   6   5
+reset      0  .     .     0100111001110000  ..........  S S S    0   0   0
+ror        8  s     .     1110...000011...  ..........  U U U    6   6   8
+ror       16  s     .     1110...001011...  ..........  U U U    6   6   8
+ror       32  s     .     1110...010011...  ..........  U U U    8   8   8
+ror        8  r     .     1110...000111...  ..........  U U U    6   6   8
+ror       16  r     .     1110...001111...  ..........  U U U    6   6   8
+ror       32  r     .     1110...010111...  ..........  U U U    8   8   8
+ror       16  .     .     1110011011......  A+-DXWL...  U U U    8   8   7
+rol        8  s     .     1110...100011...  ..........  U U U    6   6   8
+rol       16  s     .     1110...101011...  ..........  U U U    6   6   8
+rol       32  s     .     1110...110011...  ..........  U U U    8   8   8
+rol        8  r     .     1110...100111...  ..........  U U U    6   6   8
+rol       16  r     .     1110...101111...  ..........  U U U    6   6   8
+rol       32  r     .     1110...110111...  ..........  U U U    8   8   8
+rol       16  .     .     1110011111......  A+-DXWL...  U U U    8   8   7
+roxr       8  s     .     1110...000010...  ..........  U U U    6   6  12
+roxr      16  s     .     1110...001010...  ..........  U U U    6   6  12
+roxr      32  s     .     1110...010010...  ..........  U U U    8   8  12
+roxr       8  r     .     1110...000110...  ..........  U U U    6   6  12
+roxr      16  r     .     1110...001110...  ..........  U U U    6   6  12
+roxr      32  r     .     1110...010110...  ..........  U U U    8   8  12
+roxr      16  .     .     1110010011......  A+-DXWL...  U U U    8   8   5
+roxl       8  s     .     1110...100010...  ..........  U U U    6   6  12
+roxl      16  s     .     1110...101010...  ..........  U U U    6   6  12
+roxl      32  s     .     1110...110010...  ..........  U U U    8   8  12
+roxl       8  r     .     1110...100110...  ..........  U U U    6   6  12
+roxl      16  r     .     1110...101110...  ..........  U U U    6   6  12
+roxl      32  r     .     1110...110110...  ..........  U U U    8   8  12
+roxl      16  .     .     1110010111......  A+-DXWL...  U U U    8   8   5
+rtd       32  .     .     0100111001110100  ..........  . U U    .  16  10
+rte       32  .     .     0100111001110011  ..........  S S S   20  24  20  bus fault not emulated
+rtm       32  .     .     000001101100....  ..........  . . U    .   .  19  not properly emulated
+rtr       32  .     .     0100111001110111  ..........  U U U   20  20  14
+rts       32  .     .     0100111001110101  ..........  U U U   16  16  10
+sbcd       8  rr    .     1000...100000...  ..........  U U U    6   6   4
+sbcd       8  mm    ax7   1000111100001...  ..........  U U U   18  18  16
+sbcd       8  mm    ay7   1000...100001111  ..........  U U U   18  18  16
+sbcd       8  mm    axy7  1000111100001111  ..........  U U U   18  18  16
+sbcd       8  mm    .     1000...100001...  ..........  U U U   18  18  16
+st         8  .     d     0101000011000...  ..........  U U U    6   4   4
+st         8  .     .     0101000011......  A+-DXWL...  U U U    8   8   6
+sf         8  .     d     0101000111000...  ..........  U U U    4   4   4
+sf         8  .     .     0101000111......  A+-DXWL...  U U U    8   8   6
+scc        8  .     d     0101....11000...  ..........  U U U    4   4   4
+scc        8  .     .     0101....11......  A+-DXWL...  U U U    8   8   6
+stop       0  .     .     0100111001110010  ..........  S S S    4   4   8
+sub        8  er    d     1001...000000...  ..........  U U U    4   4   2
+sub        8  er    .     1001...000......  A+-DXWLdxI  U U U    4   4   2
+sub       16  er    d     1001...001000...  ..........  U U U    4   4   2
+sub       16  er    a     1001...001001...  ..........  U U U    4   4   2
+sub       16  er    .     1001...001......  A+-DXWLdxI  U U U    4   4   2
+sub       32  er    d     1001...010000...  ..........  U U U    6   6   2
+sub       32  er    a     1001...010001...  ..........  U U U    6   6   2
+sub       32  er    .     1001...010......  A+-DXWLdxI  U U U    6   6   2
+sub        8  re    .     1001...100......  A+-DXWL...  U U U    8   8   4
+sub       16  re    .     1001...101......  A+-DXWL...  U U U    8   8   4
+sub       32  re    .     1001...110......  A+-DXWL...  U U U   12  12   4
+suba      16  .     d     1001...011000...  ..........  U U U    8   8   2
+suba      16  .     a     1001...011001...  ..........  U U U    8   8   2
+suba      16  .     .     1001...011......  A+-DXWLdxI  U U U    8   8   2
+suba      32  .     d     1001...111000...  ..........  U U U    6   6   2
+suba      32  .     a     1001...111001...  ..........  U U U    6   6   2
+suba      32  .     .     1001...111......  A+-DXWLdxI  U U U    6   6   2
+subi       8  .     d     0000010000000...  ..........  U U U    8   8   2
+subi       8  .     .     0000010000......  A+-DXWL...  U U U   12  12   4
+subi      16  .     d     0000010001000...  ..........  U U U    8   8   2
+subi      16  .     .     0000010001......  A+-DXWL...  U U U   12  12   4
+subi      32  .     d     0000010010000...  ..........  U U U   16  14   2
+subi      32  .     .     0000010010......  A+-DXWL...  U U U   20  20   4
+subq       8  .     d     0101...100000...  ..........  U U U    4   4   2
+subq       8  .     .     0101...100......  A+-DXWL...  U U U    8   8   4
+subq      16  .     d     0101...101000...  ..........  U U U    4   4   2
+subq      16  .     a     0101...101001...  ..........  U U U    8   4   2
+subq      16  .     .     0101...101......  A+-DXWL...  U U U    8   8   4
+subq      32  .     d     0101...110000...  ..........  U U U    8   8   2
+subq      32  .     a     0101...110001...  ..........  U U U    8   8   2
+subq      32  .     .     0101...110......  A+-DXWL...  U U U   12  12   4
+subx       8  rr    .     1001...100000...  ..........  U U U    4   4   2
+subx      16  rr    .     1001...101000...  ..........  U U U    4   4   2
+subx      32  rr    .     1001...110000...  ..........  U U U    8   6   2
+subx       8  mm    ax7   1001111100001...  ..........  U U U   18  18  12
+subx       8  mm    ay7   1001...100001111  ..........  U U U   18  18  12
+subx       8  mm    axy7  1001111100001111  ..........  U U U   18  18  12
+subx       8  mm    .     1001...100001...  ..........  U U U   18  18  12
+subx      16  mm    .     1001...101001...  ..........  U U U   18  18  12
+subx      32  mm    .     1001...110001...  ..........  U U U   30  30  12
+swap      32  .     .     0100100001000...  ..........  U U U    4   4   4
+tas        8  .     d     0100101011000...  ..........  U U U    4   4   4
+tas        8  .     .     0100101011......  A+-DXWL...  U U U   14  14  12
+trap       0  .     .     010011100100....  ..........  U U U    4   4   4
+trapt      0  .     .     0101000011111100  ..........  . . U    .   .   4
+trapt     16  .     .     0101000011111010  ..........  . . U    .   .   6
+trapt     32  .     .     0101000011111011  ..........  . . U    .   .   8
+trapf      0  .     .     0101000111111100  ..........  . . U    .   .   4
+trapf     16  .     .     0101000111111010  ..........  . . U    .   .   6
+trapf     32  .     .     0101000111111011  ..........  . . U    .   .   8
+trapcc     0  .     .     0101....11111100  ..........  . . U    .   .   4
+trapcc    16  .     .     0101....11111010  ..........  . . U    .   .   6
+trapcc    32  .     .     0101....11111011  ..........  . . U    .   .   8
+trapv      0  .     .     0100111001110110  ..........  U U U    4   4   4
+tst        8  .     d     0100101000000...  ..........  U U U    4   4   2
+tst        8  .     .     0100101000......  A+-DXWL...  U U U    4   4   2
+tst        8  .     pcdi  0100101000111010  ..........  . . U    .   .   7
+tst        8  .     pcix  0100101000111011  ..........  . . U    .   .   9
+tst        8  .     i     0100101000111100  ..........  . . U    .   .   6
+tst       16  .     d     0100101001000...  ..........  U U U    4   4   2
+tst       16  .     a     0100101001001...  ..........  . . U    .   .   2
+tst       16  .     .     0100101001......  A+-DXWL...  U U U    4   4   2
+tst       16  .     pcdi  0100101001111010  ..........  . . U    .   .   7
+tst       16  .     pcix  0100101001111011  ..........  . . U    .   .   9
+tst       16  .     i     0100101001111100  ..........  . . U    .   .   6
+tst       32  .     d     0100101010000...  ..........  U U U    4   4   2
+tst       32  .     a     0100101010001...  ..........  . . U    .   .   2
+tst       32  .     .     0100101010......  A+-DXWL...  U U U    4   4   2
+tst       32  .     pcdi  0100101010111010  ..........  . . U    .   .   7
+tst       32  .     pcix  0100101010111011  ..........  . . U    .   .   9
+tst       32  .     i     0100101010111100  ..........  . . U    .   .   6
+unlk      32  .     a7    0100111001011111  ..........  U U U   12  12   6
+unlk      32  .     .     0100111001011...  ..........  U U U   12  12   6
+unpk      16  rr    .     1000...110000...  ..........  . . U    .   .   8
+unpk      16  mm    ax7   1000111110001...  ..........  . . U    .   .  13
+unpk      16  mm    ay7   1000...110001111  ..........  . . U    .   .  13
+unpk      16  mm    axy7  1000111110001111  ..........  . . U    .   .  13
+unpk      16  mm    .     1000...110001...  ..........  . . U    .   .  13
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_OPCODE_HANDLER_BODY
+
+M68KMAKE_OP(1010, 0, ., .)
+{
+	m68ki_exception_1010();
+}
+
+
+M68KMAKE_OP(1111, 0, ., .)
+{
+	m68ki_exception_1111();
+}
+
+
+M68KMAKE_OP(abcd, 8, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = DY;
+	uint dst = *r_dst;
+	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res += 6;
+	res += HIGH_NIBBLE(src) + HIGH_NIBBLE(dst);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res -= 0xa0;
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(abcd, 8, mm, ax7)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res += 6;
+	res += HIGH_NIBBLE(src) + HIGH_NIBBLE(dst);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res -= 0xa0;
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(abcd, 8, mm, ay7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res += 6;
+	res += HIGH_NIBBLE(src) + HIGH_NIBBLE(dst);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res -= 0xa0;
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(abcd, 8, mm, axy7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res += 6;
+	res += HIGH_NIBBLE(src) + HIGH_NIBBLE(dst);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res -= 0xa0;
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(abcd, 8, mm, .)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(src) + LOW_NIBBLE(dst) + XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res += 6;
+	res += HIGH_NIBBLE(src) + HIGH_NIBBLE(dst);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res -= 0xa0;
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(add, 8, er, d)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_8(DY);
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 8, er, .)
+{
+	uint* r_dst = &DX;
+	uint src = M68KMAKE_GET_OPER_AY_8;
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 16, er, d)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_16(DY);
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 16, er, a)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_16(AY);
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 16, er, .)
+{
+	uint* r_dst = &DX;
+	uint src = M68KMAKE_GET_OPER_AY_16;
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 32, er, d)
+{
+	uint* r_dst = &DX;
+	uint src = DY;
+	uint dst = *r_dst;
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 32, er, a)
+{
+	uint* r_dst = &DX;
+	uint src = AY;
+	uint dst = *r_dst;
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 32, er, .)
+{
+	uint* r_dst = &DX;
+	uint src = M68KMAKE_GET_OPER_AY_32;
+	uint dst = *r_dst;
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(add, 8, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = MASK_OUT_ABOVE_8(DX);
+	uint dst = m68ki_read_8(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(add, 16, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = MASK_OUT_ABOVE_16(DX);
+	uint dst = m68ki_read_16(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(add, 32, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint src = DX;
+	uint dst = m68ki_read_32(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	m68ki_write_32(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(adda, 16, ., d)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + MAKE_INT_16(DY));
+}
+
+
+M68KMAKE_OP(adda, 16, ., a)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + MAKE_INT_16(AY));
+}
+
+
+M68KMAKE_OP(adda, 16, ., .)
+{
+	signed short src = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + src);
+}
+
+
+M68KMAKE_OP(adda, 32, ., d)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + DY);
+}
+
+
+M68KMAKE_OP(adda, 32, ., a)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + AY);
+}
+
+
+M68KMAKE_OP(adda, 32, ., .)
+{
+	uint src = M68KMAKE_GET_OPER_AY_32;
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + src);
+}
+
+
+M68KMAKE_OP(addi, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = OPER_I_8();
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(addi, 8, ., .)
+{
+	uint src = OPER_I_8();
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint dst = m68ki_read_8(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(addi, 16, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = OPER_I_16();
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(addi, 16, ., .)
+{
+	uint src = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint dst = m68ki_read_16(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(addi, 32, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = OPER_I_32();
+	uint dst = *r_dst;
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(addi, 32, ., .)
+{
+	uint src = OPER_I_32();
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint dst = m68ki_read_32(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	m68ki_write_32(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(addq, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(addq, 8, ., .)
+{
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint dst = m68ki_read_8(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(addq, 16, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(addq, 16, ., a)
+{
+	uint* r_dst = &AY;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + (((REG_IR >> 9) - 1) & 7) + 1);
+}
+
+
+M68KMAKE_OP(addq, 16, ., .)
+{
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint dst = m68ki_read_16(ea);
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(addq, 32, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint dst = *r_dst;
+	uint res = src + dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(addq, 32, ., a)
+{
+	uint* r_dst = &AY;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + (((REG_IR >> 9) - 1) & 7) + 1);
+}
+
+
+M68KMAKE_OP(addq, 32, ., .)
+{
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint dst = m68ki_read_32(ea);
+	uint res = src + dst;
+
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	m68ki_write_32(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(addx, 8, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_8(DY);
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(addx, 16, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_16(DY);
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+
+	res = MASK_OUT_ABOVE_16(res);
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(addx, 32, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = DY;
+	uint dst = *r_dst;
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+
+	res = MASK_OUT_ABOVE_32(res);
+	FLAG_Z |= res;
+
+	*r_dst = res;
+}
+
+
+M68KMAKE_OP(addx, 8, mm, ax7)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(addx, 8, mm, ay7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(addx, 8, mm, axy7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(addx, 8, mm, .)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_V = VFLAG_ADD_8(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(addx, 16, mm, .)
+{
+	uint src = OPER_AY_PD_16();
+	uint ea  = EA_AX_PD_16();
+	uint dst = m68ki_read_16(ea);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_V = VFLAG_ADD_16(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+
+	res = MASK_OUT_ABOVE_16(res);
+	FLAG_Z |= res;
+
+	m68ki_write_16(ea, res);
+}
+
+
+M68KMAKE_OP(addx, 32, mm, .)
+{
+	uint src = OPER_AY_PD_32();
+	uint ea  = EA_AX_PD_32();
+	uint dst = m68ki_read_32(ea);
+	uint res = src + dst + XFLAG_AS_1();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_ADD_32(src, dst, res);
+	FLAG_X = FLAG_C = CFLAG_ADD_32(src, dst, res);
+
+	res = MASK_OUT_ABOVE_32(res);
+	FLAG_Z |= res;
+
+	m68ki_write_32(ea, res);
+}
+
+
+M68KMAKE_OP(and, 8, er, d)
+{
+	FLAG_Z = MASK_OUT_ABOVE_8(DX &= (DY | 0xffffff00));
+
+	FLAG_N = NFLAG_8(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(and, 8, er, .)
+{
+	FLAG_Z = MASK_OUT_ABOVE_8(DX &= (M68KMAKE_GET_OPER_AY_8 | 0xffffff00));
+
+	FLAG_N = NFLAG_8(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(and, 16, er, d)
+{
+	FLAG_Z = MASK_OUT_ABOVE_16(DX &= (DY | 0xffff0000));
+
+	FLAG_N = NFLAG_16(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(and, 16, er, .)
+{
+	FLAG_Z = MASK_OUT_ABOVE_16(DX &= (M68KMAKE_GET_OPER_AY_16 | 0xffff0000));
+
+	FLAG_N = NFLAG_16(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(and, 32, er, d)
+{
+	FLAG_Z = DX &= DY;
+
+	FLAG_N = NFLAG_32(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(and, 32, er, .)
+{
+	FLAG_Z = DX &= M68KMAKE_GET_OPER_AY_32;
+
+	FLAG_N = NFLAG_32(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(and, 8, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint res = DX & m68ki_read_8(ea);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(and, 16, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint res = DX & m68ki_read_16(ea);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(and, 32, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint res = DX & m68ki_read_32(ea);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+
+	m68ki_write_32(ea, res);
+}
+
+
+M68KMAKE_OP(andi, 8, ., d)
+{
+	FLAG_Z = MASK_OUT_ABOVE_8(DY &= (OPER_I_8() | 0xffffff00));
+
+	FLAG_N = NFLAG_8(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(andi, 8, ., .)
+{
+	uint src = OPER_I_8();
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint res = src & m68ki_read_8(ea);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(andi, 16, ., d)
+{
+	FLAG_Z = MASK_OUT_ABOVE_16(DY &= (OPER_I_16() | 0xffff0000));
+
+	FLAG_N = NFLAG_16(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(andi, 16, ., .)
+{
+	uint src = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint res = src & m68ki_read_16(ea);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+
+	m68ki_write_16(ea, res);
+}
+
+
+M68KMAKE_OP(andi, 32, ., d)
+{
+	FLAG_Z = DY &= (OPER_I_32());
+
+	FLAG_N = NFLAG_32(FLAG_Z);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(andi, 32, ., .)
+{
+	uint src = OPER_I_32();
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint res = src & m68ki_read_32(ea);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+
+	m68ki_write_32(ea, res);
+}
+
+
+M68KMAKE_OP(andi, 16, toc, .)
+{
+	m68ki_set_ccr(m68ki_get_ccr() & OPER_I_16());
+}
+
+
+M68KMAKE_OP(andi, 16, tos, .)
+{
+	if(FLAG_S)
+	{
+		uint src = OPER_I_16();
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_set_sr(m68ki_get_sr() & src);
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(asr, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src >> shift;
+
+	if(GET_MSB_8(src))
+		res |= m68ki_shift_8_table[shift];
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_X = FLAG_C = src << (9-shift);
+}
+
+
+M68KMAKE_OP(asr, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src >> shift;
+
+	if(GET_MSB_16(src))
+		res |= m68ki_shift_16_table[shift];
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_X = FLAG_C = src << (9-shift);
+}
+
+
+M68KMAKE_OP(asr, 32, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = *r_dst;
+	uint res = src >> shift;
+
+	if(GET_MSB_32(src))
+		res |= m68ki_shift_32_table[shift];
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_X = FLAG_C = src << (9-shift);
+}
+
+
+M68KMAKE_OP(asr, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src >> shift;
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 8)
+		{
+			if(GET_MSB_8(src))
+				res |= m68ki_shift_8_table[shift];
+
+			*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+			FLAG_X = FLAG_C = src << (9-shift);
+			FLAG_N = NFLAG_8(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		if(GET_MSB_8(src))
+		{
+			*r_dst |= 0xff;
+			FLAG_C = CFLAG_SET;
+			FLAG_X = XFLAG_SET;
+			FLAG_N = NFLAG_SET;
+			FLAG_Z = ZFLAG_CLEAR;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst &= 0xffffff00;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_X = XFLAG_CLEAR;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_8(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(asr, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src >> shift;
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 16)
+		{
+			if(GET_MSB_16(src))
+				res |= m68ki_shift_16_table[shift];
+
+			*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+			FLAG_C = FLAG_X = (src >> (shift - 1))<<8;
+			FLAG_N = NFLAG_16(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		if(GET_MSB_16(src))
+		{
+			*r_dst |= 0xffff;
+			FLAG_C = CFLAG_SET;
+			FLAG_X = XFLAG_SET;
+			FLAG_N = NFLAG_SET;
+			FLAG_Z = ZFLAG_CLEAR;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst &= 0xffff0000;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_X = XFLAG_CLEAR;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_16(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(asr, 32, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = *r_dst;
+	uint res = src >> shift;
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 32)
+		{
+			if(GET_MSB_32(src))
+				res |= m68ki_shift_32_table[shift];
+
+			*r_dst = res;
+
+			FLAG_C = FLAG_X = (src >> (shift - 1))<<8;
+			FLAG_N = NFLAG_32(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		if(GET_MSB_32(src))
+		{
+			*r_dst = 0xffffffff;
+			FLAG_C = CFLAG_SET;
+			FLAG_X = XFLAG_SET;
+			FLAG_N = NFLAG_SET;
+			FLAG_Z = ZFLAG_CLEAR;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst = 0;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_X = XFLAG_CLEAR;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_32(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(asr, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = src >> 1;
+
+	if(GET_MSB_16(src))
+		res |= 0x8000;
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = FLAG_X = src << 8;
+}
+
+
+M68KMAKE_OP(asl, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = MASK_OUT_ABOVE_8(src << shift);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_X = FLAG_C = src << shift;
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	src &= m68ki_shift_8_table[shift + 1];
+	FLAG_V = (!(src == 0 || (src == m68ki_shift_8_table[shift + 1] && shift < 8)))<<7;
+}
+
+
+M68KMAKE_OP(asl, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = MASK_OUT_ABOVE_16(src << shift);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src >> (8-shift);
+	src &= m68ki_shift_16_table[shift + 1];
+	FLAG_V = (!(src == 0 || src == m68ki_shift_16_table[shift + 1]))<<7;
+}
+
+
+M68KMAKE_OP(asl, 32, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32(src << shift);
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src >> (24-shift);
+	src &= m68ki_shift_32_table[shift + 1];
+	FLAG_V = (!(src == 0 || src == m68ki_shift_32_table[shift + 1]))<<7;
+}
+
+
+M68KMAKE_OP(asl, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = MASK_OUT_ABOVE_8(src << shift);
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 8)
+		{
+			*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+			FLAG_X = FLAG_C = src << shift;
+			FLAG_N = NFLAG_8(res);
+			FLAG_Z = res;
+			src &= m68ki_shift_8_table[shift + 1];
+			FLAG_V = (!(src == 0 || src == m68ki_shift_8_table[shift + 1]))<<7;
+			return;
+		}
+
+		*r_dst &= 0xffffff00;
+		FLAG_X = FLAG_C = ((shift == 8 ? src & 1 : 0))<<8;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = (!(src == 0))<<7;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_8(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(asl, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = MASK_OUT_ABOVE_16(src << shift);
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 16)
+		{
+			*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+			FLAG_X = FLAG_C = (src << shift) >> 8;
+			FLAG_N = NFLAG_16(res);
+			FLAG_Z = res;
+			src &= m68ki_shift_16_table[shift + 1];
+			FLAG_V = (!(src == 0 || src == m68ki_shift_16_table[shift + 1]))<<7;
+			return;
+		}
+
+		*r_dst &= 0xffff0000;
+		FLAG_X = FLAG_C = ((shift == 16 ? src & 1 : 0))<<8;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = (!(src == 0))<<7;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_16(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(asl, 32, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32(src << shift);
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 32)
+		{
+			*r_dst = res;
+			FLAG_X = FLAG_C = (src >> (32 - shift)) << 8;
+			FLAG_N = NFLAG_32(res);
+			FLAG_Z = res;
+			src &= m68ki_shift_32_table[shift + 1];
+			FLAG_V = (!(src == 0 || src == m68ki_shift_32_table[shift + 1]))<<7;
+			return;
+		}
+
+		*r_dst = 0;
+		FLAG_X = FLAG_C = ((shift == 32 ? src & 1 : 0))<<8;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = (!(src == 0))<<7;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_32(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(asl, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = MASK_OUT_ABOVE_16(src << 1);
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src >> 7;
+	src &= 0xc000;
+	FLAG_V = (!(src == 0 || src == 0xc000))<<7;
+}
+
+
+M68KMAKE_OP(bcc, 8, ., .)
+{
+	if(M68KMAKE_CC)
+	{
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+		return;
+	}
+	USE_CYCLES(CYC_BCC_NOTAKE_B);
+}
+
+
+M68KMAKE_OP(bcc, 16, ., .)
+{
+	if(M68KMAKE_CC)
+	{
+		uint offset = OPER_I_16();
+		REG_PC -= 2;
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_branch_16(offset);
+		return;
+	}
+	REG_PC += 2;
+	USE_CYCLES(CYC_BCC_NOTAKE_W);
+}
+
+
+M68KMAKE_OP(bcc, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		if(M68KMAKE_CC)
+		{
+			uint offset = OPER_I_32();
+			REG_PC -= 4;
+			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+			m68ki_branch_32(offset);
+			return;
+		}
+		REG_PC += 4;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bchg, 32, r, d)
+{
+	uint* r_dst = &DY;
+	uint mask = 1 << (DX & 0x1f);
+
+	FLAG_Z = *r_dst & mask;
+	*r_dst ^= mask;
+}
+
+
+M68KMAKE_OP(bchg, 8, r, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+	uint mask = 1 << (DX & 7);
+
+	FLAG_Z = src & mask;
+	m68ki_write_8(ea, src ^ mask);
+}
+
+
+M68KMAKE_OP(bchg, 32, s, d)
+{
+	uint* r_dst = &DY;
+	uint mask = 1 << (OPER_I_8() & 0x1f);
+
+	FLAG_Z = *r_dst & mask;
+	*r_dst ^= mask;
+}
+
+
+M68KMAKE_OP(bchg, 8, s, .)
+{
+	uint mask = 1 << (OPER_I_8() & 7);
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+
+	FLAG_Z = src & mask;
+	m68ki_write_8(ea, src ^ mask);
+}
+
+
+M68KMAKE_OP(bclr, 32, r, d)
+{
+	uint* r_dst = &DY;
+	uint mask = 1 << (DX & 0x1f);
+
+	FLAG_Z = *r_dst & mask;
+	*r_dst &= ~mask;
+}
+
+
+M68KMAKE_OP(bclr, 8, r, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+	uint mask = 1 << (DX & 7);
+
+	FLAG_Z = src & mask;
+	m68ki_write_8(ea, src & ~mask);
+}
+
+
+M68KMAKE_OP(bclr, 32, s, d)
+{
+	uint* r_dst = &DY;
+	uint mask = 1 << (OPER_I_8() & 0x1f);
+
+	FLAG_Z = *r_dst & mask;
+	*r_dst &= ~mask;
+}
+
+
+M68KMAKE_OP(bclr, 8, s, .)
+{
+	uint mask = 1 << (OPER_I_8() & 7);
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+
+	FLAG_Z = src & mask;
+	m68ki_write_8(ea, src & ~mask);
+}
+
+
+M68KMAKE_OP(bfchg, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint* data = &DY;
+		uint64 mask;
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+		mask = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask = ROR_32(mask, offset);
+
+		FLAG_N = NFLAG_32(*data<<offset);
+		FLAG_Z = *data & mask;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		*data ^= mask;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfchg, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		uint width = word2;
+		uint mask_base;
+		uint data_long;
+		uint mask_long;
+		uint data_byte = 0;
+		uint mask_byte = 0;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+
+		if(BIT_B(word2))
+			offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		offset %= 8;
+		if(offset < 0)
+		{
+			offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask_long = mask_base >> offset;
+
+		data_long = m68ki_read_32(ea);
+		FLAG_N = NFLAG_32(data_long << offset);
+		FLAG_Z = data_long & mask_long;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		m68ki_write_32(ea, data_long ^ mask_long);
+
+		if((width + offset) > 32)
+		{
+			mask_byte = MASK_OUT_ABOVE_8(mask_base);
+			data_byte = m68ki_read_8(ea+4);
+			FLAG_Z |= (data_byte & mask_byte);
+			m68ki_write_8(ea+4, data_byte ^ mask_byte);
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfclr, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint* data = &DY;
+		uint64 mask;
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+
+		mask = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask = ROR_32(mask, offset);
+
+		FLAG_N = NFLAG_32(*data<<offset);
+		FLAG_Z = *data & mask;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		*data &= ~mask;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfclr, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		uint width = word2;
+		uint mask_base;
+		uint data_long;
+		uint mask_long;
+		uint data_byte = 0;
+		uint mask_byte = 0;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+
+		if(BIT_B(word2))
+			offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		offset %= 8;
+		if(offset < 0)
+		{
+			offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask_long = mask_base >> offset;
+
+		data_long = m68ki_read_32(ea);
+		FLAG_N = NFLAG_32(data_long << offset);
+		FLAG_Z = data_long & mask_long;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		m68ki_write_32(ea, data_long & ~mask_long);
+
+		if((width + offset) > 32)
+		{
+			mask_byte = MASK_OUT_ABOVE_8(mask_base);
+			data_byte = m68ki_read_8(ea+4);
+			FLAG_Z |= (data_byte & mask_byte);
+			m68ki_write_8(ea+4, data_byte & ~mask_byte);
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfexts, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint64 data = DY;
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+		data = ROL_32(data, offset);
+		FLAG_N = NFLAG_32(data);
+		data = MAKE_INT_32(data) >> (32 - width);
+
+		FLAG_Z = data;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		REG_D[(word2>>12)&7] = data;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfexts, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		uint width = word2;
+		uint data;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+
+		if(BIT_B(word2))
+			offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		offset %= 8;
+		if(offset < 0)
+		{
+			offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+		data = m68ki_read_32(ea);
+
+		data = MASK_OUT_ABOVE_32(data<<offset);
+
+		if((offset+width) > 32)
+			data |= (m68ki_read_8(ea+4) << offset) >> 8;
+
+		FLAG_N = NFLAG_32(data);
+		data  = MAKE_INT_32(data) >> (32 - width);
+
+		FLAG_Z = data;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		REG_D[(word2 >> 12) & 7] = data;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfextu, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint64 data = DY;
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+		data = ROL_32(data, offset);
+		FLAG_N = NFLAG_32(data);
+		data >>= 32 - width;
+
+		FLAG_Z = data;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		REG_D[(word2>>12)&7] = data;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfextu, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		uint width = word2;
+		uint data;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+
+		if(BIT_B(word2))
+		offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		offset %= 8;
+		if(offset < 0)
+		{
+			offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+		data = m68ki_read_32(ea);
+		data = MASK_OUT_ABOVE_32(data<<offset);
+
+		if((offset+width) > 32)
+			data |= (m68ki_read_8(ea+4) << offset) >> 8;
+
+		FLAG_N = NFLAG_32(data);
+		data  >>= (32 - width);
+
+		FLAG_Z = data;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		REG_D[(word2 >> 12) & 7] = data;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfffo, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint64 data = DY;
+		uint bit;
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+		data = ROL_32(data, offset);
+		FLAG_N = NFLAG_32(data);
+		data >>= 32 - width;
+
+		FLAG_Z = data;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		for(bit = 1<<(width-1);bit && !(data & bit);bit>>= 1)
+			offset++;
+
+		REG_D[(word2>>12)&7] = offset;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfffo, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		sint local_offset;
+		uint width = word2;
+		uint data;
+		uint bit;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+
+		if(BIT_B(word2))
+			offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		local_offset = offset % 8;
+		if(local_offset < 0)
+		{
+			local_offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+		data = m68ki_read_32(ea);
+		data = MASK_OUT_ABOVE_32(data<<local_offset);
+
+		if((local_offset+width) > 32)
+			data |= (m68ki_read_8(ea+4) << local_offset) >> 8;
+
+		FLAG_N = NFLAG_32(data);
+		data  >>= (32 - width);
+
+		FLAG_Z = data;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		for(bit = 1<<(width-1);bit && !(data & bit);bit>>= 1)
+			offset++;
+
+		REG_D[(word2>>12)&7] = offset;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfins, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint* data = &DY;
+		uint64 mask;
+		uint64 insert = REG_D[(word2>>12)&7];
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+
+		mask = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask = ROR_32(mask, offset);
+
+		insert = MASK_OUT_ABOVE_32(insert << (32 - width));
+		FLAG_N = NFLAG_32(insert);
+		FLAG_Z = insert;
+		insert = ROR_32(insert, offset);
+
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		*data &= ~mask;
+		*data |= insert;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfins, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		uint width = word2;
+		uint insert_base = REG_D[(word2>>12)&7];
+		uint insert_long;
+		uint insert_byte;
+		uint mask_base;
+		uint data_long;
+		uint mask_long;
+		uint data_byte = 0;
+		uint mask_byte = 0;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+
+		if(BIT_B(word2))
+			offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		offset %= 8;
+		if(offset < 0)
+		{
+			offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask_long = mask_base >> offset;
+
+		insert_base = MASK_OUT_ABOVE_32(insert_base << (32 - width));
+		FLAG_N = NFLAG_32(insert_base);
+		FLAG_Z = insert_base;
+		insert_long = insert_base >> offset;
+
+		data_long = m68ki_read_32(ea);
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		m68ki_write_32(ea, (data_long & ~mask_long) | insert_long);
+
+		if((width + offset) > 32)
+		{
+			mask_byte = MASK_OUT_ABOVE_8(mask_base);
+			insert_byte = MASK_OUT_ABOVE_8(insert_base);
+			data_byte = m68ki_read_8(ea+4);
+			FLAG_Z |= (data_byte & mask_byte);
+			m68ki_write_8(ea+4, (data_byte & ~mask_byte) | insert_byte);
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfset, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint* data = &DY;
+		uint64 mask;
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+
+		mask = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask = ROR_32(mask, offset);
+
+		FLAG_N = NFLAG_32(*data<<offset);
+		FLAG_Z = *data & mask;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		*data |= mask;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bfset, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		uint width = word2;
+		uint mask_base;
+		uint data_long;
+		uint mask_long;
+		uint data_byte = 0;
+		uint mask_byte = 0;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+
+		if(BIT_B(word2))
+			offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		offset %= 8;
+		if(offset < 0)
+		{
+			offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+
+		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask_long = mask_base >> offset;
+
+		data_long = m68ki_read_32(ea);
+		FLAG_N = NFLAG_32(data_long << offset);
+		FLAG_Z = data_long & mask_long;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		m68ki_write_32(ea, data_long | mask_long);
+
+		if((width + offset) > 32)
+		{
+			mask_byte = MASK_OUT_ABOVE_8(mask_base);
+			data_byte = m68ki_read_8(ea+4);
+			FLAG_Z |= (data_byte & mask_byte);
+			m68ki_write_8(ea+4, data_byte | mask_byte);
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bftst, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint offset = (word2>>6)&31;
+		uint width = word2;
+		uint* data = &DY;
+		uint64 mask;
+
+
+		if(BIT_B(word2))
+			offset = REG_D[offset&7];
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+
+		offset &= 31;
+		width = ((width-1) & 31) + 1;
+
+
+		mask = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask = ROR_32(mask, offset);
+
+		FLAG_N = NFLAG_32(*data<<offset);
+		FLAG_Z = *data & mask;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bftst, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		sint offset = (word2>>6)&31;
+		uint width = word2;
+		uint mask_base;
+		uint data_long;
+		uint mask_long;
+		uint data_byte = 0;
+		uint mask_byte = 0;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+
+		if(BIT_B(word2))
+			offset = MAKE_INT_32(REG_D[offset&7]);
+		if(BIT_5(word2))
+			width = REG_D[width&7];
+
+		/* Offset is signed so we have to use ugly math =( */
+		ea += offset / 8;
+		offset %= 8;
+		if(offset < 0)
+		{
+			offset += 8;
+			ea--;
+		}
+		width = ((width-1) & 31) + 1;
+
+
+		mask_base = MASK_OUT_ABOVE_32(0xffffffff << (32 - width));
+		mask_long = mask_base >> offset;
+
+		data_long = m68ki_read_32(ea);
+		FLAG_N = ((data_long & (0x80000000 >> offset))<<offset)>>24;
+		FLAG_Z = data_long & mask_long;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+
+		if((width + offset) > 32)
+		{
+			mask_byte = MASK_OUT_ABOVE_8(mask_base);
+			data_byte = m68ki_read_8(ea+4);
+			FLAG_Z |= (data_byte & mask_byte);
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bkpt, 0, ., .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		m68ki_bkpt_ack(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE) ? REG_IR & 7 : 0);	/* auto-disable (see m68kcpu.h) */
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bra, 8, ., .)
+{
+	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
+	m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+	if(REG_PC == REG_PPC)
+		USE_ALL_CYCLES();
+}
+
+
+M68KMAKE_OP(bra, 16, ., .)
+{
+	uint offset = OPER_I_16();
+	REG_PC -= 2;
+	m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+	m68ki_branch_16(offset);
+	if(REG_PC == REG_PPC)
+		USE_ALL_CYCLES();
+}
+
+
+M68KMAKE_OP(bra, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint offset = OPER_I_32();
+		REG_PC -= 4;
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_branch_32(offset);
+		if(REG_PC == REG_PPC)
+			USE_ALL_CYCLES();
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(bset, 32, r, d)
+{
+	uint* r_dst = &DY;
+	uint mask = 1 << (DX & 0x1f);
+
+	FLAG_Z = *r_dst & mask;
+	*r_dst |= mask;
+}
+
+
+M68KMAKE_OP(bset, 8, r, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+	uint mask = 1 << (DX & 7);
+
+	FLAG_Z = src & mask;
+	m68ki_write_8(ea, src | mask);
+}
+
+
+M68KMAKE_OP(bset, 32, s, d)
+{
+	uint* r_dst = &DY;
+	uint mask = 1 << (OPER_I_8() & 0x1f);
+
+	FLAG_Z = *r_dst & mask;
+	*r_dst |= mask;
+}
+
+
+M68KMAKE_OP(bset, 8, s, .)
+{
+	uint mask = 1 << (OPER_I_8() & 7);
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+
+	FLAG_Z = src & mask;
+	m68ki_write_8(ea, src | mask);
+}
+
+
+M68KMAKE_OP(bsr, 8, ., .)
+{
+	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
+	m68ki_push_32(REG_PC);
+	m68ki_branch_8(MASK_OUT_ABOVE_8(REG_IR));
+}
+
+
+M68KMAKE_OP(bsr, 16, ., .)
+{
+	uint offset = OPER_I_16();
+	m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+	m68ki_push_32(REG_PC);
+	REG_PC -= 2;
+	m68ki_branch_16(offset);
+}
+
+
+M68KMAKE_OP(bsr, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint offset = OPER_I_32();
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_push_32(REG_PC);
+		REG_PC -= 4;
+		m68ki_branch_32(offset);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(btst, 32, r, d)
+{
+	FLAG_Z = DY & (1 << (DX & 0x1f));
+}
+
+
+M68KMAKE_OP(btst, 8, r, .)
+{
+	FLAG_Z = M68KMAKE_GET_OPER_AY_8 & (1 << (DX & 7));
+}
+
+
+M68KMAKE_OP(btst, 32, s, d)
+{
+	FLAG_Z = DY & (1 << (OPER_I_8() & 0x1f));
+}
+
+
+M68KMAKE_OP(btst, 8, s, .)
+{
+	uint bit = OPER_I_8() & 7;
+
+	FLAG_Z = M68KMAKE_GET_OPER_AY_8 & (1 << bit);
+}
+
+
+M68KMAKE_OP(callm, 32, ., .)
+{
+	/* note: watch out for pcrelative modes */
+	if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+	{
+		uint ea = M68KMAKE_GET_EA_AY_32;
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		REG_PC += 2;
+(void)ea;	/* just to avoid an 'unused variable' warning */
+		M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: called unimplemented instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
+					 m68k_disassemble_quick(ADDRESS_68K(REG_PC - 2))));
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cas, 8, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint ea = M68KMAKE_GET_EA_AY_8;
+		uint dest = m68ki_read_8(ea);
+		uint* compare = &REG_D[word2 & 7];
+		uint res = dest - MASK_OUT_ABOVE_8(*compare);
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = MASK_OUT_ABOVE_8(res);
+		FLAG_V = VFLAG_SUB_8(*compare, dest, res);
+		FLAG_C = CFLAG_8(res);
+
+		if(COND_NE())
+			*compare = MASK_OUT_BELOW_8(*compare) | dest;
+		else
+		{
+			USE_CYCLES(3);
+			m68ki_write_8(ea, MASK_OUT_ABOVE_8(REG_D[(word2 >> 6) & 7]));
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cas, 16, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint ea = M68KMAKE_GET_EA_AY_16;
+		uint dest = m68ki_read_16(ea);
+		uint* compare = &REG_D[word2 & 7];
+		uint res = dest - MASK_OUT_ABOVE_16(*compare);
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = MASK_OUT_ABOVE_16(res);
+		FLAG_V = VFLAG_SUB_16(*compare, dest, res);
+		FLAG_C = CFLAG_16(res);
+
+		if(COND_NE())
+			*compare = MASK_OUT_BELOW_16(*compare) | dest;
+		else
+		{
+			USE_CYCLES(3);
+			m68ki_write_16(ea, MASK_OUT_ABOVE_16(REG_D[(word2 >> 6) & 7]));
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cas, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint ea = M68KMAKE_GET_EA_AY_32;
+		uint dest = m68ki_read_32(ea);
+		uint* compare = &REG_D[word2 & 7];
+		uint res = dest - *compare;
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = MASK_OUT_ABOVE_32(res);
+		FLAG_V = VFLAG_SUB_32(*compare, dest, res);
+		FLAG_C = CFLAG_SUB_32(*compare, dest, res);
+
+		if(COND_NE())
+			*compare = dest;
+		else
+		{
+			USE_CYCLES(3);
+			m68ki_write_32(ea, REG_D[(word2 >> 6) & 7]);
+		}
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cas2, 16, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_32();
+		uint* compare1 = &REG_D[(word2 >> 16) & 7];
+		uint ea1 = REG_DA[(word2 >> 28) & 15];
+		uint dest1 = m68ki_read_16(ea1);
+		uint res1 = dest1 - MASK_OUT_ABOVE_16(*compare1);
+		uint* compare2 = &REG_D[word2 & 7];
+		uint ea2 = REG_DA[(word2 >> 12) & 15];
+		uint dest2 = m68ki_read_16(ea2);
+		uint res2;
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		FLAG_N = NFLAG_16(res1);
+		FLAG_Z = MASK_OUT_ABOVE_16(res1);
+		FLAG_V = VFLAG_SUB_16(*compare1, dest1, res1);
+		FLAG_C = CFLAG_16(res1);
+
+		if(COND_EQ())
+		{
+			res2 = dest2 - MASK_OUT_ABOVE_16(*compare2);
+
+			FLAG_N = NFLAG_16(res2);
+			FLAG_Z = MASK_OUT_ABOVE_16(res2);
+			FLAG_V = VFLAG_SUB_16(*compare2, dest2, res2);
+			FLAG_C = CFLAG_16(res2);
+
+			if(COND_EQ())
+			{
+				USE_CYCLES(3);
+				m68ki_write_16(ea1, REG_D[(word2 >> 22) & 7]);
+				m68ki_write_16(ea2, REG_D[(word2 >> 6) & 7]);
+				return;
+			}
+		}
+		*compare1 = BIT_1F(word2) ? MAKE_INT_16(dest1) : MASK_OUT_BELOW_16(*compare1) | dest1;
+		*compare2 = BIT_F(word2) ? MAKE_INT_16(dest2) : MASK_OUT_BELOW_16(*compare2) | dest2;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cas2, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_32();
+		uint* compare1 = &REG_D[(word2 >> 16) & 7];
+		uint ea1 = REG_DA[(word2 >> 28) & 15];
+		uint dest1 = m68ki_read_32(ea1);
+		uint res1 = dest1 - *compare1;
+		uint* compare2 = &REG_D[word2 & 7];
+		uint ea2 = REG_DA[(word2 >> 12) & 15];
+		uint dest2 = m68ki_read_32(ea2);
+		uint res2;
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		FLAG_N = NFLAG_32(res1);
+		FLAG_Z = MASK_OUT_ABOVE_32(res1);
+		FLAG_V = VFLAG_SUB_32(*compare1, dest1, res1);
+		FLAG_C = CFLAG_SUB_32(*compare1, dest1, res1);
+
+		if(COND_EQ())
+		{
+			res2 = dest2 - *compare2;
+
+			FLAG_N = NFLAG_32(res2);
+			FLAG_Z = MASK_OUT_ABOVE_32(res2);
+			FLAG_V = VFLAG_SUB_32(*compare2, dest2, res2);
+			FLAG_C = CFLAG_SUB_32(*compare2, dest2, res2);
+
+			if(COND_EQ())
+			{
+				USE_CYCLES(3);
+				m68ki_write_32(ea1, REG_D[(word2 >> 22) & 7]);
+				m68ki_write_32(ea2, REG_D[(word2 >> 6) & 7]);
+				return;
+			}
+		}
+		*compare1 = dest1;
+		*compare2 = dest2;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk, 16, ., d)
+{
+	sint src = MAKE_INT_16(DX);
+	sint bound = MAKE_INT_16(DY);
+
+	FLAG_Z = ZFLAG_16(src); /* Undocumented */
+	FLAG_V = VFLAG_CLEAR;   /* Undocumented */
+	FLAG_C = CFLAG_CLEAR;   /* Undocumented */
+
+	if(src >= 0 && src <= bound)
+	{
+		return;
+	}
+	FLAG_N = (src < 0)<<7;
+	m68ki_exception_trap(EXCEPTION_CHK);
+}
+
+
+M68KMAKE_OP(chk, 16, ., .)
+{
+	sint src = MAKE_INT_16(DX);
+	sint bound = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
+
+	FLAG_Z = ZFLAG_16(src); /* Undocumented */
+	FLAG_V = VFLAG_CLEAR;   /* Undocumented */
+	FLAG_C = CFLAG_CLEAR;   /* Undocumented */
+
+	if(src >= 0 && src <= bound)
+	{
+		return;
+	}
+	FLAG_N = (src < 0)<<7;
+	m68ki_exception_trap(EXCEPTION_CHK);
+}
+
+
+M68KMAKE_OP(chk, 32, ., d)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		sint src = MAKE_INT_32(DX);
+		sint bound = MAKE_INT_32(DY);
+
+		FLAG_Z = ZFLAG_32(src); /* Undocumented */
+		FLAG_V = VFLAG_CLEAR;   /* Undocumented */
+		FLAG_C = CFLAG_CLEAR;   /* Undocumented */
+
+		if(src >= 0 && src <= bound)
+		{
+			return;
+		}
+		FLAG_N = (src < 0)<<7;
+		m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		sint src = MAKE_INT_32(DX);
+		sint bound = MAKE_INT_32(M68KMAKE_GET_OPER_AY_32);
+
+		FLAG_Z = ZFLAG_32(src); /* Undocumented */
+		FLAG_V = VFLAG_CLEAR;   /* Undocumented */
+		FLAG_C = CFLAG_CLEAR;   /* Undocumented */
+
+		if(src >= 0 && src <= bound)
+		{
+			return;
+		}
+		FLAG_N = (src < 0)<<7;
+		m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 8, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15]&0xff;
+		uint ea = EA_PCDI_8();
+		uint lower_bound = m68ki_read_pcrel_8(ea);
+		uint upper_bound = m68ki_read_pcrel_8(ea + 1);
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_8(compare) - MAKE_INT_8(lower_bound);
+		else
+			FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		FLAG_C = upper_bound - compare;
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 8, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15]&0xff;
+		uint ea = EA_PCIX_8();
+		uint lower_bound = m68ki_read_pcrel_8(ea);
+		uint upper_bound = m68ki_read_pcrel_8(ea + 1);
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_8(compare) - MAKE_INT_8(lower_bound);
+		else
+			FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		FLAG_C = upper_bound - compare;
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 8, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15]&0xff;
+		uint ea = M68KMAKE_GET_EA_AY_8;
+		uint lower_bound = m68ki_read_8(ea);
+		uint upper_bound = m68ki_read_8(ea + 1);
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_8(compare) - MAKE_INT_8(lower_bound);
+		else
+			FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		FLAG_C = upper_bound - compare;
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 16, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15]&0xffff;
+		uint ea = EA_PCDI_16();
+		uint lower_bound = m68ki_read_pcrel_16(ea);
+		uint upper_bound = m68ki_read_pcrel_16(ea + 2);
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_16(compare) - MAKE_INT_16(lower_bound);
+		else
+			FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		FLAG_C = CFLAG_16(FLAG_C);
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_16(upper_bound) - MAKE_INT_16(compare);
+		else
+			FLAG_C = upper_bound - compare;
+		FLAG_C = CFLAG_16(FLAG_C);
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 16, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15]&0xffff;
+		uint ea = EA_PCIX_16();
+		uint lower_bound = m68ki_read_pcrel_16(ea);
+		uint upper_bound = m68ki_read_pcrel_16(ea + 2);
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_16(compare) - MAKE_INT_16(lower_bound);
+		else
+			FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		FLAG_C = CFLAG_16(FLAG_C);
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_16(upper_bound) - MAKE_INT_16(compare);
+		else
+			FLAG_C = upper_bound - compare;
+		FLAG_C = CFLAG_16(FLAG_C);
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 16, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15]&0xffff;
+		uint ea = M68KMAKE_GET_EA_AY_16;
+		uint lower_bound = m68ki_read_16(ea);
+		uint upper_bound = m68ki_read_16(ea + 2);
+
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_16(compare) - MAKE_INT_16(lower_bound);
+		else
+			FLAG_C = compare - lower_bound;
+
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		FLAG_C = CFLAG_16(FLAG_C);
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+		if(!BIT_F(word2))
+			FLAG_C = MAKE_INT_16(upper_bound) - MAKE_INT_16(compare);
+		else
+			FLAG_C = upper_bound - compare;
+
+		FLAG_C = CFLAG_16(FLAG_C);
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 32, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15];
+		uint ea = EA_PCDI_32();
+		uint lower_bound = m68ki_read_pcrel_32(ea);
+		uint upper_bound = m68ki_read_pcrel_32(ea + 4);
+
+		FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		FLAG_C = CFLAG_SUB_32(lower_bound, compare, FLAG_C);
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		FLAG_C = upper_bound - compare;
+		FLAG_C = CFLAG_SUB_32(compare, upper_bound, FLAG_C);
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 32, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15];
+		uint ea = EA_PCIX_32();
+		uint lower_bound = m68ki_read_pcrel_32(ea);
+		uint upper_bound = m68ki_read_pcrel_32(ea + 4);
+
+		FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		FLAG_C = CFLAG_SUB_32(lower_bound, compare, FLAG_C);
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		FLAG_C = upper_bound - compare;
+		FLAG_C = CFLAG_SUB_32(compare, upper_bound, FLAG_C);
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(chk2cmp2, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint compare = REG_DA[(word2 >> 12) & 15];
+		uint ea = M68KMAKE_GET_EA_AY_32;
+		uint lower_bound = m68ki_read_32(ea);
+		uint upper_bound = m68ki_read_32(ea + 4);
+
+		FLAG_C = compare - lower_bound;
+		FLAG_Z = !((upper_bound==compare) | (lower_bound==compare));
+		FLAG_C = CFLAG_SUB_32(lower_bound, compare, FLAG_C);
+		if(COND_CS())
+		{
+			if(BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+			return;
+		}
+
+		FLAG_C = upper_bound - compare;
+		FLAG_C = CFLAG_SUB_32(compare, upper_bound, FLAG_C);
+		if(COND_CS() && BIT_B(word2))
+				m68ki_exception_trap(EXCEPTION_CHK);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(clr, 8, ., d)
+{
+	DY &= 0xffffff00;
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_Z = ZFLAG_SET;
+}
+
+
+M68KMAKE_OP(clr, 8, ., .)
+{
+	m68ki_write_8(M68KMAKE_GET_EA_AY_8, 0);
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_Z = ZFLAG_SET;
+}
+
+
+M68KMAKE_OP(clr, 16, ., d)
+{
+	DY &= 0xffff0000;
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_Z = ZFLAG_SET;
+}
+
+
+M68KMAKE_OP(clr, 16, ., .)
+{
+	m68ki_write_16(M68KMAKE_GET_EA_AY_16, 0);
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_Z = ZFLAG_SET;
+}
+
+
+M68KMAKE_OP(clr, 32, ., d)
+{
+	DY = 0;
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_Z = ZFLAG_SET;
+}
+
+
+M68KMAKE_OP(clr, 32, ., .)
+{
+	m68ki_write_32(M68KMAKE_GET_EA_AY_32, 0);
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_Z = ZFLAG_SET;
+}
+
+
+M68KMAKE_OP(cmp, 8, ., d)
+{
+	uint src = MASK_OUT_ABOVE_8(DY);
+	uint dst = MASK_OUT_ABOVE_8(DX);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmp, 8, ., .)
+{
+	uint src = M68KMAKE_GET_OPER_AY_8;
+	uint dst = MASK_OUT_ABOVE_8(DX);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmp, 16, ., d)
+{
+	uint src = MASK_OUT_ABOVE_16(DY);
+	uint dst = MASK_OUT_ABOVE_16(DX);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_C = CFLAG_16(res);
+}
+
+
+M68KMAKE_OP(cmp, 16, ., a)
+{
+	uint src = MASK_OUT_ABOVE_16(AY);
+	uint dst = MASK_OUT_ABOVE_16(DX);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_C = CFLAG_16(res);
+}
+
+
+M68KMAKE_OP(cmp, 16, ., .)
+{
+	uint src = M68KMAKE_GET_OPER_AY_16;
+	uint dst = MASK_OUT_ABOVE_16(DX);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_C = CFLAG_16(res);
+}
+
+
+M68KMAKE_OP(cmp, 32, ., d)
+{
+	uint src = DY;
+	uint dst = DX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmp, 32, ., a)
+{
+	uint src = AY;
+	uint dst = DX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmp, 32, ., .)
+{
+	uint src = M68KMAKE_GET_OPER_AY_32;
+	uint dst = DX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpa, 16, ., d)
+{
+	uint src = MAKE_INT_16(DY);
+	uint dst = AX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpa, 16, ., a)
+{
+	uint src = MAKE_INT_16(AY);
+	uint dst = AX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpa, 16, ., .)
+{
+	uint src = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
+	uint dst = AX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpa, 32, ., d)
+{
+	uint src = DY;
+	uint dst = AX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpa, 32, ., a)
+{
+	uint src = AY;
+	uint dst = AX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpa, 32, ., .)
+{
+	uint src = M68KMAKE_GET_OPER_AY_32;
+	uint dst = AX;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpi, 8, ., d)
+{
+	uint src = OPER_I_8();
+	uint dst = MASK_OUT_ABOVE_8(DY);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmpi, 8, ., .)
+{
+	uint src = OPER_I_8();
+	uint dst = M68KMAKE_GET_OPER_AY_8;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmpi, 8, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint src = OPER_I_8();
+		uint dst = OPER_PCDI_8();
+		uint res = dst - src;
+
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = MASK_OUT_ABOVE_8(res);
+		FLAG_V = VFLAG_SUB_8(src, dst, res);
+		FLAG_C = CFLAG_8(res);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cmpi, 8, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint src = OPER_I_8();
+		uint dst = OPER_PCIX_8();
+		uint res = dst - src;
+
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = MASK_OUT_ABOVE_8(res);
+		FLAG_V = VFLAG_SUB_8(src, dst, res);
+		FLAG_C = CFLAG_8(res);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cmpi, 16, ., d)
+{
+	uint src = OPER_I_16();
+	uint dst = MASK_OUT_ABOVE_16(DY);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_C = CFLAG_16(res);
+}
+
+
+M68KMAKE_OP(cmpi, 16, ., .)
+{
+	uint src = OPER_I_16();
+	uint dst = M68KMAKE_GET_OPER_AY_16;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_C = CFLAG_16(res);
+}
+
+
+M68KMAKE_OP(cmpi, 16, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint src = OPER_I_16();
+		uint dst = OPER_PCDI_16();
+		uint res = dst - src;
+
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = MASK_OUT_ABOVE_16(res);
+		FLAG_V = VFLAG_SUB_16(src, dst, res);
+		FLAG_C = CFLAG_16(res);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cmpi, 16, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint src = OPER_I_16();
+		uint dst = OPER_PCIX_16();
+		uint res = dst - src;
+
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = MASK_OUT_ABOVE_16(res);
+		FLAG_V = VFLAG_SUB_16(src, dst, res);
+		FLAG_C = CFLAG_16(res);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cmpi, 32, ., d)
+{
+	uint src = OPER_I_32();
+	uint dst = DY;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpi, 32, ., .)
+{
+	uint src = OPER_I_32();
+	uint dst = M68KMAKE_GET_OPER_AY_32;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cmpi, 32, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint src = OPER_I_32();
+		uint dst = OPER_PCDI_32();
+		uint res = dst - src;
+
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = MASK_OUT_ABOVE_32(res);
+		FLAG_V = VFLAG_SUB_32(src, dst, res);
+		FLAG_C = CFLAG_SUB_32(src, dst, res);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cmpi, 32, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint src = OPER_I_32();
+		uint dst = OPER_PCIX_32();
+		uint res = dst - src;
+
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = MASK_OUT_ABOVE_32(res);
+		FLAG_V = VFLAG_SUB_32(src, dst, res);
+		FLAG_C = CFLAG_SUB_32(src, dst, res);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(cmpm, 8, ., ax7)
+{
+	uint src = OPER_AY_PI_8();
+	uint dst = OPER_A7_PI_8();
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmpm, 8, ., ay7)
+{
+	uint src = OPER_A7_PI_8();
+	uint dst = OPER_AX_PI_8();
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmpm, 8, ., axy7)
+{
+	uint src = OPER_A7_PI_8();
+	uint dst = OPER_A7_PI_8();
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmpm, 8, ., .)
+{
+	uint src = OPER_AY_PI_8();
+	uint dst = OPER_AX_PI_8();
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_C = CFLAG_8(res);
+}
+
+
+M68KMAKE_OP(cmpm, 16, ., .)
+{
+	uint src = OPER_AY_PI_16();
+	uint dst = OPER_AX_PI_16();
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_C = CFLAG_16(res);
+}
+
+
+M68KMAKE_OP(cmpm, 32, ., .)
+{
+	uint src = OPER_AY_PI_32();
+	uint dst = OPER_AX_PI_32();
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_C = CFLAG_SUB_32(src, dst, res);
+}
+
+
+M68KMAKE_OP(cpbcc, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: called unimplemented instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
+					 m68k_disassemble_quick(ADDRESS_68K(REG_PC - 2))));
+		return;
+	}
+	m68ki_exception_1111();
+}
+
+
+M68KMAKE_OP(cpdbcc, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: called unimplemented instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
+					 m68k_disassemble_quick(ADDRESS_68K(REG_PC - 2))));
+		return;
+	}
+	m68ki_exception_1111();
+}
+
+
+M68KMAKE_OP(cpgen, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: called unimplemented instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
+					 m68k_disassemble_quick(ADDRESS_68K(REG_PC - 2))));
+		return;
+	}
+	m68ki_exception_1111();
+}
+
+
+M68KMAKE_OP(cpscc, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: called unimplemented instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
+					 m68k_disassemble_quick(ADDRESS_68K(REG_PC - 2))));
+		return;
+	}
+	m68ki_exception_1111();
+}
+
+
+M68KMAKE_OP(cptrapcc, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: called unimplemented instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
+					 m68k_disassemble_quick(ADDRESS_68K(REG_PC - 2))));
+		return;
+	}
+	m68ki_exception_1111();
+}
+
+
+M68KMAKE_OP(dbt, 16, ., .)
+{
+	REG_PC += 2;
+}
+
+
+M68KMAKE_OP(dbf, 16, ., .)
+{
+	uint* r_dst = &DY;
+	uint res = MASK_OUT_ABOVE_16(*r_dst - 1);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+	if(res != 0xffff)
+	{
+		uint offset = OPER_I_16();
+		REG_PC -= 2;
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_branch_16(offset);
+		USE_CYCLES(CYC_DBCC_F_NOEXP);
+		return;
+	}
+	REG_PC += 2;
+	USE_CYCLES(CYC_DBCC_F_EXP);
+}
+
+
+M68KMAKE_OP(dbcc, 16, ., .)
+{
+	if(M68KMAKE_NOT_CC)
+	{
+		uint* r_dst = &DY;
+		uint res = MASK_OUT_ABOVE_16(*r_dst - 1);
+
+		*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+		if(res != 0xffff)
+		{
+			uint offset = OPER_I_16();
+			REG_PC -= 2;
+			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+			m68ki_branch_16(offset);
+			USE_CYCLES(CYC_DBCC_F_NOEXP);
+			return;
+		}
+		REG_PC += 2;
+		USE_CYCLES(CYC_DBCC_F_EXP);
+		return;
+	}
+	REG_PC += 2;
+}
+
+
+M68KMAKE_OP(divs, 16, ., d)
+{
+	uint* r_dst = &DX;
+	sint src = MAKE_INT_16(DY);
+	sint quotient;
+	sint remainder;
+
+	if(src != 0)
+	{
+		if((uint32)*r_dst == 0x80000000 && src == -1)
+		{
+			FLAG_Z = 0;
+			FLAG_N = NFLAG_CLEAR;
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			*r_dst = 0;
+			return;
+		}
+
+		quotient = MAKE_INT_32(*r_dst) / src;
+		remainder = MAKE_INT_32(*r_dst) % src;
+
+		if(quotient == MAKE_INT_16(quotient))
+		{
+			FLAG_Z = quotient;
+			FLAG_N = NFLAG_16(quotient);
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
+			return;
+		}
+		FLAG_V = VFLAG_SET;
+		return;
+	}
+	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+}
+
+
+M68KMAKE_OP(divs, 16, ., .)
+{
+	uint* r_dst = &DX;
+	sint src = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
+	sint quotient;
+	sint remainder;
+
+	if(src != 0)
+	{
+		if((uint32)*r_dst == 0x80000000 && src == -1)
+		{
+			FLAG_Z = 0;
+			FLAG_N = NFLAG_CLEAR;
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			*r_dst = 0;
+			return;
+		}
+
+		quotient = MAKE_INT_32(*r_dst) / src;
+		remainder = MAKE_INT_32(*r_dst) % src;
+
+		if(quotient == MAKE_INT_16(quotient))
+		{
+			FLAG_Z = quotient;
+			FLAG_N = NFLAG_16(quotient);
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
+			return;
+		}
+		FLAG_V = VFLAG_SET;
+		return;
+	}
+	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+}
+
+
+M68KMAKE_OP(divu, 16, ., d)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_16(DY);
+
+	if(src != 0)
+	{
+		uint quotient = *r_dst / src;
+		uint remainder = *r_dst % src;
+
+		if(quotient < 0x10000)
+		{
+			FLAG_Z = quotient;
+			FLAG_N = NFLAG_16(quotient);
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
+			return;
+		}
+		FLAG_V = VFLAG_SET;
+		return;
+	}
+	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+}
+
+
+M68KMAKE_OP(divu, 16, ., .)
+{
+	uint* r_dst = &DX;
+	uint src = M68KMAKE_GET_OPER_AY_16;
+
+	if(src != 0)
+	{
+		uint quotient = *r_dst / src;
+		uint remainder = *r_dst % src;
+
+		if(quotient < 0x10000)
+		{
+			FLAG_Z = quotient;
+			FLAG_N = NFLAG_16(quotient);
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			*r_dst = MASK_OUT_ABOVE_32(MASK_OUT_ABOVE_16(quotient) | (remainder << 16));
+			return;
+		}
+		FLAG_V = VFLAG_SET;
+		return;
+	}
+	m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+}
+
+
+M68KMAKE_OP(divl, 32, ., d)
+{
+#if M68K_USE_64_BIT
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint64 divisor   = DY;
+		uint64 dividend  = 0;
+		uint64 quotient  = 0;
+		uint64 remainder = 0;
+
+		if(divisor != 0)
+		{
+			if(BIT_A(word2))	/* 64 bit */
+			{
+				dividend = REG_D[word2 & 7];
+				dividend <<= 32;
+				dividend |= REG_D[(word2 >> 12) & 7];
+
+				if(BIT_B(word2))	   /* signed */
+				{
+					quotient  = (uint64)((sint64)dividend / (sint64)((sint32)divisor));
+					remainder = (uint64)((sint64)dividend % (sint64)((sint32)divisor));
+					if((sint64)quotient != (sint64)((sint32)quotient))
+					{
+						FLAG_V = VFLAG_SET;
+						return;
+					}
+				}
+				else					/* unsigned */
+				{
+					quotient = dividend / divisor;
+					if(quotient > 0xffffffff)
+					{
+						FLAG_V = VFLAG_SET;
+						return;
+					}
+					remainder = dividend % divisor;
+				}
+			}
+			else	/* 32 bit */
+			{
+				dividend = REG_D[(word2 >> 12) & 7];
+				if(BIT_B(word2))	   /* signed */
+				{
+					quotient  = (uint64)((sint64)((sint32)dividend) / (sint64)((sint32)divisor));
+					remainder = (uint64)((sint64)((sint32)dividend) % (sint64)((sint32)divisor));
+				}
+				else					/* unsigned */
+				{
+					quotient = dividend / divisor;
+					remainder = dividend % divisor;
+				}
+			}
+
+			REG_D[word2 & 7] = remainder;
+			REG_D[(word2 >> 12) & 7] = quotient;
+
+			FLAG_N = NFLAG_32(quotient);
+			FLAG_Z = quotient;
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			return;
+		}
+		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		return;
+	}
+	m68ki_exception_illegal();
+
+#else
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint divisor = DY;
+		uint dividend_hi = REG_D[word2 & 7];
+		uint dividend_lo = REG_D[(word2 >> 12) & 7];
+		uint quotient = 0;
+		uint remainder = 0;
+		uint dividend_neg = 0;
+		uint divisor_neg = 0;
+		sint i;
+		uint overflow;
+
+		if(divisor != 0)
+		{
+			/* quad / long : long quotient, long remainder */
+			if(BIT_A(word2))
+			{
+				if(BIT_B(word2))	   /* signed */
+				{
+					/* special case in signed divide */
+					if(dividend_hi == 0 && dividend_lo == 0x80000000 && divisor == 0xffffffff)
+					{
+						REG_D[word2 & 7] = 0;
+						REG_D[(word2 >> 12) & 7] = 0x80000000;
+
+						FLAG_N = NFLAG_SET;
+						FLAG_Z = ZFLAG_CLEAR;
+						FLAG_V = VFLAG_CLEAR;
+						FLAG_C = CFLAG_CLEAR;
+						return;
+					}
+					if(GET_MSB_32(dividend_hi))
+					{
+						dividend_neg = 1;
+						dividend_hi = (uint)MASK_OUT_ABOVE_32((-(sint)dividend_hi) - (dividend_lo != 0));
+						dividend_lo = (uint)MASK_OUT_ABOVE_32(-(sint)dividend_lo);
+					}
+					if(GET_MSB_32(divisor))
+					{
+						divisor_neg = 1;
+						divisor = (uint)MASK_OUT_ABOVE_32(-(sint)divisor);
+
+					}
+				}
+
+				/* if the upper long is greater than the divisor, we're overflowing. */
+				if(dividend_hi >= divisor)
+				{
+					FLAG_V = VFLAG_SET;
+					return;
+				}
+
+				for(i = 31; i >= 0; i--)
+				{
+					quotient <<= 1;
+					remainder = (remainder << 1) + ((dividend_hi >> i) & 1);
+					if(remainder >= divisor)
+					{
+						remainder -= divisor;
+						quotient++;
+					}
+				}
+				for(i = 31; i >= 0; i--)
+				{
+					quotient <<= 1;
+					overflow = GET_MSB_32(remainder);
+					remainder = (remainder << 1) + ((dividend_lo >> i) & 1);
+					if(remainder >= divisor || overflow)
+					{
+						remainder -= divisor;
+						quotient++;
+					}
+				}
+
+				if(BIT_B(word2))	   /* signed */
+				{
+					if(quotient > 0x7fffffff)
+					{
+						FLAG_V = VFLAG_SET;
+						return;
+					}
+					if(dividend_neg)
+					{
+						remainder = (uint)MASK_OUT_ABOVE_32(-(sint)remainder);
+						quotient = (uint)MASK_OUT_ABOVE_32(-(sint)quotient);
+					}
+					if(divisor_neg)
+						quotient = (uint)MASK_OUT_ABOVE_32(-(sint)quotient);
+				}
+
+				REG_D[word2 & 7] = remainder;
+				REG_D[(word2 >> 12) & 7] = quotient;
+
+				FLAG_N = NFLAG_32(quotient);
+				FLAG_Z = quotient;
+				FLAG_V = VFLAG_CLEAR;
+				FLAG_C = CFLAG_CLEAR;
+				return;
+			}
+
+			/* long / long: long quotient, maybe long remainder */
+			if(BIT_B(word2))	   /* signed */
+			{
+				/* Special case in divide */
+				if(dividend_lo == 0x80000000 && divisor == 0xffffffff)
+				{
+					FLAG_N = NFLAG_SET;
+					FLAG_Z = ZFLAG_CLEAR;
+					FLAG_V = VFLAG_CLEAR;
+					FLAG_C = CFLAG_CLEAR;
+					REG_D[(word2 >> 12) & 7] = 0x80000000;
+					REG_D[word2 & 7] = 0;
+					return;
+				}
+				REG_D[word2 & 7] = MAKE_INT_32(dividend_lo) % MAKE_INT_32(divisor);
+				quotient = REG_D[(word2 >> 12) & 7] = MAKE_INT_32(dividend_lo) / MAKE_INT_32(divisor);
+			}
+			else
+			{
+				REG_D[word2 & 7] = MASK_OUT_ABOVE_32(dividend_lo) % MASK_OUT_ABOVE_32(divisor);
+				quotient = REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(dividend_lo) / MASK_OUT_ABOVE_32(divisor);
+			}
+
+			FLAG_N = NFLAG_32(quotient);
+			FLAG_Z = quotient;
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			return;
+		}
+		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		return;
+	}
+	m68ki_exception_illegal();
+
+#endif
+}
+
+
+M68KMAKE_OP(divl, 32, ., .)
+{
+#if M68K_USE_64_BIT
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint64 divisor = M68KMAKE_GET_OPER_AY_32;
+		uint64 dividend  = 0;
+		uint64 quotient  = 0;
+		uint64 remainder = 0;
+
+		if(divisor != 0)
+		{
+			if(BIT_A(word2))	/* 64 bit */
+			{
+				dividend = REG_D[word2 & 7];
+				dividend <<= 32;
+				dividend |= REG_D[(word2 >> 12) & 7];
+
+				if(BIT_B(word2))	   /* signed */
+				{
+					quotient  = (uint64)((sint64)dividend / (sint64)((sint32)divisor));
+					remainder = (uint64)((sint64)dividend % (sint64)((sint32)divisor));
+					if((sint64)quotient != (sint64)((sint32)quotient))
+					{
+						FLAG_V = VFLAG_SET;
+						return;
+					}
+				}
+				else					/* unsigned */
+				{
+					quotient = dividend / divisor;
+					if(quotient > 0xffffffff)
+					{
+						FLAG_V = VFLAG_SET;
+						return;
+					}
+					remainder = dividend % divisor;
+				}
+			}
+			else	/* 32 bit */
+			{
+				dividend = REG_D[(word2 >> 12) & 7];
+				if(BIT_B(word2))	   /* signed */
+				{
+					quotient  = (uint64)((sint64)((sint32)dividend) / (sint64)((sint32)divisor));
+					remainder = (uint64)((sint64)((sint32)dividend) % (sint64)((sint32)divisor));
+				}
+				else					/* unsigned */
+				{
+					quotient = dividend / divisor;
+					remainder = dividend % divisor;
+				}
+			}
+
+			REG_D[word2 & 7] = remainder;
+			REG_D[(word2 >> 12) & 7] = quotient;
+
+			FLAG_N = NFLAG_32(quotient);
+			FLAG_Z = quotient;
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			return;
+		}
+		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		return;
+	}
+	m68ki_exception_illegal();
+
+#else
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint divisor = M68KMAKE_GET_OPER_AY_32;
+		uint dividend_hi = REG_D[word2 & 7];
+		uint dividend_lo = REG_D[(word2 >> 12) & 7];
+		uint quotient = 0;
+		uint remainder = 0;
+		uint dividend_neg = 0;
+		uint divisor_neg = 0;
+		sint i;
+		uint overflow;
+
+		if(divisor != 0)
+		{
+			/* quad / long : long quotient, long remainder */
+			if(BIT_A(word2))
+			{
+				if(BIT_B(word2))	   /* signed */
+				{
+					/* special case in signed divide */
+					if(dividend_hi == 0 && dividend_lo == 0x80000000 && divisor == 0xffffffff)
+					{
+						REG_D[word2 & 7] = 0;
+						REG_D[(word2 >> 12) & 7] = 0x80000000;
+
+						FLAG_N = NFLAG_SET;
+						FLAG_Z = ZFLAG_CLEAR;
+						FLAG_V = VFLAG_CLEAR;
+						FLAG_C = CFLAG_CLEAR;
+						return;
+					}
+					if(GET_MSB_32(dividend_hi))
+					{
+						dividend_neg = 1;
+						dividend_hi = (uint)MASK_OUT_ABOVE_32((-(sint)dividend_hi) - (dividend_lo != 0));
+						dividend_lo = (uint)MASK_OUT_ABOVE_32(-(sint)dividend_lo);
+					}
+					if(GET_MSB_32(divisor))
+					{
+						divisor_neg = 1;
+						divisor = (uint)MASK_OUT_ABOVE_32(-(sint)divisor);
+
+					}
+				}
+
+				/* if the upper long is greater than the divisor, we're overflowing. */
+				if(dividend_hi >= divisor)
+				{
+					FLAG_V = VFLAG_SET;
+					return;
+				}
+
+				for(i = 31; i >= 0; i--)
+				{
+					quotient <<= 1;
+					remainder = (remainder << 1) + ((dividend_hi >> i) & 1);
+					if(remainder >= divisor)
+					{
+						remainder -= divisor;
+						quotient++;
+					}
+				}
+				for(i = 31; i >= 0; i--)
+				{
+					quotient <<= 1;
+					overflow = GET_MSB_32(remainder);
+					remainder = (remainder << 1) + ((dividend_lo >> i) & 1);
+					if(remainder >= divisor || overflow)
+					{
+						remainder -= divisor;
+						quotient++;
+					}
+				}
+
+				if(BIT_B(word2))	   /* signed */
+				{
+					if(quotient > 0x7fffffff)
+					{
+						FLAG_V = VFLAG_SET;
+						return;
+					}
+					if(dividend_neg)
+					{
+						remainder = (uint)MASK_OUT_ABOVE_32(-(sint)remainder);
+						quotient = (uint)MASK_OUT_ABOVE_32(-(sint)quotient);
+					}
+					if(divisor_neg)
+						quotient = (uint)MASK_OUT_ABOVE_32(-(sint)quotient);
+				}
+
+				REG_D[word2 & 7] = remainder;
+				REG_D[(word2 >> 12) & 7] = quotient;
+
+				FLAG_N = NFLAG_32(quotient);
+				FLAG_Z = quotient;
+				FLAG_V = VFLAG_CLEAR;
+				FLAG_C = CFLAG_CLEAR;
+				return;
+			}
+
+			/* long / long: long quotient, maybe long remainder */
+			if(BIT_B(word2))	   /* signed */
+			{
+				/* Special case in divide */
+				if(dividend_lo == 0x80000000 && divisor == 0xffffffff)
+				{
+					FLAG_N = NFLAG_SET;
+					FLAG_Z = ZFLAG_CLEAR;
+					FLAG_V = VFLAG_CLEAR;
+					FLAG_C = CFLAG_CLEAR;
+					REG_D[(word2 >> 12) & 7] = 0x80000000;
+					REG_D[word2 & 7] = 0;
+					return;
+				}
+				REG_D[word2 & 7] = MAKE_INT_32(dividend_lo) % MAKE_INT_32(divisor);
+				quotient = REG_D[(word2 >> 12) & 7] = MAKE_INT_32(dividend_lo) / MAKE_INT_32(divisor);
+			}
+			else
+			{
+				REG_D[word2 & 7] = MASK_OUT_ABOVE_32(dividend_lo) % MASK_OUT_ABOVE_32(divisor);
+				quotient = REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(dividend_lo) / MASK_OUT_ABOVE_32(divisor);
+			}
+
+			FLAG_N = NFLAG_32(quotient);
+			FLAG_Z = quotient;
+			FLAG_V = VFLAG_CLEAR;
+			FLAG_C = CFLAG_CLEAR;
+			return;
+		}
+		m68ki_exception_trap(EXCEPTION_ZERO_DIVIDE);
+		return;
+	}
+	m68ki_exception_illegal();
+
+#endif
+}
+
+
+M68KMAKE_OP(eor, 8, ., d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY ^= MASK_OUT_ABOVE_8(DX));
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eor, 8, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint res = MASK_OUT_ABOVE_8(DX ^ m68ki_read_8(ea));
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eor, 16, ., d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY ^= MASK_OUT_ABOVE_16(DX));
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eor, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint res = MASK_OUT_ABOVE_16(DX ^ m68ki_read_16(ea));
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eor, 32, ., d)
+{
+	uint res = DY ^= DX;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eor, 32, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint res = DX ^ m68ki_read_32(ea);
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eori, 8, ., d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY ^= OPER_I_8());
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eori, 8, ., .)
+{
+	uint src = OPER_I_8();
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint res = src ^ m68ki_read_8(ea);
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eori, 16, ., d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY ^= OPER_I_16());
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eori, 16, ., .)
+{
+	uint src = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint res = src ^ m68ki_read_16(ea);
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eori, 32, ., d)
+{
+	uint res = DY ^= OPER_I_32();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eori, 32, ., .)
+{
+	uint src = OPER_I_32();
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint res = src ^ m68ki_read_32(ea);
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(eori, 16, toc, .)
+{
+	m68ki_set_ccr(m68ki_get_ccr() ^ OPER_I_16());
+}
+
+
+M68KMAKE_OP(eori, 16, tos, .)
+{
+	if(FLAG_S)
+	{
+		uint src = OPER_I_16();
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_set_sr(m68ki_get_sr() ^ src);
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(exg, 32, dd, .)
+{
+	uint* reg_a = &DX;
+	uint* reg_b = &DY;
+	uint tmp = *reg_a;
+	*reg_a = *reg_b;
+	*reg_b = tmp;
+}
+
+
+M68KMAKE_OP(exg, 32, aa, .)
+{
+	uint* reg_a = &AX;
+	uint* reg_b = &AY;
+	uint tmp = *reg_a;
+	*reg_a = *reg_b;
+	*reg_b = tmp;
+}
+
+
+M68KMAKE_OP(exg, 32, da, .)
+{
+	uint* reg_a = &DX;
+	uint* reg_b = &AY;
+	uint tmp = *reg_a;
+	*reg_a = *reg_b;
+	*reg_b = tmp;
+}
+
+
+M68KMAKE_OP(ext, 16, ., .)
+{
+	uint* r_dst = &DY;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | MASK_OUT_ABOVE_8(*r_dst) | (GET_MSB_8(*r_dst) ? 0xff00 : 0);
+
+	FLAG_N = NFLAG_16(*r_dst);
+	FLAG_Z = MASK_OUT_ABOVE_16(*r_dst);
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ext, 32, ., .)
+{
+	uint* r_dst = &DY;
+
+	*r_dst = MASK_OUT_ABOVE_16(*r_dst) | (GET_MSB_16(*r_dst) ? 0xffff0000 : 0);
+
+	FLAG_N = NFLAG_32(*r_dst);
+	FLAG_Z = *r_dst;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(extb, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint* r_dst = &DY;
+
+		*r_dst = MASK_OUT_ABOVE_8(*r_dst) | (GET_MSB_8(*r_dst) ? 0xffffff00 : 0);
+
+		FLAG_N = NFLAG_32(*r_dst);
+		FLAG_Z = *r_dst;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(illegal, 0, ., .)
+{
+	m68ki_exception_illegal();
+}
+
+M68KMAKE_OP(jmp, 32, ., .)
+{
+	m68ki_jump(M68KMAKE_GET_EA_AY_32);
+	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
+	if(REG_PC == REG_PPC)
+		USE_ALL_CYCLES();
+}
+
+
+M68KMAKE_OP(jsr, 32, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
+	m68ki_push_32(REG_PC);
+	m68ki_jump(ea);
+}
+
+
+M68KMAKE_OP(lea, 32, ., .)
+{
+	AX = M68KMAKE_GET_EA_AY_32;
+}
+
+
+M68KMAKE_OP(link, 16, ., a7)
+{
+	REG_A[7] -= 4;
+	m68ki_write_32(REG_A[7], REG_A[7]);
+	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16()));
+}
+
+
+M68KMAKE_OP(link, 16, ., .)
+{
+	uint* r_dst = &AY;
+
+	m68ki_push_32(*r_dst);
+	*r_dst = REG_A[7];
+	REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16()));
+}
+
+
+M68KMAKE_OP(link, 32, ., a7)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		REG_A[7] -= 4;
+		m68ki_write_32(REG_A[7], REG_A[7]);
+		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32());
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(link, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint* r_dst = &AY;
+
+		m68ki_push_32(*r_dst);
+		*r_dst = REG_A[7];
+		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + OPER_I_32());
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(lsr, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src >> shift;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src << (9-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsr, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src >> shift;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src << (9-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsr, 32, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = *r_dst;
+	uint res = src >> shift;
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src << (9-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsr, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = src >> shift;
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift <= 8)
+		{
+			*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+			FLAG_X = FLAG_C = src << (9-shift);
+			FLAG_N = NFLAG_CLEAR;
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst &= 0xffffff00;
+		FLAG_X = XFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_8(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsr, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = src >> shift;
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift <= 16)
+		{
+			*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+			FLAG_C = FLAG_X = (src >> (shift - 1))<<8;
+			FLAG_N = NFLAG_CLEAR;
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst &= 0xffff0000;
+		FLAG_X = XFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_16(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsr, 32, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = *r_dst;
+	uint res = src >> shift;
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 32)
+		{
+			*r_dst = res;
+			FLAG_C = FLAG_X = (src >> (shift - 1))<<8;
+			FLAG_N = NFLAG_CLEAR;
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst = 0;
+		FLAG_X = FLAG_C = (shift == 32 ? GET_MSB_32(src)>>23 : 0);
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_32(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsr, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = src >> 1;
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_CLEAR;
+	FLAG_Z = res;
+	FLAG_C = FLAG_X = src << 8;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsl, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = MASK_OUT_ABOVE_8(src << shift);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src << shift;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsl, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = MASK_OUT_ABOVE_16(src << shift);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src >> (8-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsl, 32, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32(src << shift);
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src >> (24-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsl, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = MASK_OUT_ABOVE_8(src << shift);
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift <= 8)
+		{
+			*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+			FLAG_X = FLAG_C = src << shift;
+			FLAG_N = NFLAG_8(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst &= 0xffffff00;
+		FLAG_X = XFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_8(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsl, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = MASK_OUT_ABOVE_16(src << shift);
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift <= 16)
+		{
+			*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+			FLAG_X = FLAG_C = (src << shift) >> 8;
+			FLAG_N = NFLAG_16(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst &= 0xffff0000;
+		FLAG_X = XFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_16(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsl, 32, r, .)
+{
+	uint* r_dst = &DY;
+	uint shift = DX & 0x3f;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32(src << shift);
+
+	if(shift != 0)
+	{
+		USE_CYCLES(shift<<CYC_SHIFT);
+
+		if(shift < 32)
+		{
+			*r_dst = res;
+			FLAG_X = FLAG_C = (src >> (32 - shift)) << 8;
+			FLAG_N = NFLAG_32(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		*r_dst = 0;
+		FLAG_X = FLAG_C = ((shift == 32 ? src & 1 : 0))<<8;
+		FLAG_N = NFLAG_CLEAR;
+		FLAG_Z = ZFLAG_SET;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_32(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(lsl, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = MASK_OUT_ABOVE_16(src << 1);
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_X = FLAG_C = src >> 7;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, d, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint* r_dst = &DX;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, d, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint* r_dst = &DX;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, ai, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_AX_AI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, ai, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_AX_AI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pi7, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_A7_PI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pi, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_AX_PI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pi7, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_A7_PI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pi, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_AX_PI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pd7, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_A7_PD_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pd, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_AX_PD_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pd7, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_A7_PD_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, pd, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_AX_PD_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, di, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_AX_DI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, di, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_AX_DI_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, ix, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_AX_IX_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, ix, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_AX_IX_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, aw, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_AW_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, aw, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_AW_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, al, d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+	uint ea = EA_AL_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 8, al, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+	uint ea = EA_AL_8();
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, d, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint* r_dst = &DX;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, d, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint* r_dst = &DX;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, d, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint* r_dst = &DX;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, ai, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint ea = EA_AX_AI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, ai, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint ea = EA_AX_AI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, ai, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint ea = EA_AX_AI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, pi, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint ea = EA_AX_PI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, pi, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint ea = EA_AX_PI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, pi, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint ea = EA_AX_PI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, pd, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint ea = EA_AX_PD_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, pd, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint ea = EA_AX_PD_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, pd, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint ea = EA_AX_PD_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, di, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint ea = EA_AX_DI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, di, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint ea = EA_AX_DI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, di, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint ea = EA_AX_DI_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, ix, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint ea = EA_AX_IX_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, ix, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint ea = EA_AX_IX_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, ix, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint ea = EA_AX_IX_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, aw, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint ea = EA_AW_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, aw, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint ea = EA_AW_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, aw, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint ea = EA_AW_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, al, d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+	uint ea = EA_AL_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, al, a)
+{
+	uint res = MASK_OUT_ABOVE_16(AY);
+	uint ea = EA_AL_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 16, al, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+	uint ea = EA_AL_16();
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, d, d)
+{
+	uint res = DY;
+	uint* r_dst = &DX;
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, d, a)
+{
+	uint res = AY;
+	uint* r_dst = &DX;
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, d, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint* r_dst = &DX;
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, ai, d)
+{
+	uint res = DY;
+	uint ea = EA_AX_AI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, ai, a)
+{
+	uint res = AY;
+	uint ea = EA_AX_AI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, ai, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint ea = EA_AX_AI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, pi, d)
+{
+	uint res = DY;
+	uint ea = EA_AX_PI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, pi, a)
+{
+	uint res = AY;
+	uint ea = EA_AX_PI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, pi, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint ea = EA_AX_PI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, pd, d)
+{
+	uint res = DY;
+	uint ea = EA_AX_PD_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, pd, a)
+{
+	uint res = AY;
+	uint ea = EA_AX_PD_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, pd, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint ea = EA_AX_PD_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, di, d)
+{
+	uint res = DY;
+	uint ea = EA_AX_DI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, di, a)
+{
+	uint res = AY;
+	uint ea = EA_AX_DI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, di, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint ea = EA_AX_DI_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, ix, d)
+{
+	uint res = DY;
+	uint ea = EA_AX_IX_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, ix, a)
+{
+	uint res = AY;
+	uint ea = EA_AX_IX_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, ix, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint ea = EA_AX_IX_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, aw, d)
+{
+	uint res = DY;
+	uint ea = EA_AW_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, aw, a)
+{
+	uint res = AY;
+	uint ea = EA_AW_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, aw, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint ea = EA_AW_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, al, d)
+{
+	uint res = DY;
+	uint ea = EA_AL_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, al, a)
+{
+	uint res = AY;
+	uint ea = EA_AL_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(move, 32, al, .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+	uint ea = EA_AL_32();
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(movea, 16, ., d)
+{
+	AX = MAKE_INT_16(DY);
+}
+
+
+M68KMAKE_OP(movea, 16, ., a)
+{
+	AX = MAKE_INT_16(AY);
+}
+
+
+M68KMAKE_OP(movea, 16, ., .)
+{
+	AX = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
+}
+
+
+M68KMAKE_OP(movea, 32, ., d)
+{
+	AX = DY;
+}
+
+
+M68KMAKE_OP(movea, 32, ., a)
+{
+	AX = AY;
+}
+
+
+M68KMAKE_OP(movea, 32, ., .)
+{
+	AX = M68KMAKE_GET_OPER_AY_32;
+}
+
+
+M68KMAKE_OP(move, 16, frc, d)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		DY = MASK_OUT_BELOW_16(DY) | m68ki_get_ccr();
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(move, 16, frc, .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		m68ki_write_16(M68KMAKE_GET_EA_AY_16, m68ki_get_ccr());
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(move, 16, toc, d)
+{
+	m68ki_set_ccr(DY);
+}
+
+
+M68KMAKE_OP(move, 16, toc, .)
+{
+	m68ki_set_ccr(M68KMAKE_GET_OPER_AY_16);
+}
+
+
+M68KMAKE_OP(move, 16, frs, d)
+{
+	if(CPU_TYPE_IS_000(CPU_TYPE) || FLAG_S)	/* NS990408 */
+	{
+		DY = MASK_OUT_BELOW_16(DY) | m68ki_get_sr();
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(move, 16, frs, .)
+{
+	if(CPU_TYPE_IS_000(CPU_TYPE) || FLAG_S)	/* NS990408 */
+	{
+		uint ea = M68KMAKE_GET_EA_AY_16;
+		m68ki_write_16(ea, m68ki_get_sr());
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(move, 16, tos, d)
+{
+	if(FLAG_S)
+	{
+		m68ki_set_sr(DY);
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(move, 16, tos, .)
+{
+	if(FLAG_S)
+	{
+		uint new_sr = M68KMAKE_GET_OPER_AY_16;
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_set_sr(new_sr);
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(move, 32, fru, .)
+{
+	if(FLAG_S)
+	{
+		AY = REG_USP;
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(move, 32, tou, .)
+{
+	if(FLAG_S)
+	{
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		REG_USP = AY;
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(movec, 32, cr, .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		if(FLAG_S)
+		{
+			uint word2 = OPER_I_16();
+
+			m68ki_trace_t0();		   /* auto-disable (see m68kcpu.h) */
+			switch (word2 & 0xfff)
+			{
+			case 0x000:			   /* SFC */
+				REG_DA[(word2 >> 12) & 15] = REG_SFC;
+				return;
+			case 0x001:			   /* DFC */
+				REG_DA[(word2 >> 12) & 15] = REG_DFC;
+				return;
+			case 0x002:			   /* CACR */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					REG_DA[(word2 >> 12) & 15] = REG_CACR;
+					return;
+				}
+				return;
+			case 0x800:			   /* USP */
+				REG_DA[(word2 >> 12) & 15] = REG_USP;
+				return;
+			case 0x801:			   /* VBR */
+				REG_DA[(word2 >> 12) & 15] = REG_VBR;
+				return;
+			case 0x802:			   /* CAAR */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					REG_DA[(word2 >> 12) & 15] = REG_CAAR;
+					return;
+				}
+				m68ki_exception_illegal();
+				break;
+			case 0x803:			   /* MSP */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					REG_DA[(word2 >> 12) & 15] = FLAG_M ? REG_SP : REG_MSP;
+					return;
+				}
+				m68ki_exception_illegal();
+				return;
+			case 0x804:			   /* ISP */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					REG_DA[(word2 >> 12) & 15] = FLAG_M ? REG_ISP : REG_SP;
+					return;
+				}
+				m68ki_exception_illegal();
+				return;
+			default:
+				m68ki_exception_illegal();
+				return;
+			}
+		}
+		m68ki_exception_privilege_violation();
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(movec, 32, rc, .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		if(FLAG_S)
+		{
+			uint word2 = OPER_I_16();
+
+			m68ki_trace_t0();		   /* auto-disable (see m68kcpu.h) */
+			switch (word2 & 0xfff)
+			{
+			case 0x000:			   /* SFC */
+				REG_SFC = REG_DA[(word2 >> 12) & 15] & 7;
+				return;
+			case 0x001:			   /* DFC */
+				REG_DFC = REG_DA[(word2 >> 12) & 15] & 7;
+				return;
+			case 0x002:			   /* CACR */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					REG_CACR = REG_DA[(word2 >> 12) & 15];
+					return;
+				}
+				m68ki_exception_illegal();
+				return;
+			case 0x800:			   /* USP */
+				REG_USP = REG_DA[(word2 >> 12) & 15];
+				return;
+			case 0x801:			   /* VBR */
+				REG_VBR = REG_DA[(word2 >> 12) & 15];
+				return;
+			case 0x802:			   /* CAAR */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					REG_CAAR = REG_DA[(word2 >> 12) & 15];
+					return;
+				}
+				m68ki_exception_illegal();
+				return;
+			case 0x803:			   /* MSP */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					/* we are in supervisor mode so just check for M flag */
+					if(!FLAG_M)
+					{
+						REG_MSP = REG_DA[(word2 >> 12) & 15];
+						return;
+					}
+					REG_SP = REG_DA[(word2 >> 12) & 15];
+					return;
+				}
+				m68ki_exception_illegal();
+				return;
+			case 0x804:			   /* ISP */
+				if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+				{
+					if(!FLAG_M)
+					{
+						REG_SP = REG_DA[(word2 >> 12) & 15];
+						return;
+					}
+					REG_ISP = REG_DA[(word2 >> 12) & 15];
+					return;
+				}
+				m68ki_exception_illegal();
+				return;
+			default:
+				m68ki_exception_illegal();
+				return;
+			}
+		}
+		m68ki_exception_privilege_violation();
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(movem, 16, re, pd)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = AY;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			ea -= 2;
+			m68ki_write_16(ea, MASK_OUT_ABOVE_16(REG_DA[15-i]));
+			count++;
+		}
+	AY = ea;
+
+	USE_CYCLES(count<<CYC_MOVEM_W);
+}
+
+
+M68KMAKE_OP(movem, 16, re, .)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			m68ki_write_16(ea, MASK_OUT_ABOVE_16(REG_DA[i]));
+			ea += 2;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_W);
+}
+
+
+M68KMAKE_OP(movem, 32, re, pd)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = AY;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			ea -= 4;
+			m68ki_write_32(ea, REG_DA[15-i]);
+			count++;
+		}
+	AY = ea;
+
+	USE_CYCLES(count<<CYC_MOVEM_L);
+}
+
+
+M68KMAKE_OP(movem, 32, re, .)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			m68ki_write_32(ea, REG_DA[i]);
+			ea += 4;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_L);
+}
+
+
+M68KMAKE_OP(movem, 16, er, pi)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = AY;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_16(ea)));
+			ea += 2;
+			count++;
+		}
+	AY = ea;
+
+	USE_CYCLES(count<<CYC_MOVEM_W);
+}
+
+
+M68KMAKE_OP(movem, 16, er, pcdi)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = EA_PCDI_16();
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_pcrel_16(ea)));
+			ea += 2;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_W);
+}
+
+
+M68KMAKE_OP(movem, 16, er, pcix)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = EA_PCIX_16();
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_pcrel_16(ea)));
+			ea += 2;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_W);
+}
+
+
+M68KMAKE_OP(movem, 16, er, .)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = MAKE_INT_16(MASK_OUT_ABOVE_16(m68ki_read_16(ea)));
+			ea += 2;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_W);
+}
+
+
+M68KMAKE_OP(movem, 32, er, pi)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = AY;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = m68ki_read_32(ea);
+			ea += 4;
+			count++;
+		}
+	AY = ea;
+
+	USE_CYCLES(count<<CYC_MOVEM_L);
+}
+
+
+M68KMAKE_OP(movem, 32, er, pcdi)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = EA_PCDI_32();
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = m68ki_read_pcrel_32(ea);
+			ea += 4;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_L);
+}
+
+
+M68KMAKE_OP(movem, 32, er, pcix)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = EA_PCIX_32();
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = m68ki_read_pcrel_32(ea);
+			ea += 4;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_L);
+}
+
+
+M68KMAKE_OP(movem, 32, er, .)
+{
+	uint i = 0;
+	uint register_list = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint count = 0;
+
+	for(; i < 16; i++)
+		if(register_list & (1 << i))
+		{
+			REG_DA[i] = m68ki_read_32(ea);
+			ea += 4;
+			count++;
+		}
+
+	USE_CYCLES(count<<CYC_MOVEM_L);
+}
+
+
+M68KMAKE_OP(movep, 16, re, .)
+{
+	uint ea = EA_AY_DI_16();
+	uint src = DX;
+
+	m68ki_write_8(ea, MASK_OUT_ABOVE_8(src >> 8));
+	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src));
+}
+
+
+M68KMAKE_OP(movep, 32, re, .)
+{
+	uint ea = EA_AY_DI_32();
+	uint src = DX;
+
+	m68ki_write_8(ea, MASK_OUT_ABOVE_8(src >> 24));
+	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src >> 16));
+	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src >> 8));
+	m68ki_write_8(ea += 2, MASK_OUT_ABOVE_8(src));
+}
+
+
+M68KMAKE_OP(movep, 16, er, .)
+{
+	uint ea = EA_AY_DI_16();
+	uint* r_dst = &DX;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | ((m68ki_read_8(ea) << 8) + m68ki_read_8(ea + 2));
+}
+
+
+M68KMAKE_OP(movep, 32, er, .)
+{
+	uint ea = EA_AY_DI_32();
+
+	DX = (m68ki_read_8(ea) << 24) + (m68ki_read_8(ea + 2) << 16)
+		+ (m68ki_read_8(ea + 4) << 8) + m68ki_read_8(ea + 6);
+}
+
+
+M68KMAKE_OP(moves, 8, ., .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		if(FLAG_S)
+		{
+			uint word2 = OPER_I_16();
+			uint ea = M68KMAKE_GET_EA_AY_8;
+
+			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+			if(BIT_B(word2))		   /* Register to memory */
+			{
+				m68ki_write_8_fc(ea, REG_DFC, MASK_OUT_ABOVE_8(REG_DA[(word2 >> 12) & 15]));
+				return;
+			}
+			if(BIT_F(word2))		   /* Memory to address register */
+			{
+				REG_A[(word2 >> 12) & 7] = MAKE_INT_8(m68ki_read_8_fc(ea, REG_SFC));
+				if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+					USE_CYCLES(2);
+				return;
+			}
+			/* Memory to data register */
+			REG_D[(word2 >> 12) & 7] = MASK_OUT_BELOW_8(REG_D[(word2 >> 12) & 7]) | m68ki_read_8_fc(ea, REG_SFC);
+			if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+				USE_CYCLES(2);
+			return;
+		}
+		m68ki_exception_privilege_violation();
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(moves, 16, ., .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		if(FLAG_S)
+		{
+			uint word2 = OPER_I_16();
+			uint ea = M68KMAKE_GET_EA_AY_16;
+
+			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+			if(BIT_B(word2))		   /* Register to memory */
+			{
+				m68ki_write_16_fc(ea, REG_DFC, MASK_OUT_ABOVE_16(REG_DA[(word2 >> 12) & 15]));
+				return;
+			}
+			if(BIT_F(word2))		   /* Memory to address register */
+			{
+				REG_A[(word2 >> 12) & 7] = MAKE_INT_16(m68ki_read_16_fc(ea, REG_SFC));
+				if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+					USE_CYCLES(2);
+				return;
+			}
+			/* Memory to data register */
+			REG_D[(word2 >> 12) & 7] = MASK_OUT_BELOW_16(REG_D[(word2 >> 12) & 7]) | m68ki_read_16_fc(ea, REG_SFC);
+			if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+				USE_CYCLES(2);
+			return;
+		}
+		m68ki_exception_privilege_violation();
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(moves, 32, ., .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		if(FLAG_S)
+		{
+			uint word2 = OPER_I_16();
+			uint ea = M68KMAKE_GET_EA_AY_32;
+
+			m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+			if(BIT_B(word2))		   /* Register to memory */
+			{
+				m68ki_write_32_fc(ea, REG_DFC, REG_DA[(word2 >> 12) & 15]);
+				if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+					USE_CYCLES(2);
+				return;
+			}
+			/* Memory to register */
+			REG_DA[(word2 >> 12) & 15] = m68ki_read_32_fc(ea, REG_SFC);
+			if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+				USE_CYCLES(2);
+			return;
+		}
+		m68ki_exception_privilege_violation();
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(moveq, 32, ., .)
+{
+	uint res = DX = MAKE_INT_8(MASK_OUT_ABOVE_8(REG_IR));
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(muls, 16, ., d)
+{
+	uint* r_dst = &DX;
+	uint res = MASK_OUT_ABOVE_32(MAKE_INT_16(DY) * MAKE_INT_16(MASK_OUT_ABOVE_16(*r_dst)));
+
+	*r_dst = res;
+
+	FLAG_Z = res;
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(muls, 16, ., .)
+{
+	uint* r_dst = &DX;
+	uint res = MASK_OUT_ABOVE_32(MAKE_INT_16(M68KMAKE_GET_OPER_AY_16) * MAKE_INT_16(MASK_OUT_ABOVE_16(*r_dst)));
+
+	*r_dst = res;
+
+	FLAG_Z = res;
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(mulu, 16, ., d)
+{
+	uint* r_dst = &DX;
+	uint res = MASK_OUT_ABOVE_16(DY) * MASK_OUT_ABOVE_16(*r_dst);
+
+	*r_dst = res;
+
+	FLAG_Z = res;
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(mulu, 16, ., .)
+{
+	uint* r_dst = &DX;
+	uint res = M68KMAKE_GET_OPER_AY_16 * MASK_OUT_ABOVE_16(*r_dst);
+
+	*r_dst = res;
+
+	FLAG_Z = res;
+	FLAG_N = NFLAG_32(res);
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(mull, 32, ., d)
+{
+#if M68K_USE_64_BIT
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint64 src = DY;
+		uint64 dst = REG_D[(word2 >> 12) & 7];
+		uint64 res;
+
+		FLAG_C = CFLAG_CLEAR;
+
+		if(BIT_B(word2))			   /* signed */
+		{
+			res = (sint64)((sint32)src) * (sint64)((sint32)dst);
+			if(!BIT_A(word2))
+			{
+				FLAG_Z = MASK_OUT_ABOVE_32(res);
+				FLAG_N = NFLAG_32(res);
+				FLAG_V = ((sint64)res != (sint32)res)<<7;
+				REG_D[(word2 >> 12) & 7] = FLAG_Z;
+				return;
+			}
+			FLAG_Z = MASK_OUT_ABOVE_32(res) | (res>>32);
+			FLAG_N = NFLAG_64(res);
+			FLAG_V = VFLAG_CLEAR;
+			REG_D[word2 & 7] = (res >> 32);
+			REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(res);
+			return;
+		}
+
+		res = src * dst;
+		if(!BIT_A(word2))
+		{
+			FLAG_Z = MASK_OUT_ABOVE_32(res);
+			FLAG_N = NFLAG_32(res);
+			FLAG_V = (res > 0xffffffff)<<7;
+			REG_D[(word2 >> 12) & 7] = FLAG_Z;
+			return;
+		}
+		FLAG_Z = MASK_OUT_ABOVE_32(res) | (res>>32);
+		FLAG_N = NFLAG_64(res);
+		FLAG_V = VFLAG_CLEAR;
+		REG_D[word2 & 7] = (res >> 32);
+		REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(res);
+		return;
+	}
+	m68ki_exception_illegal();
+
+#else
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint src = DY;
+		uint dst = REG_D[(word2 >> 12) & 7];
+		uint neg = GET_MSB_32(src ^ dst);
+		uint src1;
+		uint src2;
+		uint dst1;
+		uint dst2;
+		uint r1;
+		uint r2;
+		uint r3;
+		uint r4;
+		uint lo;
+		uint hi;
+
+		FLAG_C = CFLAG_CLEAR;
+
+		if(BIT_B(word2))			   /* signed */
+		{
+			if(GET_MSB_32(src))
+				src = (uint)MASK_OUT_ABOVE_32(-(sint)src);
+			if(GET_MSB_32(dst))
+				dst = (uint)MASK_OUT_ABOVE_32(-(sint)dst);
+		}
+
+		src1 = MASK_OUT_ABOVE_16(src);
+		src2 = src>>16;
+		dst1 = MASK_OUT_ABOVE_16(dst);
+		dst2 = dst>>16;
+
+
+		r1 = src1 * dst1;
+		r2 = src1 * dst2;
+		r3 = src2 * dst1;
+		r4 = src2 * dst2;
+
+		lo = r1 + (MASK_OUT_ABOVE_16(r2)<<16) + (MASK_OUT_ABOVE_16(r3)<<16);
+		hi = r4 + (r2>>16) + (r3>>16) + (((r1>>16) + MASK_OUT_ABOVE_16(r2) + MASK_OUT_ABOVE_16(r3)) >> 16);
+
+		if(BIT_B(word2) && neg)
+		{
+			hi = (uint)MASK_OUT_ABOVE_32((-(sint)hi) - (lo != 0));
+			lo = (uint)MASK_OUT_ABOVE_32(-(sint)lo);
+		}
+
+		if(BIT_A(word2))
+		{
+			REG_D[word2 & 7] = hi;
+			REG_D[(word2 >> 12) & 7] = lo;
+			FLAG_N = NFLAG_32(hi);
+			FLAG_Z = hi | lo;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		REG_D[(word2 >> 12) & 7] = lo;
+		FLAG_N = NFLAG_32(lo);
+		FLAG_Z = lo;
+		if(BIT_B(word2))
+			FLAG_V = (!((GET_MSB_32(lo) && hi == 0xffffffff) || (!GET_MSB_32(lo) && !hi)))<<7;
+		else
+			FLAG_V = (hi != 0) << 7;
+		return;
+	}
+	m68ki_exception_illegal();
+
+#endif
+}
+
+
+M68KMAKE_OP(mull, 32, ., .)
+{
+#if M68K_USE_64_BIT
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint64 src = M68KMAKE_GET_OPER_AY_32;
+		uint64 dst = REG_D[(word2 >> 12) & 7];
+		uint64 res;
+
+		FLAG_C = CFLAG_CLEAR;
+
+		if(BIT_B(word2))			   /* signed */
+		{
+			res = (sint64)((sint32)src) * (sint64)((sint32)dst);
+			if(!BIT_A(word2))
+			{
+				FLAG_Z = MASK_OUT_ABOVE_32(res);
+				FLAG_N = NFLAG_32(res);
+				FLAG_V = ((sint64)res != (sint32)res)<<7;
+				REG_D[(word2 >> 12) & 7] = FLAG_Z;
+				return;
+			}
+			FLAG_Z = MASK_OUT_ABOVE_32(res) | (res>>32);
+			FLAG_N = NFLAG_64(res);
+			FLAG_V = VFLAG_CLEAR;
+			REG_D[word2 & 7] = (res >> 32);
+			REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(res);
+			return;
+		}
+
+		res = src * dst;
+		if(!BIT_A(word2))
+		{
+			FLAG_Z = MASK_OUT_ABOVE_32(res);
+			FLAG_N = NFLAG_32(res);
+			FLAG_V = (res > 0xffffffff)<<7;
+			REG_D[(word2 >> 12) & 7] = FLAG_Z;
+			return;
+		}
+		FLAG_Z = MASK_OUT_ABOVE_32(res) | (res>>32);
+		FLAG_N = NFLAG_64(res);
+		FLAG_V = VFLAG_CLEAR;
+		REG_D[word2 & 7] = (res >> 32);
+		REG_D[(word2 >> 12) & 7] = MASK_OUT_ABOVE_32(res);
+		return;
+	}
+	m68ki_exception_illegal();
+
+#else
+
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint word2 = OPER_I_16();
+		uint src = M68KMAKE_GET_OPER_AY_32;
+		uint dst = REG_D[(word2 >> 12) & 7];
+		uint neg = GET_MSB_32(src ^ dst);
+		uint src1;
+		uint src2;
+		uint dst1;
+		uint dst2;
+		uint r1;
+		uint r2;
+		uint r3;
+		uint r4;
+		uint lo;
+		uint hi;
+
+		FLAG_C = CFLAG_CLEAR;
+
+		if(BIT_B(word2))			   /* signed */
+		{
+			if(GET_MSB_32(src))
+				src = (uint)MASK_OUT_ABOVE_32(-(sint)src);
+			if(GET_MSB_32(dst))
+				dst = (uint)MASK_OUT_ABOVE_32(-(sint)dst);
+		}
+
+		src1 = MASK_OUT_ABOVE_16(src);
+		src2 = src>>16;
+		dst1 = MASK_OUT_ABOVE_16(dst);
+		dst2 = dst>>16;
+
+
+		r1 = src1 * dst1;
+		r2 = src1 * dst2;
+		r3 = src2 * dst1;
+		r4 = src2 * dst2;
+
+		lo = r1 + (MASK_OUT_ABOVE_16(r2)<<16) + (MASK_OUT_ABOVE_16(r3)<<16);
+		hi = r4 + (r2>>16) + (r3>>16) + (((r1>>16) + MASK_OUT_ABOVE_16(r2) + MASK_OUT_ABOVE_16(r3)) >> 16);
+
+		if(BIT_B(word2) && neg)
+		{
+			hi = (uint)MASK_OUT_ABOVE_32((-(sint)hi) - (lo != 0));
+			lo = (uint)MASK_OUT_ABOVE_32(-(sint)lo);
+		}
+
+		if(BIT_A(word2))
+		{
+			REG_D[word2 & 7] = hi;
+			REG_D[(word2 >> 12) & 7] = lo;
+			FLAG_N = NFLAG_32(hi);
+			FLAG_Z = hi | lo;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+
+		REG_D[(word2 >> 12) & 7] = lo;
+		FLAG_N = NFLAG_32(lo);
+		FLAG_Z = lo;
+		if(BIT_B(word2))
+			FLAG_V = (!((GET_MSB_32(lo) && hi == 0xffffffff) || (!GET_MSB_32(lo) && !hi)))<<7;
+		else
+			FLAG_V = (hi != 0) << 7;
+		return;
+	}
+	m68ki_exception_illegal();
+
+#endif
+}
+
+
+M68KMAKE_OP(nbcd, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint dst = *r_dst;
+	uint res = MASK_OUT_ABOVE_8(0x9a - dst - XFLAG_AS_1());
+
+	if(res != 0x9a)
+	{
+		FLAG_V = ~res; /* Undefined V behavior */
+
+		if((res & 0x0f) == 0xa)
+			res = (res & 0xf0) + 0x10;
+
+		res = MASK_OUT_ABOVE_8(res);
+
+		FLAG_V &= res; /* Undefined V behavior part II */
+
+		*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+		FLAG_Z |= res;
+		FLAG_C = CFLAG_SET;
+		FLAG_X = XFLAG_SET;
+	}
+	else
+	{
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_X = XFLAG_CLEAR;
+	}
+	FLAG_N = NFLAG_8(res);	/* Undefined N behavior */
+}
+
+
+M68KMAKE_OP(nbcd, 8, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint dst = m68ki_read_8(ea);
+	uint res = MASK_OUT_ABOVE_8(0x9a - dst - XFLAG_AS_1());
+
+	if(res != 0x9a)
+	{
+		FLAG_V = ~res; /* Undefined V behavior */
+
+		if((res & 0x0f) == 0xa)
+			res = (res & 0xf0) + 0x10;
+
+		res = MASK_OUT_ABOVE_8(res);
+
+		FLAG_V &= res; /* Undefined V behavior part II */
+
+		m68ki_write_8(ea, MASK_OUT_ABOVE_8(res));
+
+		FLAG_Z |= res;
+		FLAG_C = CFLAG_SET;
+		FLAG_X = XFLAG_SET;
+	}
+	else
+	{
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		FLAG_X = XFLAG_CLEAR;
+	}
+	FLAG_N = NFLAG_8(res);	/* Undefined N behavior */
+}
+
+
+M68KMAKE_OP(neg, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = 0 - MASK_OUT_ABOVE_8(*r_dst);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_C = FLAG_X = CFLAG_8(res);
+	FLAG_V = *r_dst & res;
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(neg, 8, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+	uint res = 0 - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_C = FLAG_X = CFLAG_8(res);
+	FLAG_V = src & res;
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(neg, 16, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = 0 - MASK_OUT_ABOVE_16(*r_dst);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_C = FLAG_X = CFLAG_16(res);
+	FLAG_V = (*r_dst & res)>>8;
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(neg, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = 0 - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_C = FLAG_X = CFLAG_16(res);
+	FLAG_V = (src & res)>>8;
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(neg, 32, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = 0 - *r_dst;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_C = FLAG_X = CFLAG_SUB_32(*r_dst, 0, res);
+	FLAG_V = (*r_dst & res)>>24;
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(neg, 32, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint src = m68ki_read_32(ea);
+	uint res = 0 - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_C = FLAG_X = CFLAG_SUB_32(src, 0, res);
+	FLAG_V = (src & res)>>24;
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	m68ki_write_32(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(negx, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = 0 - MASK_OUT_ABOVE_8(*r_dst) - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = *r_dst & res;
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(negx, 8, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = m68ki_read_8(ea);
+	uint res = 0 - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = src & res;
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(negx, 16, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = 0 - MASK_OUT_ABOVE_16(*r_dst) - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = (*r_dst & res)>>8;
+
+	res = MASK_OUT_ABOVE_16(res);
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(negx, 16, ., .)
+{
+	uint ea  = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = 0 - MASK_OUT_ABOVE_16(src) - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = (src & res)>>8;
+
+	res = MASK_OUT_ABOVE_16(res);
+	FLAG_Z |= res;
+
+	m68ki_write_16(ea, res);
+}
+
+
+M68KMAKE_OP(negx, 32, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = 0 - MASK_OUT_ABOVE_32(*r_dst) - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(*r_dst, 0, res);
+	FLAG_V = (*r_dst & res)>>24;
+
+	res = MASK_OUT_ABOVE_32(res);
+	FLAG_Z |= res;
+
+	*r_dst = res;
+}
+
+
+M68KMAKE_OP(negx, 32, ., .)
+{
+	uint ea  = M68KMAKE_GET_EA_AY_32;
+	uint src = m68ki_read_32(ea);
+	uint res = 0 - MASK_OUT_ABOVE_32(src) - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, 0, res);
+	FLAG_V = (src & res)>>24;
+
+	res = MASK_OUT_ABOVE_32(res);
+	FLAG_Z |= res;
+
+	m68ki_write_32(ea, res);
+}
+
+
+M68KMAKE_OP(nop, 0, ., .)
+{
+	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
+}
+
+
+M68KMAKE_OP(not, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = MASK_OUT_ABOVE_8(~*r_dst);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(not, 8, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint res = MASK_OUT_ABOVE_8(~m68ki_read_8(ea));
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(not, 16, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = MASK_OUT_ABOVE_16(~*r_dst);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(not, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint res = MASK_OUT_ABOVE_16(~m68ki_read_16(ea));
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(not, 32, ., d)
+{
+	uint* r_dst = &DY;
+	uint res = *r_dst = MASK_OUT_ABOVE_32(~*r_dst);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(not, 32, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint res = MASK_OUT_ABOVE_32(~m68ki_read_32(ea));
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 8, er, d)
+{
+	uint res = MASK_OUT_ABOVE_8((DX |= MASK_OUT_ABOVE_8(DY)));
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 8, er, .)
+{
+	uint res = MASK_OUT_ABOVE_8((DX |= M68KMAKE_GET_OPER_AY_8));
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 16, er, d)
+{
+	uint res = MASK_OUT_ABOVE_16((DX |= MASK_OUT_ABOVE_16(DY)));
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 16, er, .)
+{
+	uint res = MASK_OUT_ABOVE_16((DX |= M68KMAKE_GET_OPER_AY_16));
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 32, er, d)
+{
+	uint res = DX |= DY;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 32, er, .)
+{
+	uint res = DX |= M68KMAKE_GET_OPER_AY_32;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 8, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint res = MASK_OUT_ABOVE_8(DX | m68ki_read_8(ea));
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 16, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint res = MASK_OUT_ABOVE_16(DX | m68ki_read_16(ea));
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(or, 32, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint res = DX | m68ki_read_32(ea);
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ori, 8, ., d)
+{
+	uint res = MASK_OUT_ABOVE_8((DY |= OPER_I_8()));
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ori, 8, ., .)
+{
+	uint src = OPER_I_8();
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint res = MASK_OUT_ABOVE_8(src | m68ki_read_8(ea));
+
+	m68ki_write_8(ea, res);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ori, 16, ., d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY |= OPER_I_16());
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ori, 16, ., .)
+{
+	uint src = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint res = MASK_OUT_ABOVE_16(src | m68ki_read_16(ea));
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ori, 32, ., d)
+{
+	uint res = DY |= OPER_I_32();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ori, 32, ., .)
+{
+	uint src = OPER_I_32();
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint res = src | m68ki_read_32(ea);
+
+	m68ki_write_32(ea, res);
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ori, 16, toc, .)
+{
+	m68ki_set_ccr(m68ki_get_ccr() | OPER_I_16());
+}
+
+
+M68KMAKE_OP(ori, 16, tos, .)
+{
+	if(FLAG_S)
+	{
+		uint src = OPER_I_16();
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		m68ki_set_sr(m68ki_get_sr() | src);
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(pack, 16, rr, .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: DX and DY are reversed in Motorola's docs */
+		uint src = DY + OPER_I_16();
+		uint* r_dst = &DX;
+
+		*r_dst = MASK_OUT_BELOW_8(*r_dst) | ((src >> 4) & 0x00f0) | (src & 0x000f);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(pack, 16, mm, ax7)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: AX and AY are reversed in Motorola's docs */
+		uint ea_src = EA_AY_PD_8();
+		uint src = m68ki_read_8(ea_src);
+		ea_src = EA_AY_PD_8();
+		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+
+		m68ki_write_8(EA_A7_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(pack, 16, mm, ay7)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: AX and AY are reversed in Motorola's docs */
+		uint ea_src = EA_A7_PD_8();
+		uint src = m68ki_read_8(ea_src);
+		ea_src = EA_A7_PD_8();
+		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+
+		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(pack, 16, mm, axy7)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint ea_src = EA_A7_PD_8();
+		uint src = m68ki_read_8(ea_src);
+		ea_src = EA_A7_PD_8();
+		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+
+		m68ki_write_8(EA_A7_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(pack, 16, mm, .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: AX and AY are reversed in Motorola's docs */
+		uint ea_src = EA_AY_PD_8();
+		uint src = m68ki_read_8(ea_src);
+		ea_src = EA_AY_PD_8();
+		src = ((src << 8) | m68ki_read_8(ea_src)) + OPER_I_16();
+
+		m68ki_write_8(EA_AX_PD_8(), ((src >> 4) & 0x00f0) | (src & 0x000f));
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(pea, 32, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+
+	m68ki_push_32(ea);
+}
+
+
+M68KMAKE_OP(reset, 0, ., .)
+{
+	if(FLAG_S)
+	{
+		m68ki_output_reset();		   /* auto-disable (see m68kcpu.h) */
+		USE_CYCLES(CYC_RESET);
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(ror, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint shift = orig_shift & 7;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = ROR_8(src, shift);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = src << (9-orig_shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ror, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = ROR_16(src, shift);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = src << (9-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ror, 32, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint64 src = *r_dst;
+	uint res = ROR_32(src, shift);
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = src << (9-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ror, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift & 7;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = ROR_8(src, shift);
+
+	if(orig_shift != 0)
+	{
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+		FLAG_C = src << (8-((shift-1)&7));
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_8(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ror, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift & 15;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = ROR_16(src, shift);
+
+	if(orig_shift != 0)
+	{
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+		FLAG_C = (src >> ((shift - 1) & 15)) << 8;
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_16(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ror, 32, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift & 31;
+	uint64 src = *r_dst;
+	uint res = ROR_32(src, shift);
+
+	if(orig_shift != 0)
+	{
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		*r_dst = res;
+		FLAG_C = (src >> ((shift - 1) & 31)) << 8;
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_32(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(ror, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = ROR_16(src, 1);
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = src << 8;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rol, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint shift = orig_shift & 7;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = ROL_8(src, shift);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_C = src << orig_shift;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rol, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = ROL_16(src, shift);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = src >> (8-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rol, 32, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint64 src = *r_dst;
+	uint res = ROL_32(src, shift);
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_C = src >> (24-shift);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rol, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift & 7;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = ROL_8(src, shift);
+
+	if(orig_shift != 0)
+	{
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		if(shift != 0)
+		{
+			*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+			FLAG_C = src << shift;
+			FLAG_N = NFLAG_8(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+		FLAG_C = (src & 1)<<8;
+		FLAG_N = NFLAG_8(src);
+		FLAG_Z = src;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_8(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rol, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift & 15;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = MASK_OUT_ABOVE_16(ROL_16(src, shift));
+
+	if(orig_shift != 0)
+	{
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		if(shift != 0)
+		{
+			*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+			FLAG_C = (src << shift) >> 8;
+			FLAG_N = NFLAG_16(res);
+			FLAG_Z = res;
+			FLAG_V = VFLAG_CLEAR;
+			return;
+		}
+		FLAG_C = (src & 1)<<8;
+		FLAG_N = NFLAG_16(src);
+		FLAG_Z = src;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_16(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rol, 32, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift & 31;
+	uint64 src = *r_dst;
+	uint res = ROL_32(src, shift);
+
+	if(orig_shift != 0)
+	{
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		*r_dst = res;
+
+		FLAG_C = (src >> (32 - shift)) << 8;
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_N = NFLAG_32(src);
+	FLAG_Z = src;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rol, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = MASK_OUT_ABOVE_16(ROL_16(src, 1));
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_C = src >> 7;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxr, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = ROR_9(src | (XFLAG_AS_1() << 8), shift);
+
+	FLAG_C = FLAG_X = res;
+	res = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxr, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = ROR_17(src | (XFLAG_AS_1() << 16), shift);
+
+	FLAG_C = FLAG_X = res >> 8;
+	res = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxr, 32, s, .)
+{
+#if M68K_USE_64_BIT
+
+	uint*  r_dst = &DY;
+	uint   shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint64 src   = *r_dst;
+	uint64 res   = src | (((uint64)XFLAG_AS_1()) << 32);
+
+	res = ROR_33_64(res, shift);
+
+	FLAG_C = FLAG_X = res >> 24;
+	res = MASK_OUT_ABOVE_32(res);
+
+	*r_dst =  res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+
+#else
+
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32((ROR_33(src, shift) & ~(1 << (32 - shift))) | (XFLAG_AS_1() << (32 - shift)));
+	uint new_x_flag = src & (1 << (shift - 1));
+
+	*r_dst = res;
+
+	FLAG_C = FLAG_X = (new_x_flag != 0)<<8;
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+
+#endif
+}
+
+
+M68KMAKE_OP(roxr, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+
+	if(orig_shift != 0)
+	{
+		uint shift = orig_shift % 9;
+		uint src   = MASK_OUT_ABOVE_8(*r_dst);
+		uint res   = ROR_9(src | (XFLAG_AS_1() << 8), shift);
+
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		FLAG_C = FLAG_X = res;
+		res = MASK_OUT_ABOVE_8(res);
+
+		*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_8(*r_dst);
+	FLAG_Z = MASK_OUT_ABOVE_8(*r_dst);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxr, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+
+	if(orig_shift != 0)
+	{
+		uint shift = orig_shift % 17;
+		uint src   = MASK_OUT_ABOVE_16(*r_dst);
+		uint res   = ROR_17(src | (XFLAG_AS_1() << 16), shift);
+
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		FLAG_C = FLAG_X = res >> 8;
+		res = MASK_OUT_ABOVE_16(res);
+
+		*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_16(*r_dst);
+	FLAG_Z = MASK_OUT_ABOVE_16(*r_dst);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxr, 32, r, .)
+{
+#if M68K_USE_64_BIT
+
+	uint*  r_dst = &DY;
+	uint   orig_shift = DX & 0x3f;
+
+	if(orig_shift != 0)
+	{
+		uint   shift = orig_shift % 33;
+		uint64 src   = *r_dst;
+		uint64 res   = src | (((uint64)XFLAG_AS_1()) << 32);
+
+		res = ROR_33_64(res, shift);
+
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		FLAG_C = FLAG_X = res >> 24;
+		res = MASK_OUT_ABOVE_32(res);
+
+		*r_dst = res;
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_32(*r_dst);
+	FLAG_Z = *r_dst;
+	FLAG_V = VFLAG_CLEAR;
+
+#else
+
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift % 33;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32((ROR_33(src, shift) & ~(1 << (32 - shift))) | (XFLAG_AS_1() << (32 - shift)));
+	uint new_x_flag = src & (1 << (shift - 1));
+
+	if(orig_shift != 0)
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+	if(shift != 0)
+	{
+		*r_dst = res;
+		FLAG_X = (new_x_flag != 0)<<8;
+	}
+	else
+		res = src;
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+
+#endif
+}
+
+
+M68KMAKE_OP(roxr, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = ROR_17(src | (XFLAG_AS_1() << 16), 1);
+
+	FLAG_C = FLAG_X = res >> 8;
+	res = MASK_OUT_ABOVE_16(res);
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxl, 8, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = ROL_9(src | (XFLAG_AS_1() << 8), shift);
+
+	FLAG_C = FLAG_X = res;
+	res = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxl, 16, s, .)
+{
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = ROL_17(src | (XFLAG_AS_1() << 16), shift);
+
+	FLAG_C = FLAG_X = res >> 8;
+	res = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxl, 32, s, .)
+{
+#if M68K_USE_64_BIT
+
+	uint*  r_dst = &DY;
+	uint   shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint64 src   = *r_dst;
+	uint64 res   = src | (((uint64)XFLAG_AS_1()) << 32);
+
+	res = ROL_33_64(res, shift);
+
+	FLAG_C = FLAG_X = res >> 24;
+	res = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = res;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+
+#else
+
+	uint* r_dst = &DY;
+	uint shift = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32((ROL_33(src, shift) & ~(1 << (shift - 1))) | (XFLAG_AS_1() << (shift - 1)));
+	uint new_x_flag = src & (1 << (32 - shift));
+
+	*r_dst = res;
+
+	FLAG_C = FLAG_X = (new_x_flag != 0)<<8;
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+
+#endif
+}
+
+
+M68KMAKE_OP(roxl, 8, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+
+
+	if(orig_shift != 0)
+	{
+		uint shift = orig_shift % 9;
+		uint src   = MASK_OUT_ABOVE_8(*r_dst);
+		uint res   = ROL_9(src | (XFLAG_AS_1() << 8), shift);
+
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		FLAG_C = FLAG_X = res;
+		res = MASK_OUT_ABOVE_8(res);
+
+		*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_8(*r_dst);
+	FLAG_Z = MASK_OUT_ABOVE_8(*r_dst);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxl, 16, r, .)
+{
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+
+	if(orig_shift != 0)
+	{
+		uint shift = orig_shift % 17;
+		uint src   = MASK_OUT_ABOVE_16(*r_dst);
+		uint res   = ROL_17(src | (XFLAG_AS_1() << 16), shift);
+
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		FLAG_C = FLAG_X = res >> 8;
+		res = MASK_OUT_ABOVE_16(res);
+
+		*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_16(*r_dst);
+	FLAG_Z = MASK_OUT_ABOVE_16(*r_dst);
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(roxl, 32, r, .)
+{
+#if M68K_USE_64_BIT
+
+	uint*  r_dst = &DY;
+	uint   orig_shift = DX & 0x3f;
+
+	if(orig_shift != 0)
+	{
+		uint   shift = orig_shift % 33;
+		uint64 src   = *r_dst;
+		uint64 res   = src | (((uint64)XFLAG_AS_1()) << 32);
+
+		res = ROL_33_64(res, shift);
+
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+		FLAG_C = FLAG_X = res >> 24;
+		res = MASK_OUT_ABOVE_32(res);
+
+		*r_dst = res;
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		return;
+	}
+
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_32(*r_dst);
+	FLAG_Z = *r_dst;
+	FLAG_V = VFLAG_CLEAR;
+
+#else
+
+	uint* r_dst = &DY;
+	uint orig_shift = DX & 0x3f;
+	uint shift = orig_shift % 33;
+	uint src = *r_dst;
+	uint res = MASK_OUT_ABOVE_32((ROL_33(src, shift) & ~(1 << (shift - 1))) | (XFLAG_AS_1() << (shift - 1)));
+	uint new_x_flag = src & (1 << (32 - shift));
+
+	if(orig_shift != 0)
+		USE_CYCLES(orig_shift<<CYC_SHIFT);
+
+	if(shift != 0)
+	{
+		*r_dst = res;
+		FLAG_X = (new_x_flag != 0)<<8;
+	}
+	else
+		res = src;
+	FLAG_C = FLAG_X;
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+
+#endif
+}
+
+
+M68KMAKE_OP(roxl, 16, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = m68ki_read_16(ea);
+	uint res = ROL_17(src | (XFLAG_AS_1() << 16), 1);
+
+	FLAG_C = FLAG_X = res >> 8;
+	res = MASK_OUT_ABOVE_16(res);
+
+	m68ki_write_16(ea, res);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(rtd, 32, ., .)
+{
+	if(CPU_TYPE_IS_010_PLUS(CPU_TYPE))
+	{
+		uint new_pc = m68ki_pull_32();
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		REG_A[7] = MASK_OUT_ABOVE_32(REG_A[7] + MAKE_INT_16(OPER_I_16()));
+		m68ki_jump(new_pc);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(rte, 32, ., .)
+{
+	if(FLAG_S)
+	{
+		uint new_sr;
+		uint new_pc;
+		uint format_word;
+
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+
+		if(CPU_TYPE_IS_000(CPU_TYPE))
+		{
+			new_sr = m68ki_pull_16();
+			new_pc = m68ki_pull_32();
+			m68ki_jump(new_pc);
+			m68ki_set_sr(new_sr);
+
+			CPU_INSTR_MODE = INSTRUCTION_YES;
+			CPU_RUN_MODE = RUN_MODE_NORMAL;
+
+			return;
+		}
+
+		if(CPU_TYPE_IS_010(CPU_TYPE))
+		{
+			format_word = m68ki_read_16(REG_A[7]+6) >> 12;
+			if(format_word == 0)
+			{
+				new_sr = m68ki_pull_16();
+				new_pc = m68ki_pull_32();
+				m68ki_fake_pull_16();	/* format word */
+				m68ki_jump(new_pc);
+				m68ki_set_sr(new_sr);
+				CPU_INSTR_MODE = INSTRUCTION_YES;
+				CPU_RUN_MODE = RUN_MODE_NORMAL;
+				return;
+			}
+			CPU_INSTR_MODE = INSTRUCTION_YES;
+			CPU_RUN_MODE = RUN_MODE_NORMAL;
+			/* Not handling bus fault (9) */
+			m68ki_exception_format_error();
+			return;
+		}
+
+		/* Otherwise it's 020 */
+rte_loop:
+		format_word = m68ki_read_16(REG_A[7]+6) >> 12;
+		switch(format_word)
+		{
+			case 0: /* Normal */
+				new_sr = m68ki_pull_16();
+				new_pc = m68ki_pull_32();
+				m68ki_fake_pull_16();	/* format word */
+				m68ki_jump(new_pc);
+				m68ki_set_sr(new_sr);
+				CPU_INSTR_MODE = INSTRUCTION_YES;
+				CPU_RUN_MODE = RUN_MODE_NORMAL;
+				return;
+			case 1: /* Throwaway */
+				new_sr = m68ki_pull_16();
+				m68ki_fake_pull_32();	/* program counter */
+				m68ki_fake_pull_16();	/* format word */
+				m68ki_set_sr_noint(new_sr);
+				goto rte_loop;
+			case 2: /* Trap */
+				new_sr = m68ki_pull_16();
+				new_pc = m68ki_pull_32();
+				m68ki_fake_pull_16();	/* format word */
+				m68ki_fake_pull_32();	/* address */
+				m68ki_jump(new_pc);
+				m68ki_set_sr(new_sr);
+				CPU_INSTR_MODE = INSTRUCTION_YES;
+				CPU_RUN_MODE = RUN_MODE_NORMAL;
+				return;
+		}
+		/* Not handling long or short bus fault */
+		CPU_INSTR_MODE = INSTRUCTION_YES;
+		CPU_RUN_MODE = RUN_MODE_NORMAL;
+		m68ki_exception_format_error();
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(rtm, 32, ., .)
+{
+	if(CPU_TYPE_IS_020_VARIANT(CPU_TYPE))
+	{
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: called unimplemented instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC - 2), REG_IR,
+					 m68k_disassemble_quick(ADDRESS_68K(REG_PC - 2))));
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(rtr, 32, ., .)
+{
+	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
+	m68ki_set_ccr(m68ki_pull_16());
+	m68ki_jump(m68ki_pull_32());
+}
+
+
+M68KMAKE_OP(rts, 32, ., .)
+{
+	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
+	m68ki_jump(m68ki_pull_32());
+}
+
+
+M68KMAKE_OP(sbcd, 8, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = DY;
+	uint dst = *r_dst;
+	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res -= 6;
+	res += HIGH_NIBBLE(dst) - HIGH_NIBBLE(src);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res += 0xa0;
+
+	res = MASK_OUT_ABOVE_8(res);
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(sbcd, 8, mm, ax7)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res -= 6;
+	res += HIGH_NIBBLE(dst) - HIGH_NIBBLE(src);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res += 0xa0;
+
+	res = MASK_OUT_ABOVE_8(res);
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(sbcd, 8, mm, ay7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res -= 6;
+	res += HIGH_NIBBLE(dst) - HIGH_NIBBLE(src);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res += 0xa0;
+
+	res = MASK_OUT_ABOVE_8(res);
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(sbcd, 8, mm, axy7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res -= 6;
+	res += HIGH_NIBBLE(dst) - HIGH_NIBBLE(src);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res += 0xa0;
+
+	res = MASK_OUT_ABOVE_8(res);
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(sbcd, 8, mm, .)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = LOW_NIBBLE(dst) - LOW_NIBBLE(src) - XFLAG_AS_1();
+
+	FLAG_V = ~res; /* Undefined V behavior */
+
+	if(res > 9)
+		res -= 6;
+	res += HIGH_NIBBLE(dst) - HIGH_NIBBLE(src);
+	FLAG_X = FLAG_C = (res > 0x99) << 8;
+	if(FLAG_C)
+		res += 0xa0;
+
+	res = MASK_OUT_ABOVE_8(res);
+
+	FLAG_V &= res; /* Undefined V behavior part II */
+	FLAG_N = NFLAG_8(res); /* Undefined N behavior */
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(st, 8, ., d)
+{
+	DY |= 0xff;
+}
+
+
+M68KMAKE_OP(st, 8, ., .)
+{
+	m68ki_write_8(M68KMAKE_GET_EA_AY_8, 0xff);
+}
+
+
+M68KMAKE_OP(sf, 8, ., d)
+{
+	DY &= 0xffffff00;
+}
+
+
+M68KMAKE_OP(sf, 8, ., .)
+{
+	m68ki_write_8(M68KMAKE_GET_EA_AY_8, 0);
+}
+
+
+M68KMAKE_OP(scc, 8, ., d)
+{
+	if(M68KMAKE_CC)
+	{
+		DY |= 0xff;
+		USE_CYCLES(CYC_SCC_R_TRUE);
+		return;
+	}
+	DY &= 0xffffff00;
+}
+
+
+M68KMAKE_OP(scc, 8, ., .)
+{
+	m68ki_write_8(M68KMAKE_GET_EA_AY_8, M68KMAKE_CC ? 0xff : 0);
+}
+
+
+M68KMAKE_OP(stop, 0, ., .)
+{
+	if(FLAG_S)
+	{
+		uint new_sr = OPER_I_16();
+		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
+		CPU_STOPPED |= STOP_LEVEL_STOP;
+		m68ki_set_sr(new_sr);
+		m68ki_remaining_cycles = 0;
+		return;
+	}
+	m68ki_exception_privilege_violation();
+}
+
+
+M68KMAKE_OP(sub, 8, er, d)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_8(DY);
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 8, er, .)
+{
+	uint* r_dst = &DX;
+	uint src = M68KMAKE_GET_OPER_AY_8;
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 16, er, d)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_16(DY);
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 16, er, a)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_16(AY);
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 16, er, .)
+{
+	uint* r_dst = &DX;
+	uint src = M68KMAKE_GET_OPER_AY_16;
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 32, er, d)
+{
+	uint* r_dst = &DX;
+	uint src = DY;
+	uint dst = *r_dst;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 32, er, a)
+{
+	uint* r_dst = &DX;
+	uint src = AY;
+	uint dst = *r_dst;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 32, er, .)
+{
+	uint* r_dst = &DX;
+	uint src = M68KMAKE_GET_OPER_AY_32;
+	uint dst = *r_dst;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(sub, 8, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint src = MASK_OUT_ABOVE_8(DX);
+	uint dst = m68ki_read_8(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(sub, 16, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint src = MASK_OUT_ABOVE_16(DX);
+	uint dst = m68ki_read_16(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(sub, 32, re, .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint src = DX;
+	uint dst = m68ki_read_32(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+
+	m68ki_write_32(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(suba, 16, ., d)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - MAKE_INT_16(DY));
+}
+
+
+M68KMAKE_OP(suba, 16, ., a)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - MAKE_INT_16(AY));
+}
+
+
+M68KMAKE_OP(suba, 16, ., .)
+{
+	signed short src = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - src);
+}
+
+
+M68KMAKE_OP(suba, 32, ., d)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - DY);
+}
+
+
+M68KMAKE_OP(suba, 32, ., a)
+{
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - AY);
+}
+
+
+M68KMAKE_OP(suba, 32, ., .)
+{
+	uint src = M68KMAKE_GET_OPER_AY_32;
+	uint* r_dst = &AX;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - src);
+}
+
+
+M68KMAKE_OP(subi, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = OPER_I_8();
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(subi, 8, ., .)
+{
+	uint src = OPER_I_8();
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint dst = m68ki_read_8(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(subi, 16, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = OPER_I_16();
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(subi, 16, ., .)
+{
+	uint src = OPER_I_16();
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint dst = m68ki_read_16(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(subi, 32, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = OPER_I_32();
+	uint dst = *r_dst;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(subi, 32, ., .)
+{
+	uint src = OPER_I_32();
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint dst = m68ki_read_32(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+
+	m68ki_write_32(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(subq, 8, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(subq, 8, ., .)
+{
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint dst = m68ki_read_8(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = MASK_OUT_ABOVE_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	m68ki_write_8(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(subq, 16, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | FLAG_Z;
+}
+
+
+M68KMAKE_OP(subq, 16, ., a)
+{
+	uint* r_dst = &AY;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - ((((REG_IR >> 9) - 1) & 7) + 1));
+}
+
+
+M68KMAKE_OP(subq, 16, ., .)
+{
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint ea = M68KMAKE_GET_EA_AY_16;
+	uint dst = m68ki_read_16(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = MASK_OUT_ABOVE_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+
+	m68ki_write_16(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(subq, 32, ., d)
+{
+	uint* r_dst = &DY;
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint dst = *r_dst;
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+
+	*r_dst = FLAG_Z;
+}
+
+
+M68KMAKE_OP(subq, 32, ., a)
+{
+	uint* r_dst = &AY;
+
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - ((((REG_IR >> 9) - 1) & 7) + 1));
+}
+
+
+M68KMAKE_OP(subq, 32, ., .)
+{
+	uint src = (((REG_IR >> 9) - 1) & 7) + 1;
+	uint ea = M68KMAKE_GET_EA_AY_32;
+	uint dst = m68ki_read_32(ea);
+	uint res = dst - src;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = MASK_OUT_ABOVE_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+
+	m68ki_write_32(ea, FLAG_Z);
+}
+
+
+M68KMAKE_OP(subx, 8, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_8(DY);
+	uint dst = MASK_OUT_ABOVE_8(*r_dst);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_8(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(subx, 16, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = MASK_OUT_ABOVE_16(DY);
+	uint dst = MASK_OUT_ABOVE_16(*r_dst);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+
+	res = MASK_OUT_ABOVE_16(res);
+	FLAG_Z |= res;
+
+	*r_dst = MASK_OUT_BELOW_16(*r_dst) | res;
+}
+
+
+M68KMAKE_OP(subx, 32, rr, .)
+{
+	uint* r_dst = &DX;
+	uint src = DY;
+	uint dst = *r_dst;
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+
+	res = MASK_OUT_ABOVE_32(res);
+	FLAG_Z |= res;
+
+	*r_dst = res;
+}
+
+
+M68KMAKE_OP(subx, 8, mm, ax7)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(subx, 8, mm, ay7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(subx, 8, mm, axy7)
+{
+	uint src = OPER_A7_PD_8();
+	uint ea  = EA_A7_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(subx, 8, mm, .)
+{
+	uint src = OPER_AY_PD_8();
+	uint ea  = EA_AX_PD_8();
+	uint dst = m68ki_read_8(ea);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_X = FLAG_C = CFLAG_8(res);
+	FLAG_V = VFLAG_SUB_8(src, dst, res);
+
+	res = MASK_OUT_ABOVE_8(res);
+	FLAG_Z |= res;
+
+	m68ki_write_8(ea, res);
+}
+
+
+M68KMAKE_OP(subx, 16, mm, .)
+{
+	uint src = OPER_AY_PD_16();
+	uint ea  = EA_AX_PD_16();
+	uint dst = m68ki_read_16(ea);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_X = FLAG_C = CFLAG_16(res);
+	FLAG_V = VFLAG_SUB_16(src, dst, res);
+
+	res = MASK_OUT_ABOVE_16(res);
+	FLAG_Z |= res;
+
+	m68ki_write_16(ea, res);
+}
+
+
+M68KMAKE_OP(subx, 32, mm, .)
+{
+	uint src = OPER_AY_PD_32();
+	uint ea  = EA_AX_PD_32();
+	uint dst = m68ki_read_32(ea);
+	uint res = dst - src - XFLAG_AS_1();
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_X = FLAG_C = CFLAG_SUB_32(src, dst, res);
+	FLAG_V = VFLAG_SUB_32(src, dst, res);
+
+	res = MASK_OUT_ABOVE_32(res);
+	FLAG_Z |= res;
+
+	m68ki_write_32(ea, res);
+}
+
+
+M68KMAKE_OP(swap, 32, ., .)
+{
+	uint* r_dst = &DY;
+
+	FLAG_Z = MASK_OUT_ABOVE_32(*r_dst<<16);
+	*r_dst = (*r_dst>>16) | FLAG_Z;
+
+	FLAG_Z = *r_dst;
+	FLAG_N = NFLAG_32(*r_dst);
+	FLAG_C = CFLAG_CLEAR;
+	FLAG_V = VFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(tas, 8, ., d)
+{
+	uint* r_dst = &DY;
+
+	FLAG_Z = MASK_OUT_ABOVE_8(*r_dst);
+	FLAG_N = NFLAG_8(*r_dst);
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	*r_dst |= 0x80;
+}
+
+
+M68KMAKE_OP(tas, 8, ., .)
+{
+	uint ea = M68KMAKE_GET_EA_AY_8;
+	uint dst = m68ki_read_8(ea);
+
+	FLAG_Z = dst;
+	FLAG_N = NFLAG_8(dst);
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+	m68ki_write_8(ea, dst | 0x80);
+}
+
+
+M68KMAKE_OP(trap, 0, ., .)
+{
+	/* Trap#n stacks exception frame type 0 */
+	m68ki_exception_trapN(EXCEPTION_TRAP_BASE + (REG_IR & 0xf));	/* HJB 990403 */
+}
+
+
+M68KMAKE_OP(trapt, 0, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapt, 16, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapt, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapf, 0, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapf, 16, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		REG_PC += 2;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapf, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		REG_PC += 4;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapcc, 0, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		if(M68KMAKE_CC)
+			m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapcc, 16, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		if(M68KMAKE_CC)
+		{
+			m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+			return;
+		}
+		REG_PC += 2;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapcc, 32, ., .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		if(M68KMAKE_CC)
+		{
+			m68ki_exception_trap(EXCEPTION_TRAPV);	/* HJB 990403 */
+			return;
+		}
+		REG_PC += 4;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(trapv, 0, ., .)
+{
+	if(COND_VC())
+	{
+		return;
+	}
+	m68ki_exception_trap(EXCEPTION_TRAPV);  /* HJB 990403 */
+}
+
+
+M68KMAKE_OP(tst, 8, ., d)
+{
+	uint res = MASK_OUT_ABOVE_8(DY);
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(tst, 8, ., .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_8;
+
+	FLAG_N = NFLAG_8(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(tst, 8, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_PCDI_8();
+
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 8, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_PCIX_8();
+
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 8, ., i)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_I_8();
+
+		FLAG_N = NFLAG_8(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 16, ., d)
+{
+	uint res = MASK_OUT_ABOVE_16(DY);
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(tst, 16, ., a)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = MAKE_INT_16(AY);
+
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 16, ., .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_16;
+
+	FLAG_N = NFLAG_16(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(tst, 16, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_PCDI_16();
+
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 16, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_PCIX_16();
+
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 16, ., i)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_I_16();
+
+		FLAG_N = NFLAG_16(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 32, ., d)
+{
+	uint res = DY;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(tst, 32, ., a)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = AY;
+
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 32, ., .)
+{
+	uint res = M68KMAKE_GET_OPER_AY_32;
+
+	FLAG_N = NFLAG_32(res);
+	FLAG_Z = res;
+	FLAG_V = VFLAG_CLEAR;
+	FLAG_C = CFLAG_CLEAR;
+}
+
+
+M68KMAKE_OP(tst, 32, ., pcdi)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_PCDI_32();
+
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 32, ., pcix)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_PCIX_32();
+
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(tst, 32, ., i)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint res = OPER_I_32();
+
+		FLAG_N = NFLAG_32(res);
+		FLAG_Z = res;
+		FLAG_V = VFLAG_CLEAR;
+		FLAG_C = CFLAG_CLEAR;
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(unlk, 32, ., a7)
+{
+	REG_A[7] = m68ki_read_32(REG_A[7]);
+}
+
+
+M68KMAKE_OP(unlk, 32, ., .)
+{
+	uint* r_dst = &AY;
+
+	REG_A[7] = *r_dst;
+	*r_dst = m68ki_pull_32();
+}
+
+
+M68KMAKE_OP(unpk, 16, rr, .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: DX and DY are reversed in Motorola's docs */
+		uint src = DY;
+		uint* r_dst = &DX;
+
+		*r_dst = MASK_OUT_BELOW_16(*r_dst) | (((((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16()) & 0xffff);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(unpk, 16, mm, ax7)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: AX and AY are reversed in Motorola's docs */
+		uint src = OPER_AY_PD_8();
+		uint ea_dst;
+
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		ea_dst = EA_A7_PD_8();
+		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		ea_dst = EA_A7_PD_8();
+		m68ki_write_8(ea_dst, src & 0xff);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(unpk, 16, mm, ay7)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: AX and AY are reversed in Motorola's docs */
+		uint src = OPER_A7_PD_8();
+		uint ea_dst;
+
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		ea_dst = EA_AX_PD_8();
+		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		ea_dst = EA_AX_PD_8();
+		m68ki_write_8(ea_dst, src & 0xff);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(unpk, 16, mm, axy7)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		uint src = OPER_A7_PD_8();
+		uint ea_dst;
+
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		ea_dst = EA_A7_PD_8();
+		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		ea_dst = EA_A7_PD_8();
+		m68ki_write_8(ea_dst, src & 0xff);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+M68KMAKE_OP(unpk, 16, mm, .)
+{
+	if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Note: AX and AY are reversed in Motorola's docs */
+		uint src = OPER_AY_PD_8();
+		uint ea_dst;
+
+		src = (((src << 4) & 0x0f00) | (src & 0x000f)) + OPER_I_16();
+		ea_dst = EA_AX_PD_8();
+		m68ki_write_8(ea_dst, (src >> 8) & 0xff);
+		ea_dst = EA_AX_PD_8();
+		m68ki_write_8(ea_dst, src & 0xff);
+		return;
+	}
+	m68ki_exception_illegal();
+}
+
+
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+M68KMAKE_END

--- a/yabause/src/musashi/m68kconf.h
+++ b/yabause/src/musashi/m68kconf.h
@@ -1,0 +1,190 @@
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.4
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright 1998-2001 Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+
+#ifndef M68KCONF__HEADER
+#define M68KCONF__HEADER
+
+/* Configuration switches.
+ * Use OPT_SPECIFY_HANDLER for configuration options that allow callbacks.
+ * OPT_SPECIFY_HANDLER causes the core to link directly to the function
+ * or macro you specify, rather than using callback functions whose pointer
+ * must be passed in using m68k_set_xxx_callback().
+ */
+#define OPT_OFF             0
+#define OPT_ON              1
+#define OPT_SPECIFY_HANDLER 2
+
+
+/* ======================================================================== */
+/* ============================== MAME STUFF ============================== */
+/* ======================================================================== */
+
+/* If you're compiling this for MAME, only change M68K_COMPILE_FOR_MAME
+ * to OPT_ON and use m68kmame.h to configure the 68k core.
+ */
+#ifndef M68K_COMPILE_FOR_MAME
+#define M68K_COMPILE_FOR_MAME      OPT_OFF
+#endif /* M68K_COMPILE_FOR_MAME */
+
+
+#if M68K_COMPILE_FOR_MAME == OPT_OFF
+
+
+/* ======================================================================== */
+/* ============================= CONFIGURATION ============================ */
+/* ======================================================================== */
+
+/* Turn ON if you want to use the following M68K variants */
+#define M68K_EMULATE_010            OPT_OFF
+#define M68K_EMULATE_EC020          OPT_OFF
+#define M68K_EMULATE_020            OPT_OFF
+
+
+/* If ON, the CPU will call m68k_read_immediate_xx() for immediate addressing
+ * and m68k_read_pcrelative_xx() for PC-relative addressing.
+ * If off, all read requests from the CPU will be redirected to m68k_read_xx()
+ */
+#define M68K_SEPARATE_READS         OPT_OFF
+
+/* If ON, the CPU will call m68k_write_32_pd() when it executes move.l with a
+ * predecrement destination EA mode instead of m68k_write_32().
+ * To simulate real 68k behavior, m68k_write_32_pd() must first write the high
+ * word to [address+2], and then write the low word to [address].
+ */
+#define M68K_SIMULATE_PD_WRITES     OPT_OFF
+
+/* If ON, CPU will call the interrupt acknowledge callback when it services an
+ * interrupt.
+ * If off, all interrupts will be autovectored and all interrupt requests will
+ * auto-clear when the interrupt is serviced.
+ */
+#define M68K_EMULATE_INT_ACK        OPT_OFF
+#define M68K_INT_ACK_CALLBACK(A)    your_int_ack_handler_function(A)
+
+
+/* If ON, CPU will call the breakpoint acknowledge callback when it encounters
+ * a breakpoint instruction and it is running a 68010+.
+ */
+#define M68K_EMULATE_BKPT_ACK       OPT_OFF
+#define M68K_BKPT_ACK_CALLBACK()    your_bkpt_ack_handler_function()
+
+
+/* If ON, the CPU will monitor the trace flags and take trace exceptions
+ */
+#define M68K_EMULATE_TRACE          OPT_OFF
+
+
+/* If ON, CPU will call the output reset callback when it encounters a reset
+ * instruction.
+ */
+#define M68K_EMULATE_RESET          OPT_OFF
+#define M68K_RESET_CALLBACK()       your_reset_handler_function()
+
+
+/* If ON, CPU will call the set fc callback on every memory access to
+ * differentiate between user/supervisor, program/data access like a real
+ * 68000 would.  This should be enabled and the callback should be set if you
+ * want to properly emulate the m68010 or higher. (moves uses function codes
+ * to read/write data from different address spaces)
+ */
+#define M68K_EMULATE_FC             OPT_OFF
+#define M68K_SET_FC_CALLBACK(A)     your_set_fc_handler_function(A)
+
+
+/* If ON, CPU will call the pc changed callback when it changes the PC by a
+ * large value.  This allows host programs to be nicer when it comes to
+ * fetching immediate data and instructions on a banked memory system.
+ */
+#define M68K_MONITOR_PC             OPT_OFF
+#define M68K_SET_PC_CALLBACK(A)     your_pc_changed_handler_function(A)
+
+
+/* If ON, CPU will call the instruction hook callback before every
+ * instruction.
+ */
+#define M68K_INSTRUCTION_HOOK       OPT_OFF
+#define M68K_INSTRUCTION_CALLBACK() your_instruction_hook_function()
+
+
+/* If ON, the CPU will emulate the 4-byte prefetch queue of a real 68000 */
+#define M68K_EMULATE_PREFETCH       OPT_OFF
+
+
+/* If ON, the CPU will generate address error exceptions if it tries to
+ * access a word or longword at an odd address.
+ * NOTE: This is only emulated properly for 68000 mode.
+ */
+#define M68K_EMULATE_ADDRESS_ERROR  OPT_OFF
+
+
+/* Turn ON to enable logging of illegal instruction calls.
+ * M68K_LOG_FILEHANDLE must be #defined to a stdio file stream.
+ * Turn on M68K_LOG_1010_1111 to log all 1010 and 1111 calls.
+ */
+#define M68K_LOG_ENABLE             OPT_OFF
+#define M68K_LOG_1010_1111          OPT_OFF
+#define M68K_LOG_FILEHANDLE         some_file_handle
+
+
+/* ----------------------------- COMPATIBILITY ---------------------------- */
+
+/* The following options set optimizations that violate the current ANSI
+ * standard, but will be compliant under the forthcoming C9X standard.
+ */
+
+
+/* If ON, the enulation core will use 64-bit integers to speed up some
+ * operations.
+*/
+#define M68K_USE_64_BIT  OPT_OFF
+
+
+/* Set to your compiler's static inline keyword to enable it, or
+ * set it to blank to disable it.
+ * If you define INLINE in the makefile, it will override this value.
+ * NOTE: not enabling inline functions will SEVERELY slow down emulation.
+ */
+#ifndef INLINE
+#ifdef _MSC_VER
+#define INLINE _inline
+#else
+#define INLINE static inline
+#endif
+#endif /* INLINE */
+
+#endif /* M68K_COMPILE_FOR_MAME */
+
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */
+
+#endif /* M68KCONF__HEADER */

--- a/yabause/src/musashi/m68kcpu.c
+++ b/yabause/src/musashi/m68kcpu.c
@@ -1,0 +1,882 @@
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.4
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright 1998-2001 Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/* ======================================================================== */
+/* ================================= NOTES ================================ */
+/* ======================================================================== */
+
+
+
+/* ======================================================================== */
+/* ================================ INCLUDES ============================== */
+/* ======================================================================== */
+
+#include "m68kops.h"
+#include "m68kcpu.h"
+
+/* ======================================================================== */
+/* ================================= DATA ================================= */
+/* ======================================================================== */
+
+int  m68ki_initial_cycles;
+int  m68ki_remaining_cycles = 0;                     /* Number of clocks remaining */
+uint m68ki_tracing = 0;
+uint m68ki_address_space;
+
+#ifdef M68K_LOG_ENABLE
+char* m68ki_cpu_names[9] =
+{
+	"Invalid CPU",
+	"M68000",
+	"M68010",
+	"Invalid CPU",
+	"M68EC020"
+	"Invalid CPU",
+	"Invalid CPU",
+	"Invalid CPU",
+	"M68020"
+};
+#endif /* M68K_LOG_ENABLE */
+
+/* The CPU core */
+m68ki_cpu_core m68ki_cpu = {0};
+
+#if M68K_EMULATE_ADDRESS_ERROR
+jmp_buf m68ki_aerr_trap;
+#endif /* M68K_EMULATE_ADDRESS_ERROR */
+
+uint    m68ki_aerr_address;
+uint    m68ki_aerr_write_mode;
+uint    m68ki_aerr_fc;
+
+/* Used by shift & rotate instructions */
+uint8 m68ki_shift_8_table[65] =
+{
+	0x00, 0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0xff, 0xff, 0xff, 0xff, 0xff
+};
+uint16 m68ki_shift_16_table[65] =
+{
+	0x0000, 0x8000, 0xc000, 0xe000, 0xf000, 0xf800, 0xfc00, 0xfe00, 0xff00,
+	0xff80, 0xffc0, 0xffe0, 0xfff0, 0xfff8, 0xfffc, 0xfffe, 0xffff, 0xffff,
+	0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+	0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+	0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+	0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+	0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+	0xffff, 0xffff
+};
+uint m68ki_shift_32_table[65] =
+{
+	0x00000000, 0x80000000, 0xc0000000, 0xe0000000, 0xf0000000, 0xf8000000,
+	0xfc000000, 0xfe000000, 0xff000000, 0xff800000, 0xffc00000, 0xffe00000,
+	0xfff00000, 0xfff80000, 0xfffc0000, 0xfffe0000, 0xffff0000, 0xffff8000,
+	0xffffc000, 0xffffe000, 0xfffff000, 0xfffff800, 0xfffffc00, 0xfffffe00,
+	0xffffff00, 0xffffff80, 0xffffffc0, 0xffffffe0, 0xfffffff0, 0xfffffff8,
+	0xfffffffc, 0xfffffffe, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+	0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
+};
+
+
+/* Number of clock cycles to use for exception processing.
+ * I used 4 for any vectors that are undocumented for processing times.
+ */
+uint8 m68ki_exception_cycle_table[3][256] =
+{
+	{ /* 000 */
+		  4, /*  0: Reset - Initial Stack Pointer                      */
+		  4, /*  1: Reset - Initial Program Counter                    */
+		 50, /*  2: Bus Error                             (unemulated) */
+		 50, /*  3: Address Error                         (unemulated) */
+		 34, /*  4: Illegal Instruction                                */
+		 38, /*  5: Divide by Zero -- ASG: changed from 42             */
+		 40, /*  6: CHK -- ASG: chanaged from 44                       */
+		 34, /*  7: TRAPV                                              */
+		 34, /*  8: Privilege Violation                                */
+		 34, /*  9: Trace                                              */
+		  4, /* 10: 1010                                               */
+		  4, /* 11: 1111                                               */
+		  4, /* 12: RESERVED                                           */
+		  4, /* 13: Coprocessor Protocol Violation        (unemulated) */
+		  4, /* 14: Format Error                                       */
+		 44, /* 15: Uninitialized Interrupt                            */
+		  4, /* 16: RESERVED                                           */
+		  4, /* 17: RESERVED                                           */
+		  4, /* 18: RESERVED                                           */
+		  4, /* 19: RESERVED                                           */
+		  4, /* 20: RESERVED                                           */
+		  4, /* 21: RESERVED                                           */
+		  4, /* 22: RESERVED                                           */
+		  4, /* 23: RESERVED                                           */
+		 44, /* 24: Spurious Interrupt                                 */
+		 44, /* 25: Level 1 Interrupt Autovector                       */
+		 44, /* 26: Level 2 Interrupt Autovector                       */
+		 44, /* 27: Level 3 Interrupt Autovector                       */
+		 44, /* 28: Level 4 Interrupt Autovector                       */
+		 44, /* 29: Level 5 Interrupt Autovector                       */
+		 44, /* 30: Level 6 Interrupt Autovector                       */
+		 44, /* 31: Level 7 Interrupt Autovector                       */
+		 34, /* 32: TRAP #0 -- ASG: chanaged from 38                   */
+		 34, /* 33: TRAP #1                                            */
+		 34, /* 34: TRAP #2                                            */
+		 34, /* 35: TRAP #3                                            */
+		 34, /* 36: TRAP #4                                            */
+		 34, /* 37: TRAP #5                                            */
+		 34, /* 38: TRAP #6                                            */
+		 34, /* 39: TRAP #7                                            */
+		 34, /* 40: TRAP #8                                            */
+		 34, /* 41: TRAP #9                                            */
+		 34, /* 42: TRAP #10                                           */
+		 34, /* 43: TRAP #11                                           */
+		 34, /* 44: TRAP #12                                           */
+		 34, /* 45: TRAP #13                                           */
+		 34, /* 46: TRAP #14                                           */
+		 34, /* 47: TRAP #15                                           */
+		  4, /* 48: FP Branch or Set on Unknown Condition (unemulated) */
+		  4, /* 49: FP Inexact Result                     (unemulated) */
+		  4, /* 50: FP Divide by Zero                     (unemulated) */
+		  4, /* 51: FP Underflow                          (unemulated) */
+		  4, /* 52: FP Operand Error                      (unemulated) */
+		  4, /* 53: FP Overflow                           (unemulated) */
+		  4, /* 54: FP Signaling NAN                      (unemulated) */
+		  4, /* 55: FP Unimplemented Data Type            (unemulated) */
+		  4, /* 56: MMU Configuration Error               (unemulated) */
+		  4, /* 57: MMU Illegal Operation Error           (unemulated) */
+		  4, /* 58: MMU Access Level Violation Error      (unemulated) */
+		  4, /* 59: RESERVED                                           */
+		  4, /* 60: RESERVED                                           */
+		  4, /* 61: RESERVED                                           */
+		  4, /* 62: RESERVED                                           */
+		  4, /* 63: RESERVED                                           */
+		     /* 64-255: User Defined                                   */
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4
+	},
+	{ /* 010 */
+		  4, /*  0: Reset - Initial Stack Pointer                      */
+		  4, /*  1: Reset - Initial Program Counter                    */
+		126, /*  2: Bus Error                             (unemulated) */
+		126, /*  3: Address Error                         (unemulated) */
+		 38, /*  4: Illegal Instruction                                */
+		 44, /*  5: Divide by Zero                                     */
+		 44, /*  6: CHK                                                */
+		 34, /*  7: TRAPV                                              */
+		 38, /*  8: Privilege Violation                                */
+		 38, /*  9: Trace                                              */
+		  4, /* 10: 1010                                               */
+		  4, /* 11: 1111                                               */
+		  4, /* 12: RESERVED                                           */
+		  4, /* 13: Coprocessor Protocol Violation        (unemulated) */
+		  4, /* 14: Format Error                                       */
+		 44, /* 15: Uninitialized Interrupt                            */
+		  4, /* 16: RESERVED                                           */
+		  4, /* 17: RESERVED                                           */
+		  4, /* 18: RESERVED                                           */
+		  4, /* 19: RESERVED                                           */
+		  4, /* 20: RESERVED                                           */
+		  4, /* 21: RESERVED                                           */
+		  4, /* 22: RESERVED                                           */
+		  4, /* 23: RESERVED                                           */
+		 46, /* 24: Spurious Interrupt                                 */
+		 46, /* 25: Level 1 Interrupt Autovector                       */
+		 46, /* 26: Level 2 Interrupt Autovector                       */
+		 46, /* 27: Level 3 Interrupt Autovector                       */
+		 46, /* 28: Level 4 Interrupt Autovector                       */
+		 46, /* 29: Level 5 Interrupt Autovector                       */
+		 46, /* 30: Level 6 Interrupt Autovector                       */
+		 46, /* 31: Level 7 Interrupt Autovector                       */
+		 38, /* 32: TRAP #0                                            */
+		 38, /* 33: TRAP #1                                            */
+		 38, /* 34: TRAP #2                                            */
+		 38, /* 35: TRAP #3                                            */
+		 38, /* 36: TRAP #4                                            */
+		 38, /* 37: TRAP #5                                            */
+		 38, /* 38: TRAP #6                                            */
+		 38, /* 39: TRAP #7                                            */
+		 38, /* 40: TRAP #8                                            */
+		 38, /* 41: TRAP #9                                            */
+		 38, /* 42: TRAP #10                                           */
+		 38, /* 43: TRAP #11                                           */
+		 38, /* 44: TRAP #12                                           */
+		 38, /* 45: TRAP #13                                           */
+		 38, /* 46: TRAP #14                                           */
+		 38, /* 47: TRAP #15                                           */
+		  4, /* 48: FP Branch or Set on Unknown Condition (unemulated) */
+		  4, /* 49: FP Inexact Result                     (unemulated) */
+		  4, /* 50: FP Divide by Zero                     (unemulated) */
+		  4, /* 51: FP Underflow                          (unemulated) */
+		  4, /* 52: FP Operand Error                      (unemulated) */
+		  4, /* 53: FP Overflow                           (unemulated) */
+		  4, /* 54: FP Signaling NAN                      (unemulated) */
+		  4, /* 55: FP Unimplemented Data Type            (unemulated) */
+		  4, /* 56: MMU Configuration Error               (unemulated) */
+		  4, /* 57: MMU Illegal Operation Error           (unemulated) */
+		  4, /* 58: MMU Access Level Violation Error      (unemulated) */
+		  4, /* 59: RESERVED                                           */
+		  4, /* 60: RESERVED                                           */
+		  4, /* 61: RESERVED                                           */
+		  4, /* 62: RESERVED                                           */
+		  4, /* 63: RESERVED                                           */
+		     /* 64-255: User Defined                                   */
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4
+	},
+	{ /* 020 */
+		  4, /*  0: Reset - Initial Stack Pointer                      */
+		  4, /*  1: Reset - Initial Program Counter                    */
+		 50, /*  2: Bus Error                             (unemulated) */
+		 50, /*  3: Address Error                         (unemulated) */
+		 20, /*  4: Illegal Instruction                                */
+		 38, /*  5: Divide by Zero                                     */
+		 40, /*  6: CHK                                                */
+		 20, /*  7: TRAPV                                              */
+		 34, /*  8: Privilege Violation                                */
+		 25, /*  9: Trace                                              */
+		 20, /* 10: 1010                                               */
+		 20, /* 11: 1111                                               */
+		  4, /* 12: RESERVED                                           */
+		  4, /* 13: Coprocessor Protocol Violation        (unemulated) */
+		  4, /* 14: Format Error                                       */
+		 30, /* 15: Uninitialized Interrupt                            */
+		  4, /* 16: RESERVED                                           */
+		  4, /* 17: RESERVED                                           */
+		  4, /* 18: RESERVED                                           */
+		  4, /* 19: RESERVED                                           */
+		  4, /* 20: RESERVED                                           */
+		  4, /* 21: RESERVED                                           */
+		  4, /* 22: RESERVED                                           */
+		  4, /* 23: RESERVED                                           */
+		 30, /* 24: Spurious Interrupt                                 */
+		 30, /* 25: Level 1 Interrupt Autovector                       */
+		 30, /* 26: Level 2 Interrupt Autovector                       */
+		 30, /* 27: Level 3 Interrupt Autovector                       */
+		 30, /* 28: Level 4 Interrupt Autovector                       */
+		 30, /* 29: Level 5 Interrupt Autovector                       */
+		 30, /* 30: Level 6 Interrupt Autovector                       */
+		 30, /* 31: Level 7 Interrupt Autovector                       */
+		 20, /* 32: TRAP #0                                            */
+		 20, /* 33: TRAP #1                                            */
+		 20, /* 34: TRAP #2                                            */
+		 20, /* 35: TRAP #3                                            */
+		 20, /* 36: TRAP #4                                            */
+		 20, /* 37: TRAP #5                                            */
+		 20, /* 38: TRAP #6                                            */
+		 20, /* 39: TRAP #7                                            */
+		 20, /* 40: TRAP #8                                            */
+		 20, /* 41: TRAP #9                                            */
+		 20, /* 42: TRAP #10                                           */
+		 20, /* 43: TRAP #11                                           */
+		 20, /* 44: TRAP #12                                           */
+		 20, /* 45: TRAP #13                                           */
+		 20, /* 46: TRAP #14                                           */
+		 20, /* 47: TRAP #15                                           */
+		  4, /* 48: FP Branch or Set on Unknown Condition (unemulated) */
+		  4, /* 49: FP Inexact Result                     (unemulated) */
+		  4, /* 50: FP Divide by Zero                     (unemulated) */
+		  4, /* 51: FP Underflow                          (unemulated) */
+		  4, /* 52: FP Operand Error                      (unemulated) */
+		  4, /* 53: FP Overflow                           (unemulated) */
+		  4, /* 54: FP Signaling NAN                      (unemulated) */
+		  4, /* 55: FP Unimplemented Data Type            (unemulated) */
+		  4, /* 56: MMU Configuration Error               (unemulated) */
+		  4, /* 57: MMU Illegal Operation Error           (unemulated) */
+		  4, /* 58: MMU Access Level Violation Error      (unemulated) */
+		  4, /* 59: RESERVED                                           */
+		  4, /* 60: RESERVED                                           */
+		  4, /* 61: RESERVED                                           */
+		  4, /* 62: RESERVED                                           */
+		  4, /* 63: RESERVED                                           */
+		     /* 64-255: User Defined                                   */
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+		  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4
+	}
+};
+
+uint8 m68ki_ea_idx_cycle_table[64] =
+{
+	 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+	 0, /* ..01.000 no memory indirect, base NULL             */
+	 5, /* ..01..01 memory indirect,    base NULL, outer NULL */
+	 7, /* ..01..10 memory indirect,    base NULL, outer 16   */
+	 7, /* ..01..11 memory indirect,    base NULL, outer 32   */
+	 0,  5,  7,  7,  0,  5,  7,  7,  0,  5,  7,  7,
+	 2, /* ..10.000 no memory indirect, base 16               */
+	 7, /* ..10..01 memory indirect,    base 16,   outer NULL */
+	 9, /* ..10..10 memory indirect,    base 16,   outer 16   */
+	 9, /* ..10..11 memory indirect,    base 16,   outer 32   */
+	 0,  7,  9,  9,  0,  7,  9,  9,  0,  7,  9,  9,
+	 6, /* ..11.000 no memory indirect, base 32               */
+	11, /* ..11..01 memory indirect,    base 32,   outer NULL */
+	13, /* ..11..10 memory indirect,    base 32,   outer 16   */
+	13, /* ..11..11 memory indirect,    base 32,   outer 32   */
+	 0, 11, 13, 13,  0, 11, 13, 13,  0, 11, 13, 13
+};
+
+
+
+/* ======================================================================== */
+/* =============================== CALLBACKS ============================== */
+/* ======================================================================== */
+
+/* Default callbacks used if the callback hasn't been set yet, or if the
+ * callback is set to NULL
+ */
+
+/* Interrupt acknowledge */
+static int default_int_ack_callback_data;
+static int default_int_ack_callback(int int_level)
+{
+	default_int_ack_callback_data = int_level;
+	CPU_INT_LEVEL = 0;
+	return M68K_INT_ACK_AUTOVECTOR;
+}
+
+/* Breakpoint acknowledge */
+static unsigned int default_bkpt_ack_callback_data;
+static void default_bkpt_ack_callback(unsigned int data)
+{
+	default_bkpt_ack_callback_data = data;
+}
+
+/* Called when a reset instruction is executed */
+static void default_reset_instr_callback(void)
+{
+}
+
+/* Called when the program counter changed by a large value */
+static unsigned int default_pc_changed_callback_data;
+static void default_pc_changed_callback(unsigned int new_pc)
+{
+	default_pc_changed_callback_data = new_pc;
+}
+
+/* Called every time there's bus activity (read/write to/from memory */
+static unsigned int default_set_fc_callback_data;
+static void default_set_fc_callback(unsigned int new_fc)
+{
+	default_set_fc_callback_data = new_fc;
+}
+
+/* Called every instruction cycle prior to execution */
+static void default_instr_hook_callback(void)
+{
+}
+
+
+#if M68K_EMULATE_ADDRESS_ERROR
+	#include <setjmp.h>
+	jmp_buf m68ki_aerr_trap;
+#endif /* M68K_EMULATE_ADDRESS_ERROR */
+
+
+/* ======================================================================== */
+/* ================================= API ================================== */
+/* ======================================================================== */
+
+/* Access the internals of the CPU */
+unsigned int m68k_get_reg(void* context, m68k_register_t regnum)
+{
+	m68ki_cpu_core* cpu = context != NULL ?(m68ki_cpu_core*)context : &m68ki_cpu;
+
+	switch(regnum)
+	{
+		case M68K_REG_D0:	return cpu->dar[0];
+		case M68K_REG_D1:	return cpu->dar[1];
+		case M68K_REG_D2:	return cpu->dar[2];
+		case M68K_REG_D3:	return cpu->dar[3];
+		case M68K_REG_D4:	return cpu->dar[4];
+		case M68K_REG_D5:	return cpu->dar[5];
+		case M68K_REG_D6:	return cpu->dar[6];
+		case M68K_REG_D7:	return cpu->dar[7];
+		case M68K_REG_A0:	return cpu->dar[8];
+		case M68K_REG_A1:	return cpu->dar[9];
+		case M68K_REG_A2:	return cpu->dar[10];
+		case M68K_REG_A3:	return cpu->dar[11];
+		case M68K_REG_A4:	return cpu->dar[12];
+		case M68K_REG_A5:	return cpu->dar[13];
+		case M68K_REG_A6:	return cpu->dar[14];
+		case M68K_REG_A7:	return cpu->dar[15];
+		case M68K_REG_PC:	return MASK_OUT_ABOVE_32(cpu->pc);
+		case M68K_REG_SR:	return	cpu->t1_flag						|
+									cpu->t0_flag						|
+									(cpu->s_flag << 11)					|
+									(cpu->m_flag << 11)					|
+									cpu->int_mask						|
+									((cpu->x_flag & XFLAG_SET) >> 4)	|
+									((cpu->n_flag & NFLAG_SET) >> 4)	|
+									((!cpu->not_z_flag) << 2)			|
+									((cpu->v_flag & VFLAG_SET) >> 6)	|
+									((cpu->c_flag & CFLAG_SET) >> 8);
+		case M68K_REG_SP:	return cpu->dar[15];
+		case M68K_REG_USP:	return cpu->s_flag ? cpu->sp[0] : cpu->dar[15];
+		case M68K_REG_ISP:	return cpu->s_flag && !cpu->m_flag ? cpu->dar[15] : cpu->sp[4];
+		case M68K_REG_MSP:	return cpu->s_flag && cpu->m_flag ? cpu->dar[15] : cpu->sp[6];
+		case M68K_REG_SFC:	return cpu->sfc;
+		case M68K_REG_DFC:	return cpu->dfc;
+		case M68K_REG_VBR:	return cpu->vbr;
+		case M68K_REG_CACR:	return cpu->cacr;
+		case M68K_REG_CAAR:	return cpu->caar;
+		case M68K_REG_PREF_ADDR:	return cpu->pref_addr;
+		case M68K_REG_PREF_DATA:	return cpu->pref_data;
+		case M68K_REG_PPC:	return MASK_OUT_ABOVE_32(cpu->ppc);
+		case M68K_REG_IR:	return cpu->ir;
+		case M68K_REG_CPU_TYPE:
+			switch(cpu->cpu_type)
+			{
+				case CPU_TYPE_000:		return (unsigned int)M68K_CPU_TYPE_68000;
+				case CPU_TYPE_010:		return (unsigned int)M68K_CPU_TYPE_68010;
+				case CPU_TYPE_EC020:	return (unsigned int)M68K_CPU_TYPE_68EC020;
+				case CPU_TYPE_020:		return (unsigned int)M68K_CPU_TYPE_68020;
+			}
+			return M68K_CPU_TYPE_INVALID;
+		default:			return 0;
+	}
+	return 0;
+}
+
+void m68k_set_reg(m68k_register_t regnum, unsigned int value)
+{
+	switch(regnum)
+	{
+		case M68K_REG_D0:	REG_D[0] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_D1:	REG_D[1] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_D2:	REG_D[2] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_D3:	REG_D[3] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_D4:	REG_D[4] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_D5:	REG_D[5] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_D6:	REG_D[6] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_D7:	REG_D[7] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A0:	REG_A[0] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A1:	REG_A[1] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A2:	REG_A[2] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A3:	REG_A[3] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A4:	REG_A[4] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A5:	REG_A[5] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A6:	REG_A[6] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_A7:	REG_A[7] = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_PC:	m68ki_jump(MASK_OUT_ABOVE_32(value)); return;
+		case M68K_REG_SR:	m68ki_set_sr(value); return;
+		case M68K_REG_SP:	REG_SP = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_USP:	if(FLAG_S)
+								REG_USP = MASK_OUT_ABOVE_32(value);
+							else
+								REG_SP = MASK_OUT_ABOVE_32(value);
+							return;
+		case M68K_REG_ISP:	if(FLAG_S && !FLAG_M)
+								REG_SP = MASK_OUT_ABOVE_32(value);
+							else
+								REG_ISP = MASK_OUT_ABOVE_32(value);
+							return;
+		case M68K_REG_MSP:	if(FLAG_S && FLAG_M)
+								REG_SP = MASK_OUT_ABOVE_32(value);
+							else
+								REG_MSP = MASK_OUT_ABOVE_32(value);
+							return;
+		case M68K_REG_VBR:	REG_VBR = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_SFC:	REG_SFC = value & 7; return;
+		case M68K_REG_DFC:	REG_DFC = value & 7; return;
+		case M68K_REG_CACR:	REG_CACR = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_CAAR:	REG_CAAR = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_PPC:	REG_PPC = MASK_OUT_ABOVE_32(value); return;
+		case M68K_REG_IR:	REG_IR = MASK_OUT_ABOVE_16(value); return;
+		case M68K_REG_CPU_TYPE: m68k_set_cpu_type(value); return;
+		default:			return;
+	}
+}
+
+/* Set the callbacks */
+void m68k_set_int_ack_callback(int  (*callback)(int int_level))
+{
+	CALLBACK_INT_ACK = callback ? callback : default_int_ack_callback;
+}
+
+void m68k_set_bkpt_ack_callback(void  (*callback)(unsigned int data))
+{
+	CALLBACK_BKPT_ACK = callback ? callback : default_bkpt_ack_callback;
+}
+
+void m68k_set_reset_instr_callback(void  (*callback)(void))
+{
+	CALLBACK_RESET_INSTR = callback ? callback : default_reset_instr_callback;
+}
+
+void m68k_set_pc_changed_callback(void  (*callback)(unsigned int new_pc))
+{
+	CALLBACK_PC_CHANGED = callback ? callback : default_pc_changed_callback;
+}
+
+void m68k_set_fc_callback(void  (*callback)(unsigned int new_fc))
+{
+	CALLBACK_SET_FC = callback ? callback : default_set_fc_callback;
+}
+
+void m68k_set_instr_hook_callback(void  (*callback)(void))
+{
+	CALLBACK_INSTR_HOOK = callback ? callback : default_instr_hook_callback;
+}
+
+#include <stdio.h>
+/* Set the CPU type. */
+void m68k_set_cpu_type(unsigned int cpu_type)
+{
+	switch(cpu_type)
+	{
+		case M68K_CPU_TYPE_68000:
+			CPU_TYPE         = CPU_TYPE_000;
+			CPU_ADDRESS_MASK = 0x00ffffff;
+			CPU_SR_MASK      = 0xa71f; /* T1 -- S  -- -- I2 I1 I0 -- -- -- X  N  Z  V  C  */
+			CYC_INSTRUCTION  = m68ki_cycles[0];
+			CYC_EXCEPTION    = m68ki_exception_cycle_table[0];
+			CYC_BCC_NOTAKE_B = -2;
+			CYC_BCC_NOTAKE_W = 2;
+			CYC_DBCC_F_NOEXP = -2;
+			CYC_DBCC_F_EXP   = 2;
+			CYC_SCC_R_TRUE   = 2;
+			CYC_MOVEM_W      = 2;
+			CYC_MOVEM_L      = 3;
+			CYC_SHIFT        = 1;
+			CYC_RESET        = 132;
+			return;
+		case M68K_CPU_TYPE_68010:
+			CPU_TYPE         = CPU_TYPE_010;
+			CPU_ADDRESS_MASK = 0x00ffffff;
+			CPU_SR_MASK      = 0xa71f; /* T1 -- S  -- -- I2 I1 I0 -- -- -- X  N  Z  V  C  */
+			CYC_INSTRUCTION  = m68ki_cycles[1];
+			CYC_EXCEPTION    = m68ki_exception_cycle_table[1];
+			CYC_BCC_NOTAKE_B = -4;
+			CYC_BCC_NOTAKE_W = 0;
+			CYC_DBCC_F_NOEXP = 0;
+			CYC_DBCC_F_EXP   = 6;
+			CYC_SCC_R_TRUE   = 0;
+			CYC_MOVEM_W      = 2;
+			CYC_MOVEM_L      = 3;
+			CYC_SHIFT        = 1;
+			CYC_RESET        = 130;
+			return;
+		case M68K_CPU_TYPE_68EC020:
+			CPU_TYPE         = CPU_TYPE_EC020;
+			CPU_ADDRESS_MASK = 0x00ffffff;
+			CPU_SR_MASK      = 0xf71f; /* T1 T0 S  M  -- I2 I1 I0 -- -- -- X  N  Z  V  C  */
+			CYC_INSTRUCTION  = m68ki_cycles[2];
+			CYC_EXCEPTION    = m68ki_exception_cycle_table[2];
+			CYC_BCC_NOTAKE_B = -2;
+			CYC_BCC_NOTAKE_W = 0;
+			CYC_DBCC_F_NOEXP = 0;
+			CYC_DBCC_F_EXP   = 4;
+			CYC_SCC_R_TRUE   = 0;
+			CYC_MOVEM_W      = 2;
+			CYC_MOVEM_L      = 2;
+			CYC_SHIFT        = 0;
+			CYC_RESET        = 518;
+			return;
+		case M68K_CPU_TYPE_68020:
+			CPU_TYPE         = CPU_TYPE_020;
+			CPU_ADDRESS_MASK = 0xffffffff;
+			CPU_SR_MASK      = 0xf71f; /* T1 T0 S  M  -- I2 I1 I0 -- -- -- X  N  Z  V  C  */
+			CYC_INSTRUCTION  = m68ki_cycles[2];
+			CYC_EXCEPTION    = m68ki_exception_cycle_table[2];
+			CYC_BCC_NOTAKE_B = -2;
+			CYC_BCC_NOTAKE_W = 0;
+			CYC_DBCC_F_NOEXP = 0;
+			CYC_DBCC_F_EXP   = 4;
+			CYC_SCC_R_TRUE   = 0;
+			CYC_MOVEM_W      = 2;
+			CYC_MOVEM_L      = 2;
+			CYC_SHIFT        = 0;
+			CYC_RESET        = 518;
+			return;
+	}
+}
+
+/* Execute some instructions until we use up num_cycles clock cycles */
+/* ASG: removed per-instruction interrupt checks */
+int m68k_execute(int num_cycles)
+{
+	/* Make sure we're not stopped */
+	if(!CPU_STOPPED)
+	{
+		/* Set our pool of clock cycles available */
+		SET_CYCLES(num_cycles);
+		m68ki_initial_cycles = num_cycles;
+
+		/* ASG: update cycles */
+		USE_CYCLES(CPU_INT_CYCLES);
+		CPU_INT_CYCLES = 0;
+
+		/* Return point if we had an address error */
+		m68ki_set_address_error_trap(); /* auto-disable (see m68kcpu.h) */
+
+		/* Main loop.  Keep going until we run out of clock cycles */
+		do
+		{
+			/* Set tracing accodring to T1. (T0 is done inside instruction) */
+			m68ki_trace_t1(); /* auto-disable (see m68kcpu.h) */
+
+			/* Set the address space for reads */
+			m68ki_use_data_space(); /* auto-disable (see m68kcpu.h) */
+
+			/* Call external hook to peek at CPU */
+			m68ki_instr_hook(); /* auto-disable (see m68kcpu.h) */
+
+			/* Record previous program counter */
+			REG_PPC = REG_PC;
+
+			/* Read an instruction and call its handler */
+			REG_IR = m68ki_read_imm_16();
+			m68ki_instruction_jump_table[REG_IR]();
+			USE_CYCLES(CYC_INSTRUCTION[REG_IR]);
+
+			/* Trace m68k_exception, if necessary */
+			m68ki_exception_if_trace(); /* auto-disable (see m68kcpu.h) */
+		} while(GET_CYCLES() > 0);
+
+		/* set previous PC to current PC for the next entry into the loop */
+		REG_PPC = REG_PC;
+
+		/* ASG: update cycles */
+		USE_CYCLES(CPU_INT_CYCLES);
+		CPU_INT_CYCLES = 0;
+
+		/* return how many clocks we used */
+		return m68ki_initial_cycles - GET_CYCLES();
+	}
+
+	/* We get here if the CPU is stopped or halted */
+	SET_CYCLES(0);
+	CPU_INT_CYCLES = 0;
+
+	return num_cycles;
+}
+
+
+int m68k_cycles_run(void)
+{
+	return m68ki_initial_cycles - GET_CYCLES();
+}
+
+int m68k_cycles_remaining(void)
+{
+	return GET_CYCLES();
+}
+
+/* Change the timeslice */
+void m68k_modify_timeslice(int cycles)
+{
+	m68ki_initial_cycles += cycles;
+	ADD_CYCLES(cycles);
+}
+
+
+void m68k_end_timeslice(void)
+{
+	m68ki_initial_cycles = GET_CYCLES();
+	SET_CYCLES(0);
+}
+
+
+/* ASG: rewrote so that the int_level is a mask of the IPL0/IPL1/IPL2 bits */
+/* KS: Modified so that IPL* bits match with mask positions in the SR
+ *     and cleaned out remenants of the interrupt controller.
+ */
+void m68k_set_irq(unsigned int int_level)
+{
+	uint old_level = CPU_INT_LEVEL;
+	CPU_INT_LEVEL = int_level << 8;
+
+	/* A transition from < 7 to 7 always interrupts (NMI) */
+	/* Note: Level 7 can also level trigger like a normal IRQ */
+	if(old_level != 0x0700 && CPU_INT_LEVEL == 0x0700)
+		m68ki_exception_interrupt(7); /* Edge triggered level 7 (NMI) */
+	else
+		m68ki_check_interrupts(); /* Level triggered (IRQ) */
+}
+
+void m68k_init(void)
+{
+	static uint emulation_initialized = 0;
+
+	/* The first call to this function initializes the opcode handler jump table */
+	if(!emulation_initialized)
+		{
+		m68ki_build_opcode_table();
+		emulation_initialized = 1;
+	}
+
+	m68k_set_int_ack_callback(NULL);
+	m68k_set_bkpt_ack_callback(NULL);
+	m68k_set_reset_instr_callback(NULL);
+	m68k_set_pc_changed_callback(NULL);
+	m68k_set_fc_callback(NULL);
+	m68k_set_instr_hook_callback(NULL);
+}
+
+/* Pulse the RESET line on the CPU */
+void m68k_pulse_reset(void)
+{
+	/* Clear all stop levels and eat up all remaining cycles */
+	CPU_STOPPED = 0;
+	SET_CYCLES(0);
+
+	CPU_RUN_MODE = RUN_MODE_BERR_AERR_RESET;
+	CPU_INSTR_MODE = INSTRUCTION_YES;
+
+	/* Turn off tracing */
+	FLAG_T1 = FLAG_T0 = 0;
+	m68ki_clear_trace();
+	/* Interrupt mask to level 7 */
+	FLAG_INT_MASK = 0x0700;
+	/* Reset VBR */
+	REG_VBR = 0;
+	/* Go to supervisor mode */
+	m68ki_set_sm_flag(SFLAG_SET | MFLAG_CLEAR);
+
+	/* Invalidate the prefetch queue */
+#if M68K_EMULATE_PREFETCH
+	/* Set to arbitrary number since our first fetch is from 0 */
+	CPU_PREF_ADDR = 0x1000;
+#endif /* M68K_EMULATE_PREFETCH */
+
+	/* Read the initial stack pointer and program counter */
+	m68ki_jump(0);
+	REG_SP = m68ki_read_imm_32();
+	REG_PC = m68ki_read_imm_32();
+	m68ki_jump(REG_PC);
+
+	CPU_RUN_MODE = RUN_MODE_NORMAL;
+}
+
+/* Pulse the HALT line on the CPU */
+void m68k_pulse_halt(void)
+{
+	CPU_STOPPED |= STOP_LEVEL_HALT;
+}
+
+
+/* Get and set the current CPU context */
+/* This is to allow for multiple CPUs */
+unsigned int m68k_context_size()
+{
+	return sizeof(m68ki_cpu_core);
+}
+
+unsigned int m68k_get_context(void* dst)
+{
+	if(dst) *(m68ki_cpu_core*)dst = m68ki_cpu;
+	return sizeof(m68ki_cpu_core);
+}
+
+void m68k_set_context(void* src)
+{
+	if(src) m68ki_cpu = *(m68ki_cpu_core*)src;
+}
+
+
+
+/* ======================================================================== */
+/* ============================== MAME STUFF ============================== */
+/* ======================================================================== */
+
+#if M68K_COMPILE_FOR_MAME == OPT_ON
+
+#include "state.h"
+
+static struct {
+	UINT16 sr;
+	int stopped;
+	int halted;
+} m68k_substate;
+
+static void m68k_prepare_substate(void)
+{
+	m68k_substate.sr = m68ki_get_sr();
+	m68k_substate.stopped = (CPU_STOPPED & STOP_LEVEL_STOP) != 0;
+	m68k_substate.halted  = (CPU_STOPPED & STOP_LEVEL_HALT) != 0;
+}
+
+static void m68k_post_load(void)
+{
+	m68ki_set_sr_noint_nosp(m68k_substate.sr);
+	CPU_STOPPED = m68k_substate.stopped ? STOP_LEVEL_STOP : 0
+		        | m68k_substate.halted  ? STOP_LEVEL_HALT : 0;
+	m68ki_jump(REG_PC);
+}
+
+void m68k_state_register(const char *type)
+{
+	int cpu = cpu_getactivecpu();
+
+	state_save_register_UINT32(type, cpu, "D"         , REG_D, 8);
+	state_save_register_UINT32(type, cpu, "A"         , REG_A, 8);
+	state_save_register_UINT32(type, cpu, "PPC"       , &REG_PPC, 1);
+	state_save_register_UINT32(type, cpu, "PC"        , &REG_PC, 1);
+	state_save_register_UINT32(type, cpu, "USP"       , &REG_USP, 1);
+	state_save_register_UINT32(type, cpu, "ISP"       , &REG_ISP, 1);
+	state_save_register_UINT32(type, cpu, "MSP"       , &REG_MSP, 1);
+	state_save_register_UINT32(type, cpu, "VBR"       , &REG_VBR, 1);
+	state_save_register_UINT32(type, cpu, "SFC"       , &REG_SFC, 1);
+	state_save_register_UINT32(type, cpu, "DFC"       , &REG_DFC, 1);
+	state_save_register_UINT32(type, cpu, "CACR"      , &REG_CACR, 1);
+	state_save_register_UINT32(type, cpu, "CAAR"      , &REG_CAAR, 1);
+	state_save_register_UINT16(type, cpu, "SR"        , &m68k_substate.sr, 1);
+	state_save_register_UINT32(type, cpu, "INT_LEVEL" , &CPU_INT_LEVEL, 1);
+	state_save_register_UINT32(type, cpu, "INT_CYCLES", &CPU_INT_CYCLES, 1);
+	state_save_register_int   (type, cpu, "STOPPED"   , &m68k_substate.stopped);
+	state_save_register_int   (type, cpu, "HALTED"    , &m68k_substate.halted);
+	state_save_register_UINT32(type, cpu, "PREF_ADDR" , &CPU_PREF_ADDR, 1);
+	state_save_register_UINT32(type, cpu, "PREF_DATA" , &CPU_PREF_DATA, 1);
+	state_save_register_func_presave(m68k_prepare_substate);
+	state_save_register_func_postload(m68k_post_load);
+}
+
+#endif /* M68K_COMPILE_FOR_MAME */
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */

--- a/yabause/src/musashi/m68kcpu.h
+++ b/yabause/src/musashi/m68kcpu.h
@@ -1,0 +1,1975 @@
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.4
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright 1998-2001 Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+
+
+#ifndef M68KCPU__HEADER
+#define M68KCPU__HEADER
+
+#include "m68k.h"
+#include <limits.h>
+
+#if M68K_EMULATE_ADDRESS_ERROR
+#include <setjmp.h>
+#endif /* M68K_EMULATE_ADDRESS_ERROR */
+
+/* ======================================================================== */
+/* ==================== ARCHITECTURE-DEPENDANT DEFINES ==================== */
+/* ======================================================================== */
+
+/* Check for > 32bit sizes */
+#if UINT_MAX > 0xffffffff
+	#define M68K_INT_GT_32_BIT  1
+#else
+	#define M68K_INT_GT_32_BIT  0
+#endif
+
+/* Data types used in this emulation core */
+#undef sint8
+#undef sint16
+#undef sint32
+#undef sint64
+#undef uint8
+#undef uint16
+#undef uint32
+#undef uint64
+#undef sint
+#undef uint
+
+#define sint8  signed   char			/* ASG: changed from char to signed char */
+#define sint16 signed   short
+#define sint32 signed   long
+#define uint8  unsigned char
+#define uint16 unsigned short
+#define uint32 unsigned long
+
+/* signed and unsigned int must be at least 32 bits wide */
+#define sint   signed   int
+#define uint   unsigned int
+
+
+#if M68K_USE_64_BIT
+#define sint64 signed   long long
+#define uint64 unsigned long long
+#else
+#define sint64 sint32
+#define uint64 uint32
+#endif /* M68K_USE_64_BIT */
+
+
+
+/* Allow for architectures that don't have 8-bit sizes */
+#if UCHAR_MAX == 0xff
+	#define MAKE_INT_8(A) (sint8)(A)
+#else
+	#undef  sint8
+	#define sint8  signed   int
+	#undef  uint8
+	#define uint8  unsigned int
+	INLINE sint MAKE_INT_8(uint value)
+	{
+		return (value & 0x80) ? value | ~0xff : value & 0xff;
+	}
+#endif /* UCHAR_MAX == 0xff */
+
+
+/* Allow for architectures that don't have 16-bit sizes */
+#if USHRT_MAX == 0xffff
+	#define MAKE_INT_16(A) (sint16)(A)
+#else
+	#undef  sint16
+	#define sint16 signed   int
+	#undef  uint16
+	#define uint16 unsigned int
+	INLINE sint MAKE_INT_16(uint value)
+	{
+		return (value & 0x8000) ? value | ~0xffff : value & 0xffff;
+	}
+#endif /* USHRT_MAX == 0xffff */
+
+
+/* Allow for architectures that don't have 32-bit sizes */
+#if ULONG_MAX == 0xffffffff
+	#define MAKE_INT_32(A) (sint32)(A)
+#else
+	#undef  sint32
+	#define sint32  signed   int
+	#undef  uint32
+	#define uint32  unsigned int
+	INLINE sint MAKE_INT_32(uint value)
+	{
+		return (value & 0x80000000) ? value | ~0xffffffff : value & 0xffffffff;
+	}
+#endif /* ULONG_MAX == 0xffffffff */
+
+
+
+
+/* ======================================================================== */
+/* ============================ GENERAL DEFINES =========================== */
+/* ======================================================================== */
+
+/* Exception Vectors handled by emulation */
+#define EXCEPTION_BUS_ERROR                2 /* This one is not emulated! */
+#define EXCEPTION_ADDRESS_ERROR            3 /* This one is partially emulated (doesn't stack a proper frame yet) */
+#define EXCEPTION_ILLEGAL_INSTRUCTION      4
+#define EXCEPTION_ZERO_DIVIDE              5
+#define EXCEPTION_CHK                      6
+#define EXCEPTION_TRAPV                    7
+#define EXCEPTION_PRIVILEGE_VIOLATION      8
+#define EXCEPTION_TRACE                    9
+#define EXCEPTION_1010                    10
+#define EXCEPTION_1111                    11
+#define EXCEPTION_FORMAT_ERROR            14
+#define EXCEPTION_UNINITIALIZED_INTERRUPT 15
+#define EXCEPTION_SPURIOUS_INTERRUPT      24
+#define EXCEPTION_INTERRUPT_AUTOVECTOR    24
+#define EXCEPTION_TRAP_BASE               32
+
+/* Function codes set by CPU during data/address bus activity */
+#define FUNCTION_CODE_USER_DATA          1
+#define FUNCTION_CODE_USER_PROGRAM       2
+#define FUNCTION_CODE_SUPERVISOR_DATA    5
+#define FUNCTION_CODE_SUPERVISOR_PROGRAM 6
+#define FUNCTION_CODE_CPU_SPACE          7
+
+/* CPU types for deciding what to emulate */
+#define CPU_TYPE_000   1
+#define CPU_TYPE_010   2
+#define CPU_TYPE_EC020 4
+#define CPU_TYPE_020   8
+
+/* Different ways to stop the CPU */
+#define STOP_LEVEL_STOP 1
+#define STOP_LEVEL_HALT 2
+
+/* Used for 68000 address error processing */
+#define INSTRUCTION_YES 0
+#define INSTRUCTION_NO  0x08
+#define MODE_READ       0x10
+#define MODE_WRITE      0
+
+#define RUN_MODE_NORMAL          0
+#define RUN_MODE_BERR_AERR_RESET 1
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
+/* ======================================================================== */
+/* ================================ MACROS ================================ */
+/* ======================================================================== */
+
+
+/* ---------------------------- General Macros ---------------------------- */
+
+/* Bit Isolation Macros */
+#define BIT_0(A)  ((A) & 0x00000001)
+#define BIT_1(A)  ((A) & 0x00000002)
+#define BIT_2(A)  ((A) & 0x00000004)
+#define BIT_3(A)  ((A) & 0x00000008)
+#define BIT_4(A)  ((A) & 0x00000010)
+#define BIT_5(A)  ((A) & 0x00000020)
+#define BIT_6(A)  ((A) & 0x00000040)
+#define BIT_7(A)  ((A) & 0x00000080)
+#define BIT_8(A)  ((A) & 0x00000100)
+#define BIT_9(A)  ((A) & 0x00000200)
+#define BIT_A(A)  ((A) & 0x00000400)
+#define BIT_B(A)  ((A) & 0x00000800)
+#define BIT_C(A)  ((A) & 0x00001000)
+#define BIT_D(A)  ((A) & 0x00002000)
+#define BIT_E(A)  ((A) & 0x00004000)
+#define BIT_F(A)  ((A) & 0x00008000)
+#define BIT_10(A) ((A) & 0x00010000)
+#define BIT_11(A) ((A) & 0x00020000)
+#define BIT_12(A) ((A) & 0x00040000)
+#define BIT_13(A) ((A) & 0x00080000)
+#define BIT_14(A) ((A) & 0x00100000)
+#define BIT_15(A) ((A) & 0x00200000)
+#define BIT_16(A) ((A) & 0x00400000)
+#define BIT_17(A) ((A) & 0x00800000)
+#define BIT_18(A) ((A) & 0x01000000)
+#define BIT_19(A) ((A) & 0x02000000)
+#define BIT_1A(A) ((A) & 0x04000000)
+#define BIT_1B(A) ((A) & 0x08000000)
+#define BIT_1C(A) ((A) & 0x10000000)
+#define BIT_1D(A) ((A) & 0x20000000)
+#define BIT_1E(A) ((A) & 0x40000000)
+#define BIT_1F(A) ((A) & 0x80000000)
+
+/* Get the most significant bit for specific sizes */
+#define GET_MSB_8(A)  ((A) & 0x80)
+#define GET_MSB_9(A)  ((A) & 0x100)
+#define GET_MSB_16(A) ((A) & 0x8000)
+#define GET_MSB_17(A) ((A) & 0x10000)
+#define GET_MSB_32(A) ((A) & 0x80000000)
+#if M68K_USE_64_BIT
+#define GET_MSB_33(A) ((A) & 0x100000000)
+#endif /* M68K_USE_64_BIT */
+
+/* Isolate nibbles */
+#define LOW_NIBBLE(A)  ((A) & 0x0f)
+#define HIGH_NIBBLE(A) ((A) & 0xf0)
+
+/* These are used to isolate 8, 16, and 32 bit sizes */
+#define MASK_OUT_ABOVE_2(A)  ((A) & 3)
+#define MASK_OUT_ABOVE_8(A)  ((A) & 0xff)
+#define MASK_OUT_ABOVE_16(A) ((A) & 0xffff)
+#define MASK_OUT_BELOW_2(A)  ((A) & ~3)
+#define MASK_OUT_BELOW_8(A)  ((A) & ~0xff)
+#define MASK_OUT_BELOW_16(A) ((A) & ~0xffff)
+
+/* No need to mask if we are 32 bit */
+#if M68K_INT_GT_32_BIT || M68K_USE_64_BIT
+	#define MASK_OUT_ABOVE_32(A) ((A) & 0xffffffff)
+	#define MASK_OUT_BELOW_32(A) ((A) & ~0xffffffff)
+#else
+	#define MASK_OUT_ABOVE_32(A) (A)
+	#define MASK_OUT_BELOW_32(A) 0
+#endif /* M68K_INT_GT_32_BIT || M68K_USE_64_BIT */
+
+/* Simulate address lines of 68k family */
+#define ADDRESS_68K(A) ((A)&CPU_ADDRESS_MASK)
+
+
+/* Shift & Rotate Macros. */
+#define LSL(A, C) ((A) << (C))
+#define LSR(A, C) ((A) >> (C))
+
+/* Some > 32-bit optimizations */
+#if M68K_INT_GT_32_BIT
+	/* Shift left and right */
+	#define LSR_32(A, C) ((A) >> (C))
+	#define LSL_32(A, C) ((A) << (C))
+#else
+	/* We have to do this because the morons at ANSI decided that shifts
+	 * by >= data size are undefined.
+	 */
+	#define LSR_32(A, C) ((C) < 32 ? (A) >> (C) : 0)
+	#define LSL_32(A, C) ((C) < 32 ? (A) << (C) : 0)
+#endif /* M68K_INT_GT_32_BIT */
+
+#if M68K_USE_64_BIT
+	#define LSL_32_64(A, C) ((A) << (C))
+	#define LSR_32_64(A, C) ((A) >> (C))
+	#define ROL_33_64(A, C) (LSL_32_64(A, C) | LSR_32_64(A, 33-(C)))
+	#define ROR_33_64(A, C) (LSR_32_64(A, C) | LSL_32_64(A, 33-(C)))
+#endif /* M68K_USE_64_BIT */
+
+#define ROL_8(A, C)      MASK_OUT_ABOVE_8(LSL(A, C) | LSR(A, 8-(C)))
+#define ROL_9(A, C)                      (LSL(A, C) | LSR(A, 9-(C)))
+#define ROL_16(A, C)    MASK_OUT_ABOVE_16(LSL(A, C) | LSR(A, 16-(C)))
+#define ROL_17(A, C)                     (LSL(A, C) | LSR(A, 17-(C)))
+#define ROL_32(A, C)    MASK_OUT_ABOVE_32(LSL_32(A, C) | LSR_32(A, 32-(C)))
+#define ROL_33(A, C)                     (LSL_32(A, C) | LSR_32(A, 33-(C)))
+
+#define ROR_8(A, C)      MASK_OUT_ABOVE_8(LSR(A, C) | LSL(A, 8-(C)))
+#define ROR_9(A, C)                      (LSR(A, C) | LSL(A, 9-(C)))
+#define ROR_16(A, C)    MASK_OUT_ABOVE_16(LSR(A, C) | LSL(A, 16-(C)))
+#define ROR_17(A, C)                     (LSR(A, C) | LSL(A, 17-(C)))
+#define ROR_32(A, C)    MASK_OUT_ABOVE_32(LSR_32(A, C) | LSL_32(A, 32-(C)))
+#define ROR_33(A, C)                     (LSR_32(A, C) | LSL_32(A, 33-(C)))
+
+
+
+/* ------------------------------ CPU Access ------------------------------ */
+
+/* Access the CPU registers */
+#define CPU_TYPE         m68ki_cpu.cpu_type
+
+#define REG_DA           m68ki_cpu.dar /* easy access to data and address regs */
+#define REG_D            m68ki_cpu.dar
+#define REG_A            (m68ki_cpu.dar+8)
+#define REG_PPC 		 m68ki_cpu.ppc
+#define REG_PC           m68ki_cpu.pc
+#define REG_SP_BASE      m68ki_cpu.sp
+#define REG_USP          m68ki_cpu.sp[0]
+#define REG_ISP          m68ki_cpu.sp[4]
+#define REG_MSP          m68ki_cpu.sp[6]
+#define REG_SP           m68ki_cpu.dar[15]
+#define REG_VBR          m68ki_cpu.vbr
+#define REG_SFC          m68ki_cpu.sfc
+#define REG_DFC          m68ki_cpu.dfc
+#define REG_CACR         m68ki_cpu.cacr
+#define REG_CAAR         m68ki_cpu.caar
+#define REG_IR           m68ki_cpu.ir
+
+#define FLAG_T1          m68ki_cpu.t1_flag
+#define FLAG_T0          m68ki_cpu.t0_flag
+#define FLAG_S           m68ki_cpu.s_flag
+#define FLAG_M           m68ki_cpu.m_flag
+#define FLAG_X           m68ki_cpu.x_flag
+#define FLAG_N           m68ki_cpu.n_flag
+#define FLAG_Z           m68ki_cpu.not_z_flag
+#define FLAG_V           m68ki_cpu.v_flag
+#define FLAG_C           m68ki_cpu.c_flag
+#define FLAG_INT_MASK    m68ki_cpu.int_mask
+
+#define CPU_INT_LEVEL    m68ki_cpu.int_level /* ASG: changed from CPU_INTS_PENDING */
+#define CPU_INT_CYCLES   m68ki_cpu.int_cycles /* ASG */
+#define CPU_STOPPED      m68ki_cpu.stopped
+#define CPU_PREF_ADDR    m68ki_cpu.pref_addr
+#define CPU_PREF_DATA    m68ki_cpu.pref_data
+#define CPU_ADDRESS_MASK m68ki_cpu.address_mask
+#define CPU_SR_MASK      m68ki_cpu.sr_mask
+#define CPU_INSTR_MODE   m68ki_cpu.instr_mode
+#define CPU_RUN_MODE     m68ki_cpu.run_mode
+
+#define CYC_INSTRUCTION  m68ki_cpu.cyc_instruction
+#define CYC_EXCEPTION    m68ki_cpu.cyc_exception
+#define CYC_BCC_NOTAKE_B m68ki_cpu.cyc_bcc_notake_b
+#define CYC_BCC_NOTAKE_W m68ki_cpu.cyc_bcc_notake_w
+#define CYC_DBCC_F_NOEXP m68ki_cpu.cyc_dbcc_f_noexp
+#define CYC_DBCC_F_EXP   m68ki_cpu.cyc_dbcc_f_exp
+#define CYC_SCC_R_TRUE   m68ki_cpu.cyc_scc_r_true
+#define CYC_MOVEM_W      m68ki_cpu.cyc_movem_w
+#define CYC_MOVEM_L      m68ki_cpu.cyc_movem_l
+#define CYC_SHIFT        m68ki_cpu.cyc_shift
+#define CYC_RESET        m68ki_cpu.cyc_reset
+
+
+#define CALLBACK_INT_ACK     m68ki_cpu.int_ack_callback
+#define CALLBACK_BKPT_ACK    m68ki_cpu.bkpt_ack_callback
+#define CALLBACK_RESET_INSTR m68ki_cpu.reset_instr_callback
+#define CALLBACK_PC_CHANGED  m68ki_cpu.pc_changed_callback
+#define CALLBACK_SET_FC      m68ki_cpu.set_fc_callback
+#define CALLBACK_INSTR_HOOK  m68ki_cpu.instr_hook_callback
+
+
+
+/* ----------------------------- Configuration ---------------------------- */
+
+/* These defines are dependant on the configuration defines in m68kconf.h */
+
+/* Disable certain comparisons if we're not using all CPU types */
+#if M68K_EMULATE_020
+	#define CPU_TYPE_IS_020_PLUS(A)    ((A) & CPU_TYPE_020)
+	#define CPU_TYPE_IS_020_LESS(A)    1
+#else
+	#define CPU_TYPE_IS_020_PLUS(A)    0
+	#define CPU_TYPE_IS_020_LESS(A)    1
+#endif
+
+#if M68K_EMULATE_EC020
+	#define CPU_TYPE_IS_EC020_PLUS(A)  ((A) & (CPU_TYPE_EC020 | CPU_TYPE_020))
+	#define CPU_TYPE_IS_EC020_LESS(A)  ((A) & (CPU_TYPE_000 | CPU_TYPE_010 | CPU_TYPE_EC020))
+#else
+	#define CPU_TYPE_IS_EC020_PLUS(A)  CPU_TYPE_IS_020_PLUS(A)
+	#define CPU_TYPE_IS_EC020_LESS(A)  CPU_TYPE_IS_020_LESS(A)
+#endif
+
+#if M68K_EMULATE_010
+	#define CPU_TYPE_IS_010(A)         ((A) == CPU_TYPE_010)
+	#define CPU_TYPE_IS_010_PLUS(A)    ((A) & (CPU_TYPE_010 | CPU_TYPE_EC020 | CPU_TYPE_020))
+	#define CPU_TYPE_IS_010_LESS(A)    ((A) & (CPU_TYPE_000 | CPU_TYPE_010))
+#else
+	#define CPU_TYPE_IS_010(A)         0
+	#define CPU_TYPE_IS_010_PLUS(A)    CPU_TYPE_IS_EC020_PLUS(A)
+	#define CPU_TYPE_IS_010_LESS(A)    CPU_TYPE_IS_EC020_LESS(A)
+#endif
+
+#if M68K_EMULATE_020 || M68K_EMULATE_EC020
+	#define CPU_TYPE_IS_020_VARIANT(A) ((A) & (CPU_TYPE_EC020 | CPU_TYPE_020))
+#else
+	#define CPU_TYPE_IS_020_VARIANT(A) 0
+#endif
+
+#if M68K_EMULATE_020 || M68K_EMULATE_EC020 || M68K_EMULATE_010
+	#define CPU_TYPE_IS_000(A)         ((A) == CPU_TYPE_000)
+#else
+	#define CPU_TYPE_IS_000(A)         1
+#endif
+
+
+#if !M68K_SEPARATE_READS
+#define m68k_read_immediate_16(A) m68ki_read_program_16(A)
+#define m68k_read_immediate_32(A) m68ki_read_program_32(A)
+
+#define m68k_read_pcrelative_8(A) m68ki_read_program_8(A)
+#define m68k_read_pcrelative_16(A) m68ki_read_program_16(A)
+#define m68k_read_pcrelative_32(A) m68ki_read_program_32(A)
+#endif /* M68K_SEPARATE_READS */
+
+
+/* Enable or disable callback functions */
+#if M68K_EMULATE_INT_ACK
+	#if M68K_EMULATE_INT_ACK == OPT_SPECIFY_HANDLER
+		#define m68ki_int_ack(A) M68K_INT_ACK_CALLBACK(A)
+	#else
+		#define m68ki_int_ack(A) CALLBACK_INT_ACK(A)
+	#endif
+#else
+	/* Default action is to used autovector mode, which is most common */
+	#define m68ki_int_ack(A) M68K_INT_ACK_AUTOVECTOR
+#endif /* M68K_EMULATE_INT_ACK */
+
+#if M68K_EMULATE_BKPT_ACK
+	#if M68K_EMULATE_BKPT_ACK == OPT_SPECIFY_HANDLER
+		#define m68ki_bkpt_ack(A) M68K_BKPT_ACK_CALLBACK(A)
+	#else
+		#define m68ki_bkpt_ack(A) CALLBACK_BKPT_ACK(A)
+	#endif
+#else
+	#define m68ki_bkpt_ack(A)
+#endif /* M68K_EMULATE_BKPT_ACK */
+
+#if M68K_EMULATE_RESET
+	#if M68K_EMULATE_RESET == OPT_SPECIFY_HANDLER
+		#define m68ki_output_reset() M68K_RESET_CALLBACK()
+	#else
+		#define m68ki_output_reset() CALLBACK_RESET_INSTR()
+	#endif
+#else
+	#define m68ki_output_reset()
+#endif /* M68K_EMULATE_RESET */
+
+#if M68K_INSTRUCTION_HOOK
+	#if M68K_INSTRUCTION_HOOK == OPT_SPECIFY_HANDLER
+		#define m68ki_instr_hook() M68K_INSTRUCTION_CALLBACK()
+	#else
+		#define m68ki_instr_hook() CALLBACK_INSTR_HOOK()
+	#endif
+#else
+	#define m68ki_instr_hook()
+#endif /* M68K_INSTRUCTION_HOOK */
+
+#if M68K_MONITOR_PC
+	#if M68K_MONITOR_PC == OPT_SPECIFY_HANDLER
+		#define m68ki_pc_changed(A) M68K_SET_PC_CALLBACK(ADDRESS_68K(A))
+	#else
+		#define m68ki_pc_changed(A) CALLBACK_PC_CHANGED(ADDRESS_68K(A))
+	#endif
+#else
+	#define m68ki_pc_changed(A)
+#endif /* M68K_MONITOR_PC */
+
+
+/* Enable or disable function code emulation */
+#if M68K_EMULATE_FC
+	#if M68K_EMULATE_FC == OPT_SPECIFY_HANDLER
+		#define m68ki_set_fc(A) M68K_SET_FC_CALLBACK(A)
+	#else
+		#define m68ki_set_fc(A) CALLBACK_SET_FC(A)
+	#endif
+	#define m68ki_use_data_space() m68ki_address_space = FUNCTION_CODE_USER_DATA
+	#define m68ki_use_program_space() m68ki_address_space = FUNCTION_CODE_USER_PROGRAM
+	#define m68ki_get_address_space() m68ki_address_space
+#else
+	#define m68ki_set_fc(A)
+	#define m68ki_use_data_space()
+	#define m68ki_use_program_space()
+	#define m68ki_get_address_space() FUNCTION_CODE_USER_DATA
+#endif /* M68K_EMULATE_FC */
+
+
+/* Enable or disable trace emulation */
+#if M68K_EMULATE_TRACE
+	/* Initiates trace checking before each instruction (t1) */
+	#define m68ki_trace_t1() m68ki_tracing = FLAG_T1
+	/* adds t0 to trace checking if we encounter change of flow */
+	#define m68ki_trace_t0() m68ki_tracing |= FLAG_T0
+	/* Clear all tracing */
+	#define m68ki_clear_trace() m68ki_tracing = 0
+	/* Cause a trace exception if we are tracing */
+	#define m68ki_exception_if_trace() if(m68ki_tracing) m68ki_exception_trace()
+#else
+	#define m68ki_trace_t1()
+	#define m68ki_trace_t0()
+	#define m68ki_clear_trace()
+	#define m68ki_exception_if_trace()
+#endif /* M68K_EMULATE_TRACE */
+
+
+
+/* Address error */
+#if M68K_EMULATE_ADDRESS_ERROR
+	#include <setjmp.h>
+	extern jmp_buf m68ki_aerr_trap;
+
+	#define m68ki_set_address_error_trap() \
+		if(setjmp(m68ki_aerr_trap) != 0) \
+		{ \
+			m68ki_exception_address_error(); \
+			if(CPU_STOPPED) \
+			{ \
+				SET_CYCLES(0); \
+				CPU_INT_CYCLES = 0; \
+				return m68ki_initial_cycles; \
+			} \
+		}
+
+	#define m68ki_check_address_error(ADDR, WRITE_MODE, FC) \
+		if((ADDR)&1) \
+		{ \
+			m68ki_aerr_address = ADDR; \
+			m68ki_aerr_write_mode = WRITE_MODE; \
+			m68ki_aerr_fc = FC; \
+			longjmp(m68ki_aerr_trap, 1); \
+		}
+#else
+	#define m68ki_set_address_error_trap()
+	#define m68ki_check_address_error(ADDR, WRITE_MODE, FC)
+#endif /* M68K_ADDRESS_ERROR */
+
+/* Logging */
+#if M68K_LOG_ENABLE
+	#include <stdio.h>
+	extern FILE* M68K_LOG_FILEHANDLE
+	extern char* m68ki_cpu_names[];
+
+	#define M68K_DO_LOG(A) if(M68K_LOG_FILEHANDLE) fprintf A
+	#if M68K_LOG_1010_1111
+		#define M68K_DO_LOG_EMU(A) if(M68K_LOG_FILEHANDLE) fprintf A
+	#else
+		#define M68K_DO_LOG_EMU(A)
+	#endif
+#else
+	#define M68K_DO_LOG(A)
+	#define M68K_DO_LOG_EMU(A)
+#endif
+
+
+
+/* -------------------------- EA / Operand Access ------------------------- */
+
+/*
+ * The general instruction format follows this pattern:
+ * .... XXX. .... .YYY
+ * where XXX is register X and YYY is register Y
+ */
+/* Data Register Isolation */
+#define DX (REG_D[(REG_IR >> 9) & 7])
+#define DY (REG_D[REG_IR & 7])
+/* Address Register Isolation */
+#define AX (REG_A[(REG_IR >> 9) & 7])
+#define AY (REG_A[REG_IR & 7])
+
+
+/* Effective Address Calculations */
+#define EA_AY_AI_8()   AY                                    /* address register indirect */
+#define EA_AY_AI_16()  EA_AY_AI_8()
+#define EA_AY_AI_32()  EA_AY_AI_8()
+#define EA_AY_PI_8()   (AY++)                                /* postincrement (size = byte) */
+#define EA_AY_PI_16()  ((AY+=2)-2)                           /* postincrement (size = word) */
+#define EA_AY_PI_32()  ((AY+=4)-4)                           /* postincrement (size = long) */
+#define EA_AY_PD_8()   (--AY)                                /* predecrement (size = byte) */
+#define EA_AY_PD_16()  (AY-=2)                               /* predecrement (size = word) */
+#define EA_AY_PD_32()  (AY-=4)                               /* predecrement (size = long) */
+#define EA_AY_DI_8()   (AY+MAKE_INT_16(m68ki_read_imm_16())) /* displacement */
+#define EA_AY_DI_16()  EA_AY_DI_8()
+#define EA_AY_DI_32()  EA_AY_DI_8()
+#define EA_AY_IX_8()   m68ki_get_ea_ix(AY)                   /* indirect + index */
+#define EA_AY_IX_16()  EA_AY_IX_8()
+#define EA_AY_IX_32()  EA_AY_IX_8()
+
+#define EA_AX_AI_8()   AX
+#define EA_AX_AI_16()  EA_AX_AI_8()
+#define EA_AX_AI_32()  EA_AX_AI_8()
+#define EA_AX_PI_8()   (AX++)
+#define EA_AX_PI_16()  ((AX+=2)-2)
+#define EA_AX_PI_32()  ((AX+=4)-4)
+#define EA_AX_PD_8()   (--AX)
+#define EA_AX_PD_16()  (AX-=2)
+#define EA_AX_PD_32()  (AX-=4)
+#define EA_AX_DI_8()   (AX+MAKE_INT_16(m68ki_read_imm_16()))
+#define EA_AX_DI_16()  EA_AX_DI_8()
+#define EA_AX_DI_32()  EA_AX_DI_8()
+#define EA_AX_IX_8()   m68ki_get_ea_ix(AX)
+#define EA_AX_IX_16()  EA_AX_IX_8()
+#define EA_AX_IX_32()  EA_AX_IX_8()
+
+#define EA_A7_PI_8()   ((REG_A[7]+=2)-2)
+#define EA_A7_PD_8()   (REG_A[7]-=2)
+
+#define EA_AW_8()      MAKE_INT_16(m68ki_read_imm_16())      /* absolute word */
+#define EA_AW_16()     EA_AW_8()
+#define EA_AW_32()     EA_AW_8()
+#define EA_AL_8()      m68ki_read_imm_32()                   /* absolute long */
+#define EA_AL_16()     EA_AL_8()
+#define EA_AL_32()     EA_AL_8()
+#define EA_PCDI_8()    m68ki_get_ea_pcdi()                   /* pc indirect + displacement */
+#define EA_PCDI_16()   EA_PCDI_8()
+#define EA_PCDI_32()   EA_PCDI_8()
+#define EA_PCIX_8()    m68ki_get_ea_pcix()                   /* pc indirect + index */
+#define EA_PCIX_16()   EA_PCIX_8()
+#define EA_PCIX_32()   EA_PCIX_8()
+
+
+#define OPER_I_8()     m68ki_read_imm_8()
+#define OPER_I_16()    m68ki_read_imm_16()
+#define OPER_I_32()    m68ki_read_imm_32()
+
+
+
+/* --------------------------- Status Register ---------------------------- */
+
+/* Flag Calculation Macros */
+#define CFLAG_8(A) (A)
+#define CFLAG_16(A) ((A)>>8)
+
+#if M68K_INT_GT_32_BIT
+	#define CFLAG_ADD_32(S, D, R) ((R)>>24)
+	#define CFLAG_SUB_32(S, D, R) ((R)>>24)
+#else
+	#define CFLAG_ADD_32(S, D, R) (((S & D) | (~R & (S | D)))>>23)
+	#define CFLAG_SUB_32(S, D, R) (((S & R) | (~D & (S | R)))>>23)
+#endif /* M68K_INT_GT_32_BIT */
+
+#define VFLAG_ADD_8(S, D, R) ((S^R) & (D^R))
+#define VFLAG_ADD_16(S, D, R) (((S^R) & (D^R))>>8)
+#define VFLAG_ADD_32(S, D, R) (((S^R) & (D^R))>>24)
+
+#define VFLAG_SUB_8(S, D, R) ((S^D) & (R^D))
+#define VFLAG_SUB_16(S, D, R) (((S^D) & (R^D))>>8)
+#define VFLAG_SUB_32(S, D, R) (((S^D) & (R^D))>>24)
+
+#define NFLAG_8(A) (A)
+#define NFLAG_16(A) ((A)>>8)
+#define NFLAG_32(A) ((A)>>24)
+#define NFLAG_64(A) ((A)>>56)
+
+#define ZFLAG_8(A) MASK_OUT_ABOVE_8(A)
+#define ZFLAG_16(A) MASK_OUT_ABOVE_16(A)
+#define ZFLAG_32(A) MASK_OUT_ABOVE_32(A)
+
+
+/* Flag values */
+#define NFLAG_SET   0x80
+#define NFLAG_CLEAR 0
+#define CFLAG_SET   0x100
+#define CFLAG_CLEAR 0
+#define XFLAG_SET   0x100
+#define XFLAG_CLEAR 0
+#define VFLAG_SET   0x80
+#define VFLAG_CLEAR 0
+#define ZFLAG_SET   0
+#define ZFLAG_CLEAR 0xffffffff
+
+#define SFLAG_SET   4
+#define SFLAG_CLEAR 0
+#define MFLAG_SET   2
+#define MFLAG_CLEAR 0
+
+/* Turn flag values into 1 or 0 */
+#define XFLAG_AS_1() ((FLAG_X>>8)&1)
+#define NFLAG_AS_1() ((FLAG_N>>7)&1)
+#define VFLAG_AS_1() ((FLAG_V>>7)&1)
+#define ZFLAG_AS_1() (!FLAG_Z)
+#define CFLAG_AS_1() ((FLAG_C>>8)&1)
+
+
+/* Conditions */
+#define COND_CS() (FLAG_C&0x100)
+#define COND_CC() (!COND_CS())
+#define COND_VS() (FLAG_V&0x80)
+#define COND_VC() (!COND_VS())
+#define COND_NE() FLAG_Z
+#define COND_EQ() (!COND_NE())
+#define COND_MI() (FLAG_N&0x80)
+#define COND_PL() (!COND_MI())
+#define COND_LT() ((FLAG_N^FLAG_V)&0x80)
+#define COND_GE() (!COND_LT())
+#define COND_HI() (COND_CC() && COND_NE())
+#define COND_LS() (COND_CS() || COND_EQ())
+#define COND_GT() (COND_GE() && COND_NE())
+#define COND_LE() (COND_LT() || COND_EQ())
+
+/* Reversed conditions */
+#define COND_NOT_CS() COND_CC()
+#define COND_NOT_CC() COND_CS()
+#define COND_NOT_VS() COND_VC()
+#define COND_NOT_VC() COND_VS()
+#define COND_NOT_NE() COND_EQ()
+#define COND_NOT_EQ() COND_NE()
+#define COND_NOT_MI() COND_PL()
+#define COND_NOT_PL() COND_MI()
+#define COND_NOT_LT() COND_GE()
+#define COND_NOT_GE() COND_LT()
+#define COND_NOT_HI() COND_LS()
+#define COND_NOT_LS() COND_HI()
+#define COND_NOT_GT() COND_LE()
+#define COND_NOT_LE() COND_GT()
+
+/* Not real conditions, but here for convenience */
+#define COND_XS() (FLAG_X&0x100)
+#define COND_XC() (!COND_XS)
+
+
+/* Get the condition code register */
+#define m68ki_get_ccr() ((COND_XS() >> 4) | \
+						 (COND_MI() >> 4) | \
+						 (COND_EQ() << 2) | \
+						 (COND_VS() >> 6) | \
+						 (COND_CS() >> 8))
+
+/* Get the status register */
+#define m68ki_get_sr() ( FLAG_T1              | \
+						 FLAG_T0              | \
+						(FLAG_S        << 11) | \
+						(FLAG_M        << 11) | \
+						 FLAG_INT_MASK        | \
+						 m68ki_get_ccr())
+
+
+
+/* ---------------------------- Cycle Counting ---------------------------- */
+
+#define ADD_CYCLES(A)    m68ki_remaining_cycles += (A)
+#define USE_CYCLES(A)    m68ki_remaining_cycles -= (A)
+#define SET_CYCLES(A)    m68ki_remaining_cycles = A
+#define GET_CYCLES()     m68ki_remaining_cycles
+#define USE_ALL_CYCLES() m68ki_remaining_cycles %= CYC_INSTRUCTION[REG_IR]
+
+
+
+/* ----------------------------- Read / Write ----------------------------- */
+
+/* Read from the current address space */
+#define m68ki_read_8(A)  m68ki_read_8_fc (A, FLAG_S | m68ki_get_address_space())
+#define m68ki_read_16(A) m68ki_read_16_fc(A, FLAG_S | m68ki_get_address_space())
+#define m68ki_read_32(A) m68ki_read_32_fc(A, FLAG_S | m68ki_get_address_space())
+
+/* Write to the current data space */
+#define m68ki_write_8(A, V)  m68ki_write_8_fc (A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#define m68ki_write_16(A, V) m68ki_write_16_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#define m68ki_write_32(A, V) m68ki_write_32_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+
+#if M68K_SIMULATE_PD_WRITES
+#define m68ki_write_32_pd(A, V) m68ki_write_32_pd_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#else
+#define m68ki_write_32_pd(A, V) m68ki_write_32_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA, V)
+#endif
+
+/* map read immediate 8 to read immediate 16 */
+#define m68ki_read_imm_8() MASK_OUT_ABOVE_8(m68ki_read_imm_16())
+
+/* Map PC-relative reads */
+#define m68ki_read_pcrel_8(A) m68k_read_pcrelative_8(A)
+#define m68ki_read_pcrel_16(A) m68k_read_pcrelative_16(A)
+#define m68ki_read_pcrel_32(A) m68k_read_pcrelative_32(A)
+
+/* Read from the program space */
+#define m68ki_read_program_8(A) 	m68ki_read_8_fc(A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
+#define m68ki_read_program_16(A) 	m68ki_read_16_fc(A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
+#define m68ki_read_program_32(A) 	m68ki_read_32_fc(A, FLAG_S | FUNCTION_CODE_USER_PROGRAM)
+
+/* Read from the data space */
+#define m68ki_read_data_8(A) 	m68ki_read_8_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA)
+#define m68ki_read_data_16(A) 	m68ki_read_16_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA)
+#define m68ki_read_data_32(A) 	m68ki_read_32_fc(A, FLAG_S | FUNCTION_CODE_USER_DATA)
+
+
+
+/* ======================================================================== */
+/* =============================== PROTOTYPES ============================= */
+/* ======================================================================== */
+
+typedef struct
+{
+	uint cpu_type;     /* CPU Type: 68000, 68010, 68EC020, or 68020 */
+	uint dar[16];      /* Data and Address Registers */
+	uint ppc;		   /* Previous program counter */
+	uint pc;           /* Program Counter */
+	uint sp[7];        /* User, Interrupt, and Master Stack Pointers */
+	uint vbr;          /* Vector Base Register (m68010+) */
+	uint sfc;          /* Source Function Code Register (m68010+) */
+	uint dfc;          /* Destination Function Code Register (m68010+) */
+	uint cacr;         /* Cache Control Register (m68020, unemulated) */
+	uint caar;         /* Cache Address Register (m68020, unemulated) */
+	uint ir;           /* Instruction Register */
+	uint t1_flag;      /* Trace 1 */
+	uint t0_flag;      /* Trace 0 */
+	uint s_flag;       /* Supervisor */
+	uint m_flag;       /* Master/Interrupt state */
+	uint x_flag;       /* Extend */
+	uint n_flag;       /* Negative */
+	uint not_z_flag;   /* Zero, inverted for speedups */
+	uint v_flag;       /* Overflow */
+	uint c_flag;       /* Carry */
+	uint int_mask;     /* I0-I2 */
+	uint int_level;    /* State of interrupt pins IPL0-IPL2 -- ASG: changed from ints_pending */
+	uint int_cycles;   /* ASG: extra cycles from generated interrupts */
+	uint stopped;      /* Stopped state */
+	uint pref_addr;    /* Last prefetch address */
+	uint pref_data;    /* Data in the prefetch queue */
+	uint address_mask; /* Available address pins */
+	uint sr_mask;      /* Implemented status register bits */
+	uint instr_mode;   /* Stores whether we are in instruction mode or group 0/1 exception mode */
+	uint run_mode;     /* Stores whether we are processing a reset, bus error, address error, or something else */
+
+	/* Clocks required for instructions / exceptions */
+	uint cyc_bcc_notake_b;
+	uint cyc_bcc_notake_w;
+	uint cyc_dbcc_f_noexp;
+	uint cyc_dbcc_f_exp;
+	uint cyc_scc_r_true;
+	uint cyc_movem_w;
+	uint cyc_movem_l;
+	uint cyc_shift;
+	uint cyc_reset;
+	uint8* cyc_instruction;
+	uint8* cyc_exception;
+
+	/* Callbacks to host */
+	int  (*int_ack_callback)(int int_line);           /* Interrupt Acknowledge */
+	void (*bkpt_ack_callback)(unsigned int data);     /* Breakpoint Acknowledge */
+	void (*reset_instr_callback)(void);               /* Called when a RESET instruction is encountered */
+	void (*pc_changed_callback)(unsigned int new_pc); /* Called when the PC changes by a large amount */
+	void (*set_fc_callback)(unsigned int new_fc);     /* Called when the CPU function code changes */
+	void (*instr_hook_callback)(void);                /* Called every instruction cycle prior to execution */
+
+} m68ki_cpu_core;
+
+
+extern m68ki_cpu_core m68ki_cpu;
+extern sint           m68ki_remaining_cycles;
+extern uint           m68ki_tracing;
+extern uint8          m68ki_shift_8_table[];
+extern uint16         m68ki_shift_16_table[];
+extern uint           m68ki_shift_32_table[];
+extern uint8          m68ki_exception_cycle_table[][256];
+extern uint           m68ki_address_space;
+extern uint8          m68ki_ea_idx_cycle_table[];
+
+extern uint           m68ki_aerr_address;
+extern uint           m68ki_aerr_write_mode;
+extern uint           m68ki_aerr_fc;
+
+/* Read data immediately after the program counter */
+INLINE uint m68ki_read_imm_16(void);
+INLINE uint m68ki_read_imm_32(void);
+
+/* Read data with specific function code */
+INLINE uint m68ki_read_8_fc  (uint address, uint fc);
+INLINE uint m68ki_read_16_fc (uint address, uint fc);
+INLINE uint m68ki_read_32_fc (uint address, uint fc);
+
+/* Write data with specific function code */
+INLINE void m68ki_write_8_fc (uint address, uint fc, uint value);
+INLINE void m68ki_write_16_fc(uint address, uint fc, uint value);
+INLINE void m68ki_write_32_fc(uint address, uint fc, uint value);
+#if M68K_SIMULATE_PD_WRITES
+INLINE void m68ki_write_32_pd_fc(uint address, uint fc, uint value);
+#endif /* M68K_SIMULATE_PD_WRITES */
+
+/* Indexed and PC-relative ea fetching */
+INLINE uint m68ki_get_ea_pcdi(void);
+INLINE uint m68ki_get_ea_pcix(void);
+INLINE uint m68ki_get_ea_ix(uint An);
+
+/* Operand fetching */
+INLINE uint OPER_AY_AI_8(void);
+INLINE uint OPER_AY_AI_16(void);
+INLINE uint OPER_AY_AI_32(void);
+INLINE uint OPER_AY_PI_8(void);
+INLINE uint OPER_AY_PI_16(void);
+INLINE uint OPER_AY_PI_32(void);
+INLINE uint OPER_AY_PD_8(void);
+INLINE uint OPER_AY_PD_16(void);
+INLINE uint OPER_AY_PD_32(void);
+INLINE uint OPER_AY_DI_8(void);
+INLINE uint OPER_AY_DI_16(void);
+INLINE uint OPER_AY_DI_32(void);
+INLINE uint OPER_AY_IX_8(void);
+INLINE uint OPER_AY_IX_16(void);
+INLINE uint OPER_AY_IX_32(void);
+
+INLINE uint OPER_AX_AI_8(void);
+INLINE uint OPER_AX_AI_16(void);
+INLINE uint OPER_AX_AI_32(void);
+INLINE uint OPER_AX_PI_8(void);
+INLINE uint OPER_AX_PI_16(void);
+INLINE uint OPER_AX_PI_32(void);
+INLINE uint OPER_AX_PD_8(void);
+INLINE uint OPER_AX_PD_16(void);
+INLINE uint OPER_AX_PD_32(void);
+INLINE uint OPER_AX_DI_8(void);
+INLINE uint OPER_AX_DI_16(void);
+INLINE uint OPER_AX_DI_32(void);
+INLINE uint OPER_AX_IX_8(void);
+INLINE uint OPER_AX_IX_16(void);
+INLINE uint OPER_AX_IX_32(void);
+
+INLINE uint OPER_A7_PI_8(void);
+INLINE uint OPER_A7_PD_8(void);
+
+INLINE uint OPER_AW_8(void);
+INLINE uint OPER_AW_16(void);
+INLINE uint OPER_AW_32(void);
+INLINE uint OPER_AL_8(void);
+INLINE uint OPER_AL_16(void);
+INLINE uint OPER_AL_32(void);
+INLINE uint OPER_PCDI_8(void);
+INLINE uint OPER_PCDI_16(void);
+INLINE uint OPER_PCDI_32(void);
+INLINE uint OPER_PCIX_8(void);
+INLINE uint OPER_PCIX_16(void);
+INLINE uint OPER_PCIX_32(void);
+
+/* Stack operations */
+INLINE void m68ki_push_16(uint value);
+INLINE void m68ki_push_32(uint value);
+INLINE uint m68ki_pull_16(void);
+INLINE uint m68ki_pull_32(void);
+
+/* Program flow operations */
+INLINE void m68ki_jump(uint new_pc);
+INLINE void m68ki_jump_vector(uint vector);
+INLINE void m68ki_branch_8(uint offset);
+INLINE void m68ki_branch_16(uint offset);
+INLINE void m68ki_branch_32(uint offset);
+
+/* Status register operations. */
+INLINE void m68ki_set_s_flag(uint value);            /* Only bit 2 of value should be set (i.e. 4 or 0) */
+INLINE void m68ki_set_sm_flag(uint value);           /* only bits 1 and 2 of value should be set */
+INLINE void m68ki_set_ccr(uint value);               /* set the condition code register */
+INLINE void m68ki_set_sr(uint value);                /* set the status register */
+INLINE void m68ki_set_sr_noint(uint value);          /* set the status register */
+
+/* Exception processing */
+INLINE uint m68ki_init_exception(void);              /* Initial exception processing */
+
+INLINE void m68ki_stack_frame_3word(uint pc, uint sr); /* Stack various frame types */
+INLINE void m68ki_stack_frame_buserr(uint sr);
+
+INLINE void m68ki_stack_frame_0000(uint pc, uint sr, uint vector);
+INLINE void m68ki_stack_frame_0001(uint pc, uint sr, uint vector);
+INLINE void m68ki_stack_frame_0010(uint sr, uint vector);
+INLINE void m68ki_stack_frame_1000(uint pc, uint sr, uint vector);
+INLINE void m68ki_stack_frame_1010(uint sr, uint vector, uint pc);
+INLINE void m68ki_stack_frame_1011(uint sr, uint vector, uint pc);
+
+INLINE void m68ki_exception_trap(uint vector);
+INLINE void m68ki_exception_trapN(uint vector);
+INLINE void m68ki_exception_trace(void);
+INLINE void m68ki_exception_privilege_violation(void);
+INLINE void m68ki_exception_1010(void);
+INLINE void m68ki_exception_1111(void);
+INLINE void m68ki_exception_illegal(void);
+INLINE void m68ki_exception_format_error(void);
+INLINE void m68ki_exception_address_error(void);
+INLINE void m68ki_exception_interrupt(uint int_level);
+INLINE void m68ki_check_interrupts(void);            /* ASG: check for interrupts */
+
+/* quick disassembly (used for logging) */
+char* m68ki_disassemble_quick(unsigned int pc, unsigned int cpu_type);
+
+
+/* ======================================================================== */
+/* =========================== UTILITY FUNCTIONS ========================== */
+/* ======================================================================== */
+
+
+/* ---------------------------- Read Immediate ---------------------------- */
+
+/* Handles all immediate reads, does address error check, function code setting,
+ * and prefetching if they are enabled in m68kconf.h
+ */
+INLINE uint m68ki_read_imm_16(void)
+{
+	m68ki_set_fc(FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(REG_PC, MODE_READ, FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+#if M68K_EMULATE_PREFETCH
+	if(MASK_OUT_BELOW_2(REG_PC) != CPU_PREF_ADDR)
+	{
+		CPU_PREF_ADDR = MASK_OUT_BELOW_2(REG_PC);
+		CPU_PREF_DATA = m68k_read_immediate_32(ADDRESS_68K(CPU_PREF_ADDR));
+	}
+	REG_PC += 2;
+	return MASK_OUT_ABOVE_16(CPU_PREF_DATA >> ((2-((REG_PC-2)&2))<<3));
+#else
+	REG_PC += 2;
+	return m68k_read_immediate_16(ADDRESS_68K(REG_PC-2));
+#endif /* M68K_EMULATE_PREFETCH */
+}
+INLINE uint m68ki_read_imm_32(void)
+{
+#if M68K_EMULATE_PREFETCH
+	uint temp_val;
+
+	m68ki_set_fc(FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(REG_PC, MODE_READ, FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+	if(MASK_OUT_BELOW_2(REG_PC) != CPU_PREF_ADDR)
+	{
+		CPU_PREF_ADDR = MASK_OUT_BELOW_2(REG_PC);
+		CPU_PREF_DATA = m68k_read_immediate_32(ADDRESS_68K(CPU_PREF_ADDR));
+	}
+	temp_val = CPU_PREF_DATA;
+	REG_PC += 2;
+	if(MASK_OUT_BELOW_2(REG_PC) != CPU_PREF_ADDR)
+	{
+		CPU_PREF_ADDR = MASK_OUT_BELOW_2(REG_PC);
+		CPU_PREF_DATA = m68k_read_immediate_32(ADDRESS_68K(CPU_PREF_ADDR));
+		temp_val = MASK_OUT_ABOVE_32((temp_val << 16) | (CPU_PREF_DATA >> 16));
+	}
+	REG_PC += 2;
+
+	return temp_val;
+#else
+	m68ki_set_fc(FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(REG_PC, MODE_READ, FLAG_S | FUNCTION_CODE_USER_PROGRAM); /* auto-disable (see m68kcpu.h) */
+	REG_PC += 4;
+	return m68k_read_immediate_32(ADDRESS_68K(REG_PC-4));
+#endif /* M68K_EMULATE_PREFETCH */
+}
+
+
+
+/* ------------------------- Top level read/write ------------------------- */
+
+/* Handles all memory accesses (except for immediate reads if they are
+ * configured to use separate functions in m68kconf.h).
+ * All memory accesses must go through these top level functions.
+ * These functions will also check for address error and set the function
+ * code if they are enabled in m68kconf.h.
+ */
+INLINE uint m68ki_read_8_fc(uint address, uint fc)
+{
+	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
+	return m68k_read_memory_8(ADDRESS_68K(address));
+}
+INLINE uint m68ki_read_16_fc(uint address, uint fc)
+{
+	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(address, MODE_READ, fc); /* auto-disable (see m68kcpu.h) */
+	return m68k_read_memory_16(ADDRESS_68K(address));
+}
+INLINE uint m68ki_read_32_fc(uint address, uint fc)
+{
+	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(address, MODE_READ, fc); /* auto-disable (see m68kcpu.h) */
+	return m68k_read_memory_32(ADDRESS_68K(address));
+}
+
+INLINE void m68ki_write_8_fc(uint address, uint fc, uint value)
+{
+	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
+	m68k_write_memory_8(ADDRESS_68K(address), value);
+}
+INLINE void m68ki_write_16_fc(uint address, uint fc, uint value)
+{
+	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
+	m68k_write_memory_16(ADDRESS_68K(address), value);
+}
+INLINE void m68ki_write_32_fc(uint address, uint fc, uint value)
+{
+	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
+	m68k_write_memory_32(ADDRESS_68K(address), value);
+}
+
+#if M68K_SIMULATE_PD_WRITES
+INLINE void m68ki_write_32_pd_fc(uint address, uint fc, uint value)
+{
+	m68ki_set_fc(fc); /* auto-disable (see m68kcpu.h) */
+	m68ki_check_address_error(address, MODE_WRITE, fc); /* auto-disable (see m68kcpu.h) */
+	m68k_write_memory_32_pd(ADDRESS_68K(address), value);
+}
+#endif
+
+
+/* --------------------- Effective Address Calculation -------------------- */
+
+/* The program counter relative addressing modes cause operands to be
+ * retrieved from program space, not data space.
+ */
+INLINE uint m68ki_get_ea_pcdi(void)
+{
+	uint old_pc = REG_PC;
+	m68ki_use_program_space(); /* auto-disable */
+	return old_pc + MAKE_INT_16(m68ki_read_imm_16());
+}
+
+
+INLINE uint m68ki_get_ea_pcix(void)
+{
+	m68ki_use_program_space(); /* auto-disable */
+	return m68ki_get_ea_ix(REG_PC);
+}
+
+/* Indexed addressing modes are encoded as follows:
+ *
+ * Base instruction format:
+ * F E D C B A 9 8 7 6 | 5 4 3 | 2 1 0
+ * x x x x x x x x x x | 1 1 0 | BASE REGISTER      (An)
+ *
+ * Base instruction format for destination EA in move instructions:
+ * F E D C | B A 9    | 8 7 6 | 5 4 3 2 1 0
+ * x x x x | BASE REG | 1 1 0 | X X X X X X       (An)
+ *
+ * Brief extension format:
+ *  F  |  E D C   |  B  |  A 9  | 8 | 7 6 5 4 3 2 1 0
+ * D/A | REGISTER | W/L | SCALE | 0 |  DISPLACEMENT
+ *
+ * Full extension format:
+ *  F     E D C      B     A 9    8   7    6    5 4       3   2 1 0
+ * D/A | REGISTER | W/L | SCALE | 1 | BS | IS | BD SIZE | 0 | I/IS
+ * BASE DISPLACEMENT (0, 16, 32 bit)                (bd)
+ * OUTER DISPLACEMENT (0, 16, 32 bit)               (od)
+ *
+ * D/A:     0 = Dn, 1 = An                          (Xn)
+ * W/L:     0 = W (sign extend), 1 = L              (.SIZE)
+ * SCALE:   00=1, 01=2, 10=4, 11=8                  (*SCALE)
+ * BS:      0=add base reg, 1=suppress base reg     (An suppressed)
+ * IS:      0=add index, 1=suppress index           (Xn suppressed)
+ * BD SIZE: 00=reserved, 01=NULL, 10=Word, 11=Long  (size of bd)
+ *
+ * IS I/IS Operation
+ * 0  000  No Memory Indirect
+ * 0  001  indir prex with null outer
+ * 0  010  indir prex with word outer
+ * 0  011  indir prex with long outer
+ * 0  100  reserved
+ * 0  101  indir postx with null outer
+ * 0  110  indir postx with word outer
+ * 0  111  indir postx with long outer
+ * 1  000  no memory indirect
+ * 1  001  mem indir with null outer
+ * 1  010  mem indir with word outer
+ * 1  011  mem indir with long outer
+ * 1  100-111  reserved
+ */
+INLINE uint m68ki_get_ea_ix(uint An)
+{
+	/* An = base register */
+	uint extension = m68ki_read_imm_16();
+	uint Xn = 0;                        /* Index register */
+	uint bd = 0;                        /* Base Displacement */
+	uint od = 0;                        /* Outer Displacement */
+
+	if(CPU_TYPE_IS_010_LESS(CPU_TYPE))
+	{
+		/* Calculate index */
+		Xn = REG_DA[extension>>12];     /* Xn */
+		if(!BIT_B(extension))           /* W/L */
+			Xn = MAKE_INT_16(Xn);
+
+		/* Add base register and displacement and return */
+		return An + Xn + MAKE_INT_8(extension);
+	}
+
+	/* Brief extension format */
+	if(!BIT_8(extension))
+	{
+		/* Calculate index */
+		Xn = REG_DA[extension>>12];     /* Xn */
+		if(!BIT_B(extension))           /* W/L */
+			Xn = MAKE_INT_16(Xn);
+		/* Add scale if proper CPU type */
+		if(CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+			Xn <<= (extension>>9) & 3;  /* SCALE */
+
+		/* Add base register and displacement and return */
+		return An + Xn + MAKE_INT_8(extension);
+	}
+
+	/* Full extension format */
+
+	USE_CYCLES(m68ki_ea_idx_cycle_table[extension&0x3f]);
+
+	/* Check if base register is present */
+	if(BIT_7(extension))                /* BS */
+		An = 0;                         /* An */
+
+	/* Check if index is present */
+	if(!BIT_6(extension))               /* IS */
+	{
+		Xn = REG_DA[extension>>12];     /* Xn */
+		if(!BIT_B(extension))           /* W/L */
+			Xn = MAKE_INT_16(Xn);
+		Xn <<= (extension>>9) & 3;      /* SCALE */
+	}
+
+	/* Check if base displacement is present */
+	if(BIT_5(extension))                /* BD SIZE */
+		bd = BIT_4(extension) ? m68ki_read_imm_32() : MAKE_INT_16(m68ki_read_imm_16());
+
+	/* If no indirect action, we are done */
+	if(!(extension&7))                  /* No Memory Indirect */
+		return An + bd + Xn;
+
+	/* Check if outer displacement is present */
+	if(BIT_1(extension))                /* I/IS:  od */
+		od = BIT_0(extension) ? m68ki_read_imm_32() : MAKE_INT_16(m68ki_read_imm_16());
+
+	/* Postindex */
+	if(BIT_2(extension))                /* I/IS:  0 = preindex, 1 = postindex */
+		return m68ki_read_32(An + bd) + Xn + od;
+
+	/* Preindex */
+	return m68ki_read_32(An + bd + Xn) + od;
+}
+
+
+/* Fetch operands */
+INLINE uint OPER_AY_AI_8(void)  {uint ea = EA_AY_AI_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AY_AI_16(void) {uint ea = EA_AY_AI_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AY_AI_32(void) {uint ea = EA_AY_AI_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AY_PI_8(void)  {uint ea = EA_AY_PI_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AY_PI_16(void) {uint ea = EA_AY_PI_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AY_PI_32(void) {uint ea = EA_AY_PI_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AY_PD_8(void)  {uint ea = EA_AY_PD_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AY_PD_16(void) {uint ea = EA_AY_PD_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AY_PD_32(void) {uint ea = EA_AY_PD_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AY_DI_8(void)  {uint ea = EA_AY_DI_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AY_DI_16(void) {uint ea = EA_AY_DI_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AY_DI_32(void) {uint ea = EA_AY_DI_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AY_IX_8(void)  {uint ea = EA_AY_IX_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AY_IX_16(void) {uint ea = EA_AY_IX_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AY_IX_32(void) {uint ea = EA_AY_IX_32(); return m68ki_read_32(ea);}
+
+INLINE uint OPER_AX_AI_8(void)  {uint ea = EA_AX_AI_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AX_AI_16(void) {uint ea = EA_AX_AI_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AX_AI_32(void) {uint ea = EA_AX_AI_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AX_PI_8(void)  {uint ea = EA_AX_PI_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AX_PI_16(void) {uint ea = EA_AX_PI_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AX_PI_32(void) {uint ea = EA_AX_PI_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AX_PD_8(void)  {uint ea = EA_AX_PD_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AX_PD_16(void) {uint ea = EA_AX_PD_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AX_PD_32(void) {uint ea = EA_AX_PD_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AX_DI_8(void)  {uint ea = EA_AX_DI_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AX_DI_16(void) {uint ea = EA_AX_DI_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AX_DI_32(void) {uint ea = EA_AX_DI_32(); return m68ki_read_32(ea);}
+INLINE uint OPER_AX_IX_8(void)  {uint ea = EA_AX_IX_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_AX_IX_16(void) {uint ea = EA_AX_IX_16(); return m68ki_read_16(ea);}
+INLINE uint OPER_AX_IX_32(void) {uint ea = EA_AX_IX_32(); return m68ki_read_32(ea);}
+
+INLINE uint OPER_A7_PI_8(void)  {uint ea = EA_A7_PI_8();  return m68ki_read_8(ea); }
+INLINE uint OPER_A7_PD_8(void)  {uint ea = EA_A7_PD_8();  return m68ki_read_8(ea); }
+
+INLINE uint OPER_AW_8(void)     {uint ea = EA_AW_8();     return m68ki_read_8(ea); }
+INLINE uint OPER_AW_16(void)    {uint ea = EA_AW_16();    return m68ki_read_16(ea);}
+INLINE uint OPER_AW_32(void)    {uint ea = EA_AW_32();    return m68ki_read_32(ea);}
+INLINE uint OPER_AL_8(void)     {uint ea = EA_AL_8();     return m68ki_read_8(ea); }
+INLINE uint OPER_AL_16(void)    {uint ea = EA_AL_16();    return m68ki_read_16(ea);}
+INLINE uint OPER_AL_32(void)    {uint ea = EA_AL_32();    return m68ki_read_32(ea);}
+INLINE uint OPER_PCDI_8(void)   {uint ea = EA_PCDI_8();   return m68ki_read_pcrel_8(ea); }
+INLINE uint OPER_PCDI_16(void)  {uint ea = EA_PCDI_16();  return m68ki_read_pcrel_16(ea);}
+INLINE uint OPER_PCDI_32(void)  {uint ea = EA_PCDI_32();  return m68ki_read_pcrel_32(ea);}
+INLINE uint OPER_PCIX_8(void)   {uint ea = EA_PCIX_8();   return m68ki_read_pcrel_8(ea); }
+INLINE uint OPER_PCIX_16(void)  {uint ea = EA_PCIX_16();  return m68ki_read_pcrel_16(ea);}
+INLINE uint OPER_PCIX_32(void)  {uint ea = EA_PCIX_32();  return m68ki_read_pcrel_32(ea);}
+
+
+
+/* ---------------------------- Stack Functions --------------------------- */
+
+/* Push/pull data from the stack */
+INLINE void m68ki_push_16(uint value)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 2);
+	m68ki_write_16(REG_SP, value);
+}
+
+INLINE void m68ki_push_32(uint value)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 4);
+	m68ki_write_32(REG_SP, value);
+}
+
+INLINE uint m68ki_pull_16(void)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 2);
+	return m68ki_read_16(REG_SP-2);
+}
+
+INLINE uint m68ki_pull_32(void)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 4);
+	return m68ki_read_32(REG_SP-4);
+}
+
+
+/* Increment/decrement the stack as if doing a push/pull but
+ * don't do any memory access.
+ */
+INLINE void m68ki_fake_push_16(void)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 2);
+}
+
+INLINE void m68ki_fake_push_32(void)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP - 4);
+}
+
+INLINE void m68ki_fake_pull_16(void)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 2);
+}
+
+INLINE void m68ki_fake_pull_32(void)
+{
+	REG_SP = MASK_OUT_ABOVE_32(REG_SP + 4);
+}
+
+
+/* ----------------------------- Program Flow ----------------------------- */
+
+/* Jump to a new program location or vector.
+ * These functions will also call the pc_changed callback if it was enabled
+ * in m68kconf.h.
+ */
+INLINE void m68ki_jump(uint new_pc)
+{
+	REG_PC = new_pc;
+	m68ki_pc_changed(REG_PC);
+}
+
+INLINE void m68ki_jump_vector(uint vector)
+{
+	REG_PC = (vector<<2) + REG_VBR;
+	REG_PC = m68ki_read_data_32(REG_PC);
+	m68ki_pc_changed(REG_PC);
+}
+
+
+/* Branch to a new memory location.
+ * The 32-bit branch will call pc_changed if it was enabled in m68kconf.h.
+ * So far I've found no problems with not calling pc_changed for 8 or 16
+ * bit branches.
+ */
+INLINE void m68ki_branch_8(uint offset)
+{
+	REG_PC += MAKE_INT_8(offset);
+}
+
+INLINE void m68ki_branch_16(uint offset)
+{
+	REG_PC += MAKE_INT_16(offset);
+}
+
+INLINE void m68ki_branch_32(uint offset)
+{
+	REG_PC += offset;
+	m68ki_pc_changed(REG_PC);
+}
+
+
+
+/* ---------------------------- Status Register --------------------------- */
+
+/* Set the S flag and change the active stack pointer.
+ * Note that value MUST be 4 or 0.
+ */
+INLINE void m68ki_set_s_flag(uint value)
+{
+	/* Backup the old stack pointer */
+	REG_SP_BASE[FLAG_S | ((FLAG_S>>1) & FLAG_M)] = REG_SP;
+	/* Set the S flag */
+	FLAG_S = value;
+	/* Set the new stack pointer */
+	REG_SP = REG_SP_BASE[FLAG_S | ((FLAG_S>>1) & FLAG_M)];
+}
+
+/* Set the S and M flags and change the active stack pointer.
+ * Note that value MUST be 0, 2, 4, or 6 (bit2 = S, bit1 = M).
+ */
+INLINE void m68ki_set_sm_flag(uint value)
+{
+	/* Backup the old stack pointer */
+	REG_SP_BASE[FLAG_S | ((FLAG_S>>1) & FLAG_M)] = REG_SP;
+	/* Set the S and M flags */
+	FLAG_S = value & SFLAG_SET;
+	FLAG_M = value & MFLAG_SET;
+	/* Set the new stack pointer */
+	REG_SP = REG_SP_BASE[FLAG_S | ((FLAG_S>>1) & FLAG_M)];
+}
+
+/* Set the S and M flags.  Don't touch the stack pointer. */
+INLINE void m68ki_set_sm_flag_nosp(uint value)
+{
+	/* Set the S and M flags */
+	FLAG_S = value & SFLAG_SET;
+	FLAG_M = value & MFLAG_SET;
+}
+
+
+/* Set the condition code register */
+INLINE void m68ki_set_ccr(uint value)
+{
+	FLAG_X = BIT_4(value)  << 4;
+	FLAG_N = BIT_3(value)  << 4;
+	FLAG_Z = !BIT_2(value);
+	FLAG_V = BIT_1(value)  << 6;
+	FLAG_C = BIT_0(value)  << 8;
+}
+
+/* Set the status register but don't check for interrupts */
+INLINE void m68ki_set_sr_noint(uint value)
+{
+	/* Mask out the "unimplemented" bits */
+	value &= CPU_SR_MASK;
+
+	/* Now set the status register */
+	FLAG_T1 = BIT_F(value);
+	FLAG_T0 = BIT_E(value);
+	FLAG_INT_MASK = value & 0x0700;
+	m68ki_set_ccr(value);
+	m68ki_set_sm_flag((value >> 11) & 6);
+}
+
+/* Set the status register but don't check for interrupts nor
+ * change the stack pointer
+ */
+INLINE void m68ki_set_sr_noint_nosp(uint value)
+{
+	/* Mask out the "unimplemented" bits */
+	value &= CPU_SR_MASK;
+
+	/* Now set the status register */
+	FLAG_T1 = BIT_F(value);
+	FLAG_T0 = BIT_E(value);
+	FLAG_INT_MASK = value & 0x0700;
+	m68ki_set_ccr(value);
+	m68ki_set_sm_flag_nosp((value >> 11) & 6);
+}
+
+/* Set the status register and check for interrupts */
+INLINE void m68ki_set_sr(uint value)
+{
+	m68ki_set_sr_noint(value);
+	m68ki_check_interrupts();
+}
+
+
+/* ------------------------- Exception Processing ------------------------- */
+
+/* Initiate exception processing */
+INLINE uint m68ki_init_exception(void)
+{
+	/* Save the old status register */
+	uint sr = m68ki_get_sr();
+
+	/* Turn off trace flag, clear pending traces */
+	FLAG_T1 = FLAG_T0 = 0;
+	m68ki_clear_trace();
+	/* Enter supervisor mode */
+	m68ki_set_s_flag(SFLAG_SET);
+
+	return sr;
+}
+
+/* 3 word stack frame (68000 only) */
+INLINE void m68ki_stack_frame_3word(uint pc, uint sr)
+{
+	m68ki_push_32(pc);
+	m68ki_push_16(sr);
+}
+
+/* Format 0 stack frame.
+ * This is the standard stack frame for 68010+.
+ */
+INLINE void m68ki_stack_frame_0000(uint pc, uint sr, uint vector)
+{
+	/* Stack a 3-word frame if we are 68000 */
+	if(CPU_TYPE == CPU_TYPE_000)
+	{
+		m68ki_stack_frame_3word(pc, sr);
+		return;
+	}
+	m68ki_push_16(vector<<2);
+	m68ki_push_32(pc);
+	m68ki_push_16(sr);
+}
+
+/* Format 1 stack frame (68020).
+ * For 68020, this is the 4 word throwaway frame.
+ */
+INLINE void m68ki_stack_frame_0001(uint pc, uint sr, uint vector)
+{
+	m68ki_push_16(0x1000 | (vector<<2));
+	m68ki_push_32(pc);
+	m68ki_push_16(sr);
+}
+
+/* Format 2 stack frame.
+ * This is used only by 68020 for trap exceptions.
+ */
+INLINE void m68ki_stack_frame_0010(uint sr, uint vector)
+{
+	m68ki_push_32(REG_PPC);
+	m68ki_push_16(0x2000 | (vector<<2));
+	m68ki_push_32(REG_PC);
+	m68ki_push_16(sr);
+}
+
+
+/* Bus error stack frame (68000 only).
+ */
+INLINE void m68ki_stack_frame_buserr(uint sr)
+{
+	m68ki_push_32(REG_PC);
+	m68ki_push_16(sr);
+	m68ki_push_16(REG_IR);
+	m68ki_push_32(m68ki_aerr_address);	/* access address */
+	/* 0 0 0 0 0 0 0 0 0 0 0 R/W I/N FC
+	 * R/W  0 = write, 1 = read
+	 * I/N  0 = instruction, 1 = not
+	 * FC   3-bit function code
+	 */
+	m68ki_push_16(m68ki_aerr_write_mode | CPU_INSTR_MODE | m68ki_aerr_fc);
+}
+
+/* Format 8 stack frame (68010).
+ * 68010 only.  This is the 29 word bus/address error frame.
+ */
+void m68ki_stack_frame_1000(uint pc, uint sr, uint vector)
+{
+	/* VERSION
+	 * NUMBER
+	 * INTERNAL INFORMATION, 16 WORDS
+	 */
+	m68ki_fake_push_32();
+	m68ki_fake_push_32();
+	m68ki_fake_push_32();
+	m68ki_fake_push_32();
+	m68ki_fake_push_32();
+	m68ki_fake_push_32();
+	m68ki_fake_push_32();
+	m68ki_fake_push_32();
+
+	/* INSTRUCTION INPUT BUFFER */
+	m68ki_push_16(0);
+
+	/* UNUSED, RESERVED (not written) */
+	m68ki_fake_push_16();
+
+	/* DATA INPUT BUFFER */
+	m68ki_push_16(0);
+
+	/* UNUSED, RESERVED (not written) */
+	m68ki_fake_push_16();
+
+	/* DATA OUTPUT BUFFER */
+	m68ki_push_16(0);
+
+	/* UNUSED, RESERVED (not written) */
+	m68ki_fake_push_16();
+
+	/* FAULT ADDRESS */
+	m68ki_push_32(0);
+
+	/* SPECIAL STATUS WORD */
+	m68ki_push_16(0);
+
+	/* 1000, VECTOR OFFSET */
+	m68ki_push_16(0x8000 | (vector<<2));
+
+	/* PROGRAM COUNTER */
+	m68ki_push_32(pc);
+
+	/* STATUS REGISTER */
+	m68ki_push_16(sr);
+}
+
+/* Format A stack frame (short bus fault).
+ * This is used only by 68020 for bus fault and address error
+ * if the error happens at an instruction boundary.
+ * PC stacked is address of next instruction.
+ */
+void m68ki_stack_frame_1010(uint sr, uint vector, uint pc)
+{
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* DATA OUTPUT BUFFER (2 words) */
+	m68ki_push_32(0);
+
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* DATA CYCLE FAULT ADDRESS (2 words) */
+	m68ki_push_32(0);
+
+	/* INSTRUCTION PIPE STAGE B */
+	m68ki_push_16(0);
+
+	/* INSTRUCTION PIPE STAGE C */
+	m68ki_push_16(0);
+
+	/* SPECIAL STATUS REGISTER */
+	m68ki_push_16(0);
+
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* 1010, VECTOR OFFSET */
+	m68ki_push_16(0xa000 | (vector<<2));
+
+	/* PROGRAM COUNTER */
+	m68ki_push_32(pc);
+
+	/* STATUS REGISTER */
+	m68ki_push_16(sr);
+}
+
+/* Format B stack frame (long bus fault).
+ * This is used only by 68020 for bus fault and address error
+ * if the error happens during instruction execution.
+ * PC stacked is address of instruction in progress.
+ */
+void m68ki_stack_frame_1011(uint sr, uint vector, uint pc)
+{
+	/* INTERNAL REGISTERS (18 words) */
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+
+	/* VERSION# (4 bits), INTERNAL INFORMATION */
+	m68ki_push_16(0);
+
+	/* INTERNAL REGISTERS (3 words) */
+	m68ki_push_32(0);
+	m68ki_push_16(0);
+
+	/* DATA INTPUT BUFFER (2 words) */
+	m68ki_push_32(0);
+
+	/* INTERNAL REGISTERS (2 words) */
+	m68ki_push_32(0);
+
+	/* STAGE B ADDRESS (2 words) */
+	m68ki_push_32(0);
+
+	/* INTERNAL REGISTER (4 words) */
+	m68ki_push_32(0);
+	m68ki_push_32(0);
+
+	/* DATA OUTPUT BUFFER (2 words) */
+	m68ki_push_32(0);
+
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* DATA CYCLE FAULT ADDRESS (2 words) */
+	m68ki_push_32(0);
+
+	/* INSTRUCTION PIPE STAGE B */
+	m68ki_push_16(0);
+
+	/* INSTRUCTION PIPE STAGE C */
+	m68ki_push_16(0);
+
+	/* SPECIAL STATUS REGISTER */
+	m68ki_push_16(0);
+
+	/* INTERNAL REGISTER */
+	m68ki_push_16(0);
+
+	/* 1011, VECTOR OFFSET */
+	m68ki_push_16(0xb000 | (vector<<2));
+
+	/* PROGRAM COUNTER */
+	m68ki_push_32(pc);
+
+	/* STATUS REGISTER */
+	m68ki_push_16(sr);
+}
+
+
+/* Used for Group 2 exceptions.
+ * These stack a type 2 frame on the 020.
+ */
+INLINE void m68ki_exception_trap(uint vector)
+{
+	uint sr = m68ki_init_exception();
+
+	if(CPU_TYPE_IS_010_LESS(CPU_TYPE))
+		m68ki_stack_frame_0000(REG_PC, sr, vector);
+	else
+		m68ki_stack_frame_0010(sr, vector);
+
+	m68ki_jump_vector(vector);
+
+	/* Use up some clock cycles */
+	USE_CYCLES(CYC_EXCEPTION[vector]);
+}
+
+/* Trap#n stacks a 0 frame but behaves like group2 otherwise */
+INLINE void m68ki_exception_trapN(uint vector)
+{
+	uint sr = m68ki_init_exception();
+	m68ki_stack_frame_0000(REG_PC, sr, vector);
+	m68ki_jump_vector(vector);
+
+	/* Use up some clock cycles */
+	USE_CYCLES(CYC_EXCEPTION[vector]);
+}
+
+/* Exception for trace mode */
+INLINE void m68ki_exception_trace(void)
+{
+	uint sr = m68ki_init_exception();
+
+	if(CPU_TYPE_IS_010_LESS(CPU_TYPE))
+	{
+		#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+		if(CPU_TYPE_IS_000(CPU_TYPE))
+		{
+			CPU_INSTR_MODE = INSTRUCTION_NO;
+		}
+		#endif /* M68K_EMULATE_ADDRESS_ERROR */
+		m68ki_stack_frame_0000(REG_PC, sr, EXCEPTION_TRACE);
+	}
+	else
+		m68ki_stack_frame_0010(sr, EXCEPTION_TRACE);
+
+	m68ki_jump_vector(EXCEPTION_TRACE);
+
+	/* Trace nullifies a STOP instruction */
+	CPU_STOPPED &= ~STOP_LEVEL_STOP;
+
+	/* Use up some clock cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_TRACE]);
+}
+
+/* Exception for privilege violation */
+INLINE void m68ki_exception_privilege_violation(void)
+{
+	uint sr = m68ki_init_exception();
+
+	#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+	if(CPU_TYPE_IS_000(CPU_TYPE))
+	{
+		CPU_INSTR_MODE = INSTRUCTION_NO;
+	}
+	#endif /* M68K_EMULATE_ADDRESS_ERROR */
+
+	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_PRIVILEGE_VIOLATION);
+	m68ki_jump_vector(EXCEPTION_PRIVILEGE_VIOLATION);
+
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_PRIVILEGE_VIOLATION] - CYC_INSTRUCTION[REG_IR]);
+}
+
+/* Exception for A-Line instructions */
+INLINE void m68ki_exception_1010(void)
+{
+	uint sr;
+#if M68K_LOG_1010_1111 == OPT_ON
+	M68K_DO_LOG_EMU((M68K_LOG_FILEHANDLE "%s at %08x: called 1010 instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PPC), REG_IR,
+					 m68ki_disassemble_quick(ADDRESS_68K(REG_PPC))));
+#endif
+
+	sr = m68ki_init_exception();
+	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_1010);
+	m68ki_jump_vector(EXCEPTION_1010);
+
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_1010] - CYC_INSTRUCTION[REG_IR]);
+}
+
+/* Exception for F-Line instructions */
+INLINE void m68ki_exception_1111(void)
+{
+	uint sr;
+
+#if M68K_LOG_1010_1111 == OPT_ON
+	M68K_DO_LOG_EMU((M68K_LOG_FILEHANDLE "%s at %08x: called 1111 instruction %04x (%s)\n",
+					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PPC), REG_IR,
+					 m68ki_disassemble_quick(ADDRESS_68K(REG_PPC))));
+#endif
+
+	sr = m68ki_init_exception();
+	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_1111);
+	m68ki_jump_vector(EXCEPTION_1111);
+
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_1111] - CYC_INSTRUCTION[REG_IR]);
+}
+
+/* Exception for illegal instructions */
+INLINE void m68ki_exception_illegal(void)
+{
+	uint sr;
+
+	M68K_DO_LOG((M68K_LOG_FILEHANDLE "%s at %08x: illegal instruction %04x (%s)\n",
+				 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PPC), REG_IR,
+				 m68ki_disassemble_quick(ADDRESS_68K(REG_PPC))));
+
+	sr = m68ki_init_exception();
+
+	#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+	if(CPU_TYPE_IS_000(CPU_TYPE))
+	{
+		CPU_INSTR_MODE = INSTRUCTION_NO;
+	}
+	#endif /* M68K_EMULATE_ADDRESS_ERROR */
+
+	m68ki_stack_frame_0000(REG_PPC, sr, EXCEPTION_ILLEGAL_INSTRUCTION);
+	m68ki_jump_vector(EXCEPTION_ILLEGAL_INSTRUCTION);
+
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_ILLEGAL_INSTRUCTION] - CYC_INSTRUCTION[REG_IR]);
+}
+
+/* Exception for format errror in RTE */
+INLINE void m68ki_exception_format_error(void)
+{
+	uint sr = m68ki_init_exception();
+	m68ki_stack_frame_0000(REG_PC, sr, EXCEPTION_FORMAT_ERROR);
+	m68ki_jump_vector(EXCEPTION_FORMAT_ERROR);
+
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_FORMAT_ERROR] - CYC_INSTRUCTION[REG_IR]);
+}
+
+/* Exception for address error */
+INLINE void m68ki_exception_address_error(void)
+{
+	uint sr = m68ki_init_exception();
+
+	/* If we were processing a bus error, address error, or reset,
+	 * this is a catastrophic failure.
+	 * Halt the CPU
+	 */
+	if(CPU_RUN_MODE == RUN_MODE_BERR_AERR_RESET)
+	{
+m68k_read_memory_8(0x00ffff01);
+		CPU_STOPPED = STOP_LEVEL_HALT;
+		return;
+	}
+	CPU_RUN_MODE = RUN_MODE_BERR_AERR_RESET;
+
+	/* Note: This is implemented for 68000 only! */
+	m68ki_stack_frame_buserr(sr);
+
+	m68ki_jump_vector(EXCEPTION_ADDRESS_ERROR);
+
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_ADDRESS_ERROR] - CYC_INSTRUCTION[REG_IR]);
+}
+
+
+/* Service an interrupt request and start exception processing */
+void m68ki_exception_interrupt(uint int_level)
+{
+	uint vector;
+	uint sr;
+	uint new_pc;
+
+	#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+	if(CPU_TYPE_IS_000(CPU_TYPE))
+	{
+		CPU_INSTR_MODE = INSTRUCTION_NO;
+	}
+	#endif /* M68K_EMULATE_ADDRESS_ERROR */
+
+	/* Turn off the stopped state */
+	CPU_STOPPED &= ~STOP_LEVEL_STOP;
+
+	/* If we are halted, don't do anything */
+	if(CPU_STOPPED)
+		return;
+
+	/* Acknowledge the interrupt */
+	vector = m68ki_int_ack(int_level);
+
+	/* Get the interrupt vector */
+	if(vector == M68K_INT_ACK_AUTOVECTOR)
+		/* Use the autovectors.  This is the most commonly used implementation */
+		vector = EXCEPTION_INTERRUPT_AUTOVECTOR+int_level;
+	else if(vector == M68K_INT_ACK_SPURIOUS)
+		/* Called if no devices respond to the interrupt acknowledge */
+		vector = EXCEPTION_SPURIOUS_INTERRUPT;
+	else if(vector > 255)
+	{
+		M68K_DO_LOG_EMU((M68K_LOG_FILEHANDLE "%s at %08x: Interrupt acknowledge returned invalid vector $%x\n",
+				 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PC), vector));
+		return;
+	}
+
+	/* Start exception processing */
+	sr = m68ki_init_exception();
+
+	/* Set the interrupt mask to the level of the one being serviced */
+	FLAG_INT_MASK = int_level<<8;
+
+	/* Get the new PC */
+	new_pc = m68ki_read_data_32((vector<<2) + REG_VBR);
+
+	/* If vector is uninitialized, call the uninitialized interrupt vector */
+	if(new_pc == 0)
+		new_pc = m68ki_read_data_32((EXCEPTION_UNINITIALIZED_INTERRUPT<<2) + REG_VBR);
+
+	/* Generate a stack frame */
+	m68ki_stack_frame_0000(REG_PC, sr, vector);
+	if(FLAG_M && CPU_TYPE_IS_EC020_PLUS(CPU_TYPE))
+	{
+		/* Create throwaway frame */
+		m68ki_set_sm_flag(FLAG_S);	/* clear M */
+		sr |= 0x2000; /* Same as SR in master stack frame except S is forced high */
+		m68ki_stack_frame_0001(REG_PC, sr, vector);
+	}
+
+	m68ki_jump(new_pc);
+
+	/* Defer cycle counting until later */
+	CPU_INT_CYCLES += CYC_EXCEPTION[vector];
+
+#if !M68K_EMULATE_INT_ACK
+	/* Automatically clear IRQ if we are not using an acknowledge scheme */
+	CPU_INT_LEVEL = 0;
+#endif /* M68K_EMULATE_INT_ACK */
+}
+
+
+/* ASG: Check for interrupts */
+INLINE void m68ki_check_interrupts(void)
+{
+	if(CPU_INT_LEVEL > FLAG_INT_MASK)
+		m68ki_exception_interrupt(CPU_INT_LEVEL>>8);
+}
+
+
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */
+
+#endif /* M68KCPU__HEADER */

--- a/yabause/src/musashi/m68kdasm.c
+++ b/yabause/src/musashi/m68kdasm.c
@@ -1,0 +1,3477 @@
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.4
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright 1998-2001 Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+
+/* ======================================================================== */
+/* ================================ INCLUDES ============================== */
+/* ======================================================================== */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "m68k.h"
+
+#ifndef DECL_SPEC
+#define DECL_SPEC
+#endif
+
+/* ======================================================================== */
+/* ============================ GENERAL DEFINES =========================== */
+/* ======================================================================== */
+
+/* unsigned int and int must be at least 32 bits wide */
+#undef uint
+#define uint unsigned int
+
+/* Bit Isolation Functions */
+#define BIT_0(A)  ((A) & 0x00000001)
+#define BIT_1(A)  ((A) & 0x00000002)
+#define BIT_2(A)  ((A) & 0x00000004)
+#define BIT_3(A)  ((A) & 0x00000008)
+#define BIT_4(A)  ((A) & 0x00000010)
+#define BIT_5(A)  ((A) & 0x00000020)
+#define BIT_6(A)  ((A) & 0x00000040)
+#define BIT_7(A)  ((A) & 0x00000080)
+#define BIT_8(A)  ((A) & 0x00000100)
+#define BIT_9(A)  ((A) & 0x00000200)
+#define BIT_A(A)  ((A) & 0x00000400)
+#define BIT_B(A)  ((A) & 0x00000800)
+#define BIT_C(A)  ((A) & 0x00001000)
+#define BIT_D(A)  ((A) & 0x00002000)
+#define BIT_E(A)  ((A) & 0x00004000)
+#define BIT_F(A)  ((A) & 0x00008000)
+#define BIT_10(A) ((A) & 0x00010000)
+#define BIT_11(A) ((A) & 0x00020000)
+#define BIT_12(A) ((A) & 0x00040000)
+#define BIT_13(A) ((A) & 0x00080000)
+#define BIT_14(A) ((A) & 0x00100000)
+#define BIT_15(A) ((A) & 0x00200000)
+#define BIT_16(A) ((A) & 0x00400000)
+#define BIT_17(A) ((A) & 0x00800000)
+#define BIT_18(A) ((A) & 0x01000000)
+#define BIT_19(A) ((A) & 0x02000000)
+#define BIT_1A(A) ((A) & 0x04000000)
+#define BIT_1B(A) ((A) & 0x08000000)
+#define BIT_1C(A) ((A) & 0x10000000)
+#define BIT_1D(A) ((A) & 0x20000000)
+#define BIT_1E(A) ((A) & 0x40000000)
+#define BIT_1F(A) ((A) & 0x80000000)
+
+/* These are the CPU types understood by this disassembler */
+#define TYPE_68000 1
+#define TYPE_68010 2
+#define TYPE_68020 4
+#define TYPE_68030 8
+#define TYPE_68040 16
+
+#define M68000_ONLY		TYPE_68000
+
+#define M68010_ONLY		TYPE_68010
+#define M68010_LESS		(TYPE_68000 | TYPE_68010)
+#define M68010_PLUS		(TYPE_68010 | TYPE_68020 | TYPE_68030 | TYPE_68040)
+
+#define M68020_ONLY 	TYPE_68020
+#define M68020_LESS 	(TYPE_68010 | TYPE_68020)
+#define M68020_PLUS		(TYPE_68020 | TYPE_68030 | TYPE_68040)
+
+#define M68030_ONLY 	TYPE_68030
+#define M68030_LESS 	(TYPE_68010 | TYPE_68020 | TYPE_68030)
+#define M68030_PLUS		(TYPE_68030 | TYPE_68040)
+
+#define M68040_PLUS		TYPE_68040
+
+
+/* Extension word formats */
+#define EXT_8BIT_DISPLACEMENT(A)          ((A)&0xff)
+#define EXT_FULL(A)                       BIT_8(A)
+#define EXT_EFFECTIVE_ZERO(A)             (((A)&0xe4) == 0xc4 || ((A)&0xe2) == 0xc0)
+#define EXT_BASE_REGISTER_PRESENT(A)      (!BIT_7(A))
+#define EXT_INDEX_REGISTER_PRESENT(A)     (!BIT_6(A))
+#define EXT_INDEX_REGISTER(A)             (((A)>>12)&7)
+#define EXT_INDEX_PRE_POST(A)             (EXT_INDEX_PRESENT(A) && (A)&3)
+#define EXT_INDEX_PRE(A)                  (EXT_INDEX_PRESENT(A) && ((A)&7) < 4 && ((A)&7) != 0)
+#define EXT_INDEX_POST(A)                 (EXT_INDEX_PRESENT(A) && ((A)&7) > 4)
+#define EXT_INDEX_SCALE(A)                (((A)>>9)&3)
+#define EXT_INDEX_LONG(A)                 BIT_B(A)
+#define EXT_INDEX_AR(A)                   BIT_F(A)
+#define EXT_BASE_DISPLACEMENT_PRESENT(A)  (((A)&0x30) > 0x10)
+#define EXT_BASE_DISPLACEMENT_WORD(A)     (((A)&0x30) == 0x20)
+#define EXT_BASE_DISPLACEMENT_LONG(A)     (((A)&0x30) == 0x30)
+#define EXT_OUTER_DISPLACEMENT_PRESENT(A) (((A)&3) > 1 && ((A)&0x47) < 0x44)
+#define EXT_OUTER_DISPLACEMENT_WORD(A)    (((A)&3) == 2 && ((A)&0x47) < 0x44)
+#define EXT_OUTER_DISPLACEMENT_LONG(A)    (((A)&3) == 3 && ((A)&0x47) < 0x44)
+
+
+
+/* ======================================================================== */
+/* =============================== PROTOTYPES ============================= */
+/* ======================================================================== */
+
+/* Read data at the PC and increment PC */
+uint  read_imm_8(void);
+uint  read_imm_16(void);
+uint  read_imm_32(void);
+
+/* Read data at the PC but don't imcrement the PC */
+uint  peek_imm_8(void);
+uint  peek_imm_16(void);
+uint  peek_imm_32(void);
+
+/* make signed integers 100% portably */
+static int make_int_8(int value);
+static int make_int_16(int value);
+
+/* make a string of a hex value */
+static char* make_signed_hex_str_8(uint val);
+static char* make_signed_hex_str_16(uint val);
+static char* make_signed_hex_str_32(uint val);
+
+/* make string of ea mode */
+static char* get_ea_mode_str(uint instruction, uint size);
+
+char* get_ea_mode_str_8(uint instruction);
+char* get_ea_mode_str_16(uint instruction);
+char* get_ea_mode_str_32(uint instruction);
+
+/* make string of immediate value */
+static char* get_imm_str_s(uint size);
+static char* get_imm_str_u(uint size);
+
+char* get_imm_str_s8(void);
+char* get_imm_str_s16(void);
+char* get_imm_str_s32(void);
+
+/* Stuff to build the opcode handler jump table */
+static void  build_opcode_table(void);
+static int   valid_ea(uint opcode, uint mask);
+static int DECL_SPEC compare_nof_true_bits(const void *aptr, const void *bptr);
+
+/* used to build opcode handler jump table */
+typedef struct
+{
+	void (*opcode_handler)(void); /* handler function */
+	uint mask;                    /* mask on opcode */
+	uint match;                   /* what to match after masking */
+	uint ea_mask;                 /* what ea modes are allowed */
+} opcode_struct;
+
+
+
+/* ======================================================================== */
+/* ================================= DATA ================================= */
+/* ======================================================================== */
+
+/* Opcode handler jump table */
+static void (*g_instruction_table[0x10000])(void);
+/* Flag if disassembler initialized */
+static int  g_initialized = 0;
+
+/* Address mask to simulate address lines */
+static unsigned int g_address_mask = 0xffffffff;
+
+static char g_dasm_str[100]; /* string to hold disassembly */
+static char g_helper_str[100]; /* string to hold helpful info */
+static uint g_cpu_pc;        /* program counter */
+static uint g_cpu_ir;        /* instruction register */
+static uint g_cpu_type;
+
+/* used by ops like asr, ror, addq, etc */
+static uint g_3bit_qdata_table[8] = {8, 1, 2, 3, 4, 5, 6, 7};
+
+static uint g_5bit_data_table[32] =
+{
+	32,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+	16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+};
+
+static char* g_cc[16] =
+{"t", "f", "hi", "ls", "cc", "cs", "ne", "eq", "vc", "vs", "pl", "mi", "ge", "lt", "gt", "le"};
+
+static char* g_cpcc[64] =
+{/* 000    001    010    011    100    101    110    111 */
+	  "f",  "eq", "ogt", "oge", "olt", "ole", "ogl",  "or", /* 000 */
+	 "un", "ueq", "ugt", "uge", "ult", "ule",  "ne",   "t", /* 001 */
+	 "sf", "seq",  "gt",  "ge",  "lt",  "le",  "gl"  "gle", /* 010 */
+  "ngle", "ngl", "nle", "nlt", "nge", "ngt", "sne",  "st", /* 011 */
+	  "?",   "?",   "?",   "?",   "?",   "?",   "?",   "?", /* 100 */
+	  "?",   "?",   "?",   "?",   "?",   "?",   "?",   "?", /* 101 */
+	  "?",   "?",   "?",   "?",   "?",   "?",   "?",   "?", /* 110 */
+	  "?",   "?",   "?",   "?",   "?",   "?",   "?",   "?"  /* 111 */
+};
+
+
+/* ======================================================================== */
+/* =========================== UTILITY FUNCTIONS ========================== */
+/* ======================================================================== */
+
+#define LIMIT_CPU_TYPES(ALLOWED_CPU_TYPES)	\
+	if(!(g_cpu_type & ALLOWED_CPU_TYPES))	\
+	{										\
+		d68000_illegal();					\
+		return;								\
+	}
+
+#define read_imm_8()  (m68k_read_disassembler_16(((g_cpu_pc+=2)-2)&g_address_mask)&0xff)
+#define read_imm_16() m68k_read_disassembler_16(((g_cpu_pc+=2)-2)&g_address_mask)
+#define read_imm_32() m68k_read_disassembler_32(((g_cpu_pc+=4)-4)&g_address_mask)
+
+#define peek_imm_8()  (m68k_read_disassembler_16(g_cpu_pc & g_address_mask)&0xff)
+#define peek_imm_16() m68k_read_disassembler_16(g_cpu_pc & g_address_mask)
+#define peek_imm_32() m68k_read_disassembler_32(g_cpu_pc & g_address_mask)
+
+/* Fake a split interface */
+#define get_ea_mode_str_8(instruction) get_ea_mode_str(instruction, 0)
+#define get_ea_mode_str_16(instruction) get_ea_mode_str(instruction, 1)
+#define get_ea_mode_str_32(instruction) get_ea_mode_str(instruction, 2)
+
+#define get_imm_str_s8() get_imm_str_s(0)
+#define get_imm_str_s16() get_imm_str_s(1)
+#define get_imm_str_s32() get_imm_str_s(2)
+
+#define get_imm_str_u8() get_imm_str_u(0)
+#define get_imm_str_u16() get_imm_str_u(1)
+#define get_imm_str_u32() get_imm_str_u(2)
+
+
+/* 100% portable signed int generators */
+static int make_int_8(int value)
+{
+	return (value & 0x80) ? value | ~0xff : value & 0xff;
+}
+
+static int make_int_16(int value)
+{
+	return (value & 0x8000) ? value | ~0xffff : value & 0xffff;
+}
+
+
+/* Get string representation of hex values */
+static char* make_signed_hex_str_8(uint val)
+{
+	static char str[20];
+
+	val &= 0xff;
+
+	if(val == 0x80)
+		sprintf(str, "-$80");
+	else if(val & 0x80)
+		sprintf(str, "-$%x", (0-val) & 0x7f);
+	else
+		sprintf(str, "$%x", val & 0x7f);
+
+	return str;
+}
+
+static char* make_signed_hex_str_16(uint val)
+{
+	static char str[20];
+
+	val &= 0xffff;
+
+	if(val == 0x8000)
+		sprintf(str, "-$8000");
+	else if(val & 0x8000)
+		sprintf(str, "-$%x", (0-val) & 0x7fff);
+	else
+		sprintf(str, "$%x", val & 0x7fff);
+
+	return str;
+}
+
+static char* make_signed_hex_str_32(uint val)
+{
+	static char str[20];
+
+	val &= 0xffffffff;
+
+	if(val == 0x80000000)
+		sprintf(str, "-$80000000");
+	else if(val & 0x80000000)
+		sprintf(str, "-$%x", (0-val) & 0x7fffffff);
+	else
+		sprintf(str, "$%x", val & 0x7fffffff);
+
+	return str;
+}
+
+
+/* make string of immediate value */
+static char* get_imm_str_s(uint size)
+{
+	static char str[15];
+	if(size == 0)
+		sprintf(str, "#%s", make_signed_hex_str_8(read_imm_8()));
+	else if(size == 1)
+		sprintf(str, "#%s", make_signed_hex_str_16(read_imm_16()));
+	else
+		sprintf(str, "#%s", make_signed_hex_str_32(read_imm_32()));
+	return str;
+}
+
+static char* get_imm_str_u(uint size)
+{
+	static char str[15];
+	if(size == 0)
+		sprintf(str, "#$%x", read_imm_8() & 0xff);
+	else if(size == 1)
+		sprintf(str, "#$%x", read_imm_16() & 0xffff);
+	else
+		sprintf(str, "#$%x", read_imm_32() & 0xffffffff);
+	return str;
+}
+
+/* Make string of effective address mode */
+static char* get_ea_mode_str(uint instruction, uint size)
+{
+	static char b1[64];
+	static char b2[64];
+	static char* mode = b2;
+	uint extension;
+	uint base;
+	uint outer;
+	char base_reg[4];
+	char index_reg[8];
+	uint preindex;
+	uint postindex;
+	uint comma = 0;
+	uint temp_value;
+
+	/* Switch buffers so we don't clobber on a double-call to this function */
+	mode = mode == b1 ? b2 : b1;
+
+	switch(instruction & 0x3f)
+	{
+		case 0x00: case 0x01: case 0x02: case 0x03: case 0x04: case 0x05: case 0x06: case 0x07:
+		/* data register direct */
+			sprintf(mode, "D%d", instruction&7);
+			break;
+		case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
+		/* address register direct */
+			sprintf(mode, "A%d", instruction&7);
+			break;
+		case 0x10: case 0x11: case 0x12: case 0x13: case 0x14: case 0x15: case 0x16: case 0x17:
+		/* address register indirect */
+			sprintf(mode, "(A%d)", instruction&7);
+			break;
+		case 0x18: case 0x19: case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e: case 0x1f:
+		/* address register indirect with postincrement */
+			sprintf(mode, "(A%d)+", instruction&7);
+			break;
+		case 0x20: case 0x21: case 0x22: case 0x23: case 0x24: case 0x25: case 0x26: case 0x27:
+		/* address register indirect with predecrement */
+			sprintf(mode, "-(A%d)", instruction&7);
+			break;
+		case 0x28: case 0x29: case 0x2a: case 0x2b: case 0x2c: case 0x2d: case 0x2e: case 0x2f:
+		/* address register indirect with displacement*/
+			sprintf(mode, "(%s,A%d)", make_signed_hex_str_16(read_imm_16()), instruction&7);
+			break;
+		case 0x30: case 0x31: case 0x32: case 0x33: case 0x34: case 0x35: case 0x36: case 0x37:
+		/* address register indirect with index */
+			extension = read_imm_16();
+
+			if(EXT_FULL(extension))
+			{
+				if(EXT_EFFECTIVE_ZERO(extension))
+				{
+					strcpy(mode, "0");
+					break;
+				}
+				base = EXT_BASE_DISPLACEMENT_PRESENT(extension) ? (EXT_BASE_DISPLACEMENT_LONG(extension) ? read_imm_32() : read_imm_16()) : 0;
+				outer = EXT_OUTER_DISPLACEMENT_PRESENT(extension) ? (EXT_OUTER_DISPLACEMENT_LONG(extension) ? read_imm_32() : read_imm_16()) : 0;
+				if(EXT_BASE_REGISTER_PRESENT(extension))
+					sprintf(base_reg, "A%d", instruction&7);
+				else
+					*base_reg = 0;
+				if(EXT_INDEX_REGISTER_PRESENT(extension))
+				{
+					sprintf(index_reg, "%c%d.%c", EXT_INDEX_AR(extension) ? 'A' : 'D', EXT_INDEX_REGISTER(extension), EXT_INDEX_LONG(extension) ? 'l' : 'w');
+					if(EXT_INDEX_SCALE(extension))
+						sprintf(index_reg+strlen(index_reg), "*%d", 1 << EXT_INDEX_SCALE(extension));
+				}
+				else
+					*index_reg = 0;
+				preindex = (extension&7) > 0 && (extension&7) < 4;
+				postindex = (extension&7) > 4;
+
+				strcpy(mode, "(");
+				if(preindex || postindex)
+					strcat(mode, "[");
+				if(base)
+				{
+					strcat(mode, make_signed_hex_str_16(base));
+					comma = 1;
+				}
+				if(*base_reg)
+				{
+					if(comma)
+						strcat(mode, ",");
+					strcat(mode, base_reg);
+					comma = 1;
+				}
+				if(postindex)
+				{
+					strcat(mode, "]");
+					comma = 1;
+				}
+				if(*index_reg)
+				{
+					if(comma)
+						strcat(mode, ",");
+					strcat(mode, index_reg);
+					comma = 1;
+				}
+				if(preindex)
+				{
+					strcat(mode, "]");
+					comma = 1;
+				}
+				if(outer)
+				{
+					if(comma)
+						strcat(mode, ",");
+					strcat(mode, make_signed_hex_str_16(outer));
+				}
+				strcat(mode, ")");
+				break;
+			}
+
+			if(EXT_8BIT_DISPLACEMENT(extension) == 0)
+				sprintf(mode, "(A%d,%c%d.%c", instruction&7, EXT_INDEX_AR(extension) ? 'A' : 'D', EXT_INDEX_REGISTER(extension), EXT_INDEX_LONG(extension) ? 'l' : 'w');
+			else
+				sprintf(mode, "(%s,A%d,%c%d.%c", make_signed_hex_str_8(extension), instruction&7, EXT_INDEX_AR(extension) ? 'A' : 'D', EXT_INDEX_REGISTER(extension), EXT_INDEX_LONG(extension) ? 'l' : 'w');
+			if(EXT_INDEX_SCALE(extension))
+				sprintf(mode+strlen(mode), "*%d", 1 << EXT_INDEX_SCALE(extension));
+			strcat(mode, ")");
+			break;
+		case 0x38:
+		/* absolute short address */
+			sprintf(mode, "$%x.w", read_imm_16());
+			break;
+		case 0x39:
+		/* absolute long address */
+			sprintf(mode, "$%x.l", read_imm_32());
+			break;
+		case 0x3a:
+		/* program counter with displacement */
+			temp_value = read_imm_16();
+			sprintf(mode, "(%s,PC)", make_signed_hex_str_16(temp_value));
+			sprintf(g_helper_str, "; ($%x)", (make_int_16(temp_value) + g_cpu_pc-2) & 0xffffffff);
+			break;
+		case 0x3b:
+		/* program counter with index */
+			extension = read_imm_16();
+
+			if(EXT_FULL(extension))
+			{
+				if(EXT_EFFECTIVE_ZERO(extension))
+				{
+					strcpy(mode, "0");
+					break;
+				}
+				base = EXT_BASE_DISPLACEMENT_PRESENT(extension) ? (EXT_BASE_DISPLACEMENT_LONG(extension) ? read_imm_32() : read_imm_16()) : 0;
+				outer = EXT_OUTER_DISPLACEMENT_PRESENT(extension) ? (EXT_OUTER_DISPLACEMENT_LONG(extension) ? read_imm_32() : read_imm_16()) : 0;
+				if(EXT_BASE_REGISTER_PRESENT(extension))
+					strcpy(base_reg, "PC");
+				else
+					*base_reg = 0;
+				if(EXT_INDEX_REGISTER_PRESENT(extension))
+				{
+					sprintf(index_reg, "%c%d.%c", EXT_INDEX_AR(extension) ? 'A' : 'D', EXT_INDEX_REGISTER(extension), EXT_INDEX_LONG(extension) ? 'l' : 'w');
+					if(EXT_INDEX_SCALE(extension))
+						sprintf(index_reg+strlen(index_reg), "*%d", 1 << EXT_INDEX_SCALE(extension));
+				}
+				else
+					*index_reg = 0;
+				preindex = (extension&7) > 0 && (extension&7) < 4;
+				postindex = (extension&7) > 4;
+
+				strcpy(mode, "(");
+				if(preindex || postindex)
+					strcat(mode, "[");
+				if(base)
+				{
+					strcat(mode, make_signed_hex_str_16(base));
+					comma = 1;
+				}
+				if(*base_reg)
+				{
+					if(comma)
+						strcat(mode, ",");
+					strcat(mode, base_reg);
+					comma = 1;
+				}
+				if(postindex)
+				{
+					strcat(mode, "]");
+					comma = 1;
+				}
+				if(*index_reg)
+				{
+					if(comma)
+						strcat(mode, ",");
+					strcat(mode, index_reg);
+					comma = 1;
+				}
+				if(preindex)
+				{
+					strcat(mode, "]");
+					comma = 1;
+				}
+				if(outer)
+				{
+					if(comma)
+						strcat(mode, ",");
+					strcat(mode, make_signed_hex_str_16(outer));
+				}
+				strcat(mode, ")");
+				break;
+			}
+
+			if(EXT_8BIT_DISPLACEMENT(extension) == 0)
+				sprintf(mode, "(PC,%c%d.%c", EXT_INDEX_AR(extension) ? 'A' : 'D', EXT_INDEX_REGISTER(extension), EXT_INDEX_LONG(extension) ? 'l' : 'w');
+			else
+				sprintf(mode, "(%s,PC,%c%d.%c", make_signed_hex_str_8(extension), EXT_INDEX_AR(extension) ? 'A' : 'D', EXT_INDEX_REGISTER(extension), EXT_INDEX_LONG(extension) ? 'l' : 'w');
+			if(EXT_INDEX_SCALE(extension))
+				sprintf(mode+strlen(mode), "*%d", 1 << EXT_INDEX_SCALE(extension));
+			strcat(mode, ")");
+			break;
+		case 0x3c:
+		/* Immediate */
+			sprintf(mode, "%s", get_imm_str_u(size));
+			break;
+		default:
+			sprintf(mode, "INVALID %x", instruction & 0x3f);
+	}
+	return mode;
+}
+
+
+
+/* ======================================================================== */
+/* ========================= INSTRUCTION HANDLERS ========================= */
+/* ======================================================================== */
+/* Instruction handler function names follow this convention:
+ *
+ * d68000_NAME_EXTENSIONS(void)
+ * where NAME is the name of the opcode it handles and EXTENSIONS are any
+ * extensions for special instances of that opcode.
+ *
+ * Examples:
+ *   d68000_add_er_8(): add opcode, from effective address to register,
+ *                      size = byte
+ *
+ *   d68000_asr_s_8(): arithmetic shift right, static count, size = byte
+ *
+ *
+ * Common extensions:
+ * 8   : size = byte
+ * 16  : size = word
+ * 32  : size = long
+ * rr  : register to register
+ * mm  : memory to memory
+ * r   : register
+ * s   : static
+ * er  : effective address -> register
+ * re  : register -> effective address
+ * ea  : using effective address mode of operation
+ * d   : data register direct
+ * a   : address register direct
+ * ai  : address register indirect
+ * pi  : address register indirect with postincrement
+ * pd  : address register indirect with predecrement
+ * di  : address register indirect with displacement
+ * ix  : address register indirect with index
+ * aw  : absolute word
+ * al  : absolute long
+ */
+
+static void d68000_illegal(void)
+{
+	sprintf(g_dasm_str, "dc.w $%04x; ILLEGAL", g_cpu_ir);
+}
+
+static void d68000_1010(void)
+{
+	sprintf(g_dasm_str, "dc.w    $%04x; opcode 1010", g_cpu_ir);
+}
+
+
+static void d68000_1111(void)
+{
+	sprintf(g_dasm_str, "dc.w    $%04x; opcode 1111", g_cpu_ir);
+}
+
+
+static void d68000_abcd_rr(void)
+{
+	sprintf(g_dasm_str, "abcd    D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+
+static void d68000_abcd_mm(void)
+{
+	sprintf(g_dasm_str, "abcd    -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_add_er_8(void)
+{
+	sprintf(g_dasm_str, "add.b   %s, D%d", get_ea_mode_str_8(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+
+static void d68000_add_er_16(void)
+{
+	sprintf(g_dasm_str, "add.w   %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_add_er_32(void)
+{
+	sprintf(g_dasm_str, "add.l   %s, D%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_add_re_8(void)
+{
+	sprintf(g_dasm_str, "add.b   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_add_re_16(void)
+{
+	sprintf(g_dasm_str, "add.w   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_add_re_32(void)
+{
+	sprintf(g_dasm_str, "add.l   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_adda_16(void)
+{
+	sprintf(g_dasm_str, "adda.w  %s, A%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_adda_32(void)
+{
+	sprintf(g_dasm_str, "adda.l  %s, A%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_addi_8(void)
+{
+	char* str = get_imm_str_s8();
+	sprintf(g_dasm_str, "addi.b  %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_addi_16(void)
+{
+	char* str = get_imm_str_s16();
+	sprintf(g_dasm_str, "addi.w  %s, %s", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_addi_32(void)
+{
+	char* str = get_imm_str_s32();
+	sprintf(g_dasm_str, "addi.l  %s, %s", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_addq_8(void)
+{
+	sprintf(g_dasm_str, "addq.b  #%d, %s", g_3bit_qdata_table[(g_cpu_ir>>9)&7], get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_addq_16(void)
+{
+	sprintf(g_dasm_str, "addq.w  #%d, %s", g_3bit_qdata_table[(g_cpu_ir>>9)&7], get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_addq_32(void)
+{
+	sprintf(g_dasm_str, "addq.l  #%d, %s", g_3bit_qdata_table[(g_cpu_ir>>9)&7], get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_addx_rr_8(void)
+{
+	sprintf(g_dasm_str, "addx.b  D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_addx_rr_16(void)
+{
+	sprintf(g_dasm_str, "addx.w  D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_addx_rr_32(void)
+{
+	sprintf(g_dasm_str, "addx.l  D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_addx_mm_8(void)
+{
+	sprintf(g_dasm_str, "addx.b  -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_addx_mm_16(void)
+{
+	sprintf(g_dasm_str, "addx.w  -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_addx_mm_32(void)
+{
+	sprintf(g_dasm_str, "addx.l  -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_and_er_8(void)
+{
+	sprintf(g_dasm_str, "and.b   %s, D%d", get_ea_mode_str_8(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_and_er_16(void)
+{
+	sprintf(g_dasm_str, "and.w   %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_and_er_32(void)
+{
+	sprintf(g_dasm_str, "and.l   %s, D%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_and_re_8(void)
+{
+	sprintf(g_dasm_str, "and.b   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_and_re_16(void)
+{
+	sprintf(g_dasm_str, "and.w   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_and_re_32(void)
+{
+	sprintf(g_dasm_str, "and.l   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_andi_8(void)
+{
+	char* str = get_imm_str_u8();
+	sprintf(g_dasm_str, "andi.b  %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_andi_16(void)
+{
+	char* str = get_imm_str_u16();
+	sprintf(g_dasm_str, "andi.w  %s, %s", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_andi_32(void)
+{
+	char* str = get_imm_str_u32();
+	sprintf(g_dasm_str, "andi.l  %s, %s", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_andi_to_ccr(void)
+{
+	sprintf(g_dasm_str, "andi    %s, CCR", get_imm_str_u8());
+}
+
+static void d68000_andi_to_sr(void)
+{
+	sprintf(g_dasm_str, "andi    %s, SR", get_imm_str_u16());
+}
+
+static void d68000_asr_s_8(void)
+{
+	sprintf(g_dasm_str, "asr.b   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_asr_s_16(void)
+{
+	sprintf(g_dasm_str, "asr.w   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_asr_s_32(void)
+{
+	sprintf(g_dasm_str, "asr.l   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_asr_r_8(void)
+{
+	sprintf(g_dasm_str, "asr.b   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_asr_r_16(void)
+{
+	sprintf(g_dasm_str, "asr.w   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_asr_r_32(void)
+{
+	sprintf(g_dasm_str, "asr.l   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_asr_ea(void)
+{
+	sprintf(g_dasm_str, "asr.w   %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_asl_s_8(void)
+{
+	sprintf(g_dasm_str, "asl.b   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_asl_s_16(void)
+{
+	sprintf(g_dasm_str, "asl.w   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_asl_s_32(void)
+{
+	sprintf(g_dasm_str, "asl.l   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_asl_r_8(void)
+{
+	sprintf(g_dasm_str, "asl.b   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_asl_r_16(void)
+{
+	sprintf(g_dasm_str, "asl.w   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_asl_r_32(void)
+{
+	sprintf(g_dasm_str, "asl.l   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_asl_ea(void)
+{
+	sprintf(g_dasm_str, "asl.w   %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_bcc_8(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "b%-2s     %x", g_cc[(g_cpu_ir>>8)&0xf], temp_pc + make_int_8(g_cpu_ir));
+}
+
+static void d68000_bcc_16(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "b%-2s     %x", g_cc[(g_cpu_ir>>8)&0xf], temp_pc + make_int_16(read_imm_16()));
+}
+
+static void d68020_bcc_32(void)
+{
+	uint temp_pc = g_cpu_pc;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "b%-2s     %x; (2+)", g_cc[(g_cpu_ir>>8)&0xf], temp_pc + read_imm_32());
+}
+
+static void d68000_bchg_r(void)
+{
+	sprintf(g_dasm_str, "bchg    D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_bchg_s(void)
+{
+	char* str = get_imm_str_u8();
+	sprintf(g_dasm_str, "bchg    %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_bclr_r(void)
+{
+	sprintf(g_dasm_str, "bclr    D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_bclr_s(void)
+{
+	char* str = get_imm_str_u8();
+	sprintf(g_dasm_str, "bclr    %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68010_bkpt(void)
+{
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	sprintf(g_dasm_str, "bkpt #%d; (1+)", g_cpu_ir&7);
+}
+
+static void d68020_bfchg(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bfchg   %s {%s:%s}; (2+)", get_ea_mode_str_8(g_cpu_ir), offset, width);
+}
+
+static void d68020_bfclr(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bfclr   %s {%s:%s}; (2+)", get_ea_mode_str_8(g_cpu_ir), offset, width);
+}
+
+static void d68020_bfexts(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bfexts  %s {%s:%s}, D%d; (2+)", get_ea_mode_str_8(g_cpu_ir), offset, width, (extension>>12)&7);
+}
+
+static void d68020_bfextu(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bfextu  %s {%s:%s}, D%d; (2+)", get_ea_mode_str_8(g_cpu_ir), offset, width, (extension>>12)&7);
+}
+
+static void d68020_bfffo(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bfffo   %s {%s:%s}, D%d; (2+)", get_ea_mode_str_8(g_cpu_ir), offset, width, (extension>>12)&7);
+}
+
+static void d68020_bfins(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bfins   D%d, %s {%s:%s}; (2+)", (extension>>12)&7, get_ea_mode_str_8(g_cpu_ir), offset, width);
+}
+
+static void d68020_bfset(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bfset   %s {%s:%s}; (2+)", get_ea_mode_str_8(g_cpu_ir), offset, width);
+}
+
+static void d68020_bftst(void)
+{
+	uint extension;
+	char offset[3];
+	char width[3];
+
+	LIMIT_CPU_TYPES(M68020_PLUS);
+
+	extension = read_imm_16();
+
+	if(BIT_B(extension))
+		sprintf(offset, "D%d", (extension>>6)&7);
+	else
+		sprintf(offset, "%d", (extension>>6)&31);
+	if(BIT_5(extension))
+		sprintf(width, "D%d", extension&7);
+	else
+		sprintf(width, "%d", g_5bit_data_table[extension&31]);
+	sprintf(g_dasm_str, "bftst   %s {%s:%s}; (2+)", get_ea_mode_str_8(g_cpu_ir), offset, width);
+}
+
+static void d68000_bra_8(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "bra     %x", temp_pc + make_int_8(g_cpu_ir));
+}
+
+static void d68000_bra_16(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "bra     %x", temp_pc + make_int_16(read_imm_16()));
+}
+
+static void d68020_bra_32(void)
+{
+	uint temp_pc = g_cpu_pc;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "bra     %x; (2+)", temp_pc + read_imm_32());
+}
+
+static void d68000_bset_r(void)
+{
+	sprintf(g_dasm_str, "bset    D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_bset_s(void)
+{
+	char* str = get_imm_str_u8();
+	sprintf(g_dasm_str, "bset    %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_bsr_8(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "bsr     %x", temp_pc + make_int_8(g_cpu_ir));
+}
+
+static void d68000_bsr_16(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "bsr     %x", temp_pc + make_int_16(read_imm_16()));
+}
+
+static void d68020_bsr_32(void)
+{
+	uint temp_pc = g_cpu_pc;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "bsr     %x; (2+)", temp_pc + peek_imm_32());
+}
+
+static void d68000_btst_r(void)
+{
+	sprintf(g_dasm_str, "btst    D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_btst_s(void)
+{
+	char* str = get_imm_str_u8();
+	sprintf(g_dasm_str, "btst    %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_callm(void)
+{
+	char* str;
+	LIMIT_CPU_TYPES(M68020_ONLY);
+	str = get_imm_str_u8();
+
+	sprintf(g_dasm_str, "callm   %s, %s; (2)", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_cas_8(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	sprintf(g_dasm_str, "cas.b   D%d, D%d, %s; (2+)", extension&7, (extension>>6)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_cas_16(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	sprintf(g_dasm_str, "cas.w   D%d, D%d, %s; (2+)", extension&7, (extension>>6)&7, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68020_cas_32(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	sprintf(g_dasm_str, "cas.l   D%d, D%d, %s; (2+)", extension&7, (extension>>6)&7, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68020_cas2_16(void)
+{
+/* CAS2 Dc1:Dc2,Du1:Dc2:(Rn1):(Rn2)
+f e d c b a 9 8 7 6 5 4 3 2 1 0
+ DARn1  0 0 0  Du1  0 0 0  Dc1
+ DARn2  0 0 0  Du2  0 0 0  Dc2
+*/
+
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_32();
+	sprintf(g_dasm_str, "cas2.w  D%d:D%d, D%d:D%d, (%c%d):(%c%d); (2+)",
+		(extension>>16)&7, extension&7, (extension>>22)&7, (extension>>6)&7,
+		BIT_1F(extension) ? 'A' : 'D', (extension>>28)&7,
+		BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68020_cas2_32(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_32();
+	sprintf(g_dasm_str, "cas2.l  D%d:D%d, D%d:D%d, (%c%d):(%c%d); (2+)",
+		(extension>>16)&7, extension&7, (extension>>22)&7, (extension>>6)&7,
+		BIT_1F(extension) ? 'A' : 'D', (extension>>28)&7,
+		BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68000_chk_16(void)
+{
+	sprintf(g_dasm_str, "chk.w   %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68020_chk_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "chk.l   %s, D%d; (2+)", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68020_chk2_cmp2_8(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	sprintf(g_dasm_str, "%s.b  %s, %c%d; (2+)", BIT_B(extension) ? "chk2" : "cmp2", get_ea_mode_str_8(g_cpu_ir), BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68020_chk2_cmp2_16(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	sprintf(g_dasm_str, "%s.w  %s, %c%d; (2+)", BIT_B(extension) ? "chk2" : "cmp2", get_ea_mode_str_16(g_cpu_ir), BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68020_chk2_cmp2_32(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	sprintf(g_dasm_str, "%s.l  %s, %c%d; (2+)", BIT_B(extension) ? "chk2" : "cmp2", get_ea_mode_str_32(g_cpu_ir), BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68040_cinv(void)
+{
+	LIMIT_CPU_TYPES(M68040_PLUS);
+	switch((g_cpu_ir>>3)&3)
+	{
+		case 0:
+			sprintf(g_dasm_str, "cinv (illegal scope); (4)");
+			break;
+		case 1:
+			sprintf(g_dasm_str, "cinvl   %d, (A%d); (4)", (g_cpu_ir>>6)&3, g_cpu_ir&7);
+			break;
+		case 2:
+			sprintf(g_dasm_str, "cinvp   %d, (A%d); (4)", (g_cpu_ir>>6)&3, g_cpu_ir&7);
+			break;
+		case 3:
+			sprintf(g_dasm_str, "cinva   %d; (4)", (g_cpu_ir>>6)&3);
+			break;
+	}
+}
+
+static void d68000_clr_8(void)
+{
+	sprintf(g_dasm_str, "clr.b   %s", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_clr_16(void)
+{
+	sprintf(g_dasm_str, "clr.w   %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_clr_32(void)
+{
+	sprintf(g_dasm_str, "clr.l   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_cmp_8(void)
+{
+	sprintf(g_dasm_str, "cmp.b   %s, D%d", get_ea_mode_str_8(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_cmp_16(void)
+{
+	sprintf(g_dasm_str, "cmp.w   %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_cmp_32(void)
+{
+	sprintf(g_dasm_str, "cmp.l   %s, D%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_cmpa_16(void)
+{
+	sprintf(g_dasm_str, "cmpa.w  %s, A%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_cmpa_32(void)
+{
+	sprintf(g_dasm_str, "cmpa.l  %s, A%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_cmpi_8(void)
+{
+	char* str = get_imm_str_s8();
+	sprintf(g_dasm_str, "cmpi.b  %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_cmpi_pcdi_8(void)
+{
+	char* str;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	str = get_imm_str_s8();
+	sprintf(g_dasm_str, "cmpi.b  %s, %s; (2+)", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_cmpi_pcix_8(void)
+{
+	char* str;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	str = get_imm_str_s8();
+	sprintf(g_dasm_str, "cmpi.b  %s, %s; (2+)", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_cmpi_16(void)
+{
+	char* str;
+	str = get_imm_str_s16();
+	sprintf(g_dasm_str, "cmpi.w  %s, %s", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68020_cmpi_pcdi_16(void)
+{
+	char* str;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	str = get_imm_str_s16();
+	sprintf(g_dasm_str, "cmpi.w  %s, %s; (2+)", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68020_cmpi_pcix_16(void)
+{
+	char* str;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	str = get_imm_str_s16();
+	sprintf(g_dasm_str, "cmpi.w  %s, %s; (2+)", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_cmpi_32(void)
+{
+	char* str;
+	str = get_imm_str_s32();
+	sprintf(g_dasm_str, "cmpi.l  %s, %s", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68020_cmpi_pcdi_32(void)
+{
+	char* str;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	str = get_imm_str_s32();
+	sprintf(g_dasm_str, "cmpi.l  %s, %s; (2+)", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68020_cmpi_pcix_32(void)
+{
+	char* str;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	str = get_imm_str_s32();
+	sprintf(g_dasm_str, "cmpi.l  %s, %s; (2+)", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_cmpm_8(void)
+{
+	sprintf(g_dasm_str, "cmpm.b  (A%d)+, (A%d)+", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_cmpm_16(void)
+{
+	sprintf(g_dasm_str, "cmpm.w  (A%d)+, (A%d)+", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_cmpm_32(void)
+{
+	sprintf(g_dasm_str, "cmpm.l  (A%d)+, (A%d)+", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68020_cpbcc_16(void)
+{
+	uint extension;
+	uint new_pc = g_cpu_pc;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	new_pc += make_int_16(peek_imm_16());
+	sprintf(g_dasm_str, "%db%-4s  %s; %x (extension = %x) (2-3)", (g_cpu_ir>>9)&7, g_cpcc[g_cpu_ir&0x3f], get_imm_str_s16(), new_pc, extension);
+}
+
+static void d68020_cpbcc_32(void)
+{
+	uint extension;
+	uint new_pc = g_cpu_pc;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+	new_pc += peek_imm_32();
+	sprintf(g_dasm_str, "%db%-4s  %s; %x (extension = %x) (2-3)", (g_cpu_ir>>9)&7, g_cpcc[g_cpu_ir&0x3f], get_imm_str_s16(), new_pc, extension);
+}
+
+static void d68020_cpdbcc(void)
+{
+	uint extension1;
+	uint extension2;
+	uint new_pc = g_cpu_pc;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension1 = read_imm_16();
+	extension2 = read_imm_16();
+	new_pc += make_int_16(peek_imm_16());
+	sprintf(g_dasm_str, "%ddb%-4s D%d,%s; %x (extension = %x) (2-3)", (g_cpu_ir>>9)&7, g_cpcc[extension1&0x3f], g_cpu_ir&7, get_imm_str_s16(), new_pc, extension2);
+}
+
+static void d68020_cpgen(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "%dgen    %s; (2-3)", (g_cpu_ir>>9)&7, get_imm_str_u32());
+}
+
+static void d68020_cprestore(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "%drestore %s; (2-3)", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_cpsave(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "%dsave   %s; (2-3)", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_cpscc(void)
+{
+	uint extension1;
+	uint extension2;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension1 = read_imm_16();
+	extension2 = read_imm_16();
+	sprintf(g_dasm_str, "%ds%-4s  %s; (extension = %x) (2-3)", (g_cpu_ir>>9)&7, g_cpcc[extension1&0x3f], get_ea_mode_str_8(g_cpu_ir), extension2);
+}
+
+static void d68020_cptrapcc_0(void)
+{
+	uint extension1;
+	uint extension2;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension1 = read_imm_16();
+	extension2 = read_imm_16();
+	sprintf(g_dasm_str, "%dtrap%-4s; (extension = %x) (2-3)", (g_cpu_ir>>9)&7, g_cpcc[extension1&0x3f], extension2);
+}
+
+static void d68020_cptrapcc_16(void)
+{
+	uint extension1;
+	uint extension2;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension1 = read_imm_16();
+	extension2 = read_imm_16();
+	sprintf(g_dasm_str, "%dtrap%-4s %s; (extension = %x) (2-3)", (g_cpu_ir>>9)&7, g_cpcc[extension1&0x3f], get_imm_str_u16(), extension2);
+}
+
+static void d68020_cptrapcc_32(void)
+{
+	uint extension1;
+	uint extension2;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension1 = read_imm_16();
+	extension2 = read_imm_16();
+	sprintf(g_dasm_str, "%dtrap%-4s %s; (extension = %x) (2-3)", (g_cpu_ir>>9)&7, g_cpcc[extension1&0x3f], get_imm_str_u32(), extension2);
+}
+
+static void d68040_cpush(void)
+{
+	LIMIT_CPU_TYPES(M68040_PLUS);
+	switch((g_cpu_ir>>3)&3)
+	{
+		case 0:
+			sprintf(g_dasm_str, "cpush (illegal scope); (4)");
+			break;
+		case 1:
+			sprintf(g_dasm_str, "cpushl  %d, (A%d); (4)", (g_cpu_ir>>6)&3, g_cpu_ir&7);
+			break;
+		case 2:
+			sprintf(g_dasm_str, "cpushp  %d, (A%d); (4)", (g_cpu_ir>>6)&3, g_cpu_ir&7);
+			break;
+		case 3:
+			sprintf(g_dasm_str, "cpusha  %d; (4)", (g_cpu_ir>>6)&3);
+			break;
+	}
+}
+
+static void d68000_dbra(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "dbra    D%d, %x", g_cpu_ir & 7, temp_pc + make_int_16(read_imm_16()));
+}
+
+static void d68000_dbcc(void)
+{
+	uint temp_pc = g_cpu_pc;
+	sprintf(g_dasm_str, "db%-2s    D%d, %x", g_cc[(g_cpu_ir>>8)&0xf], g_cpu_ir & 7, temp_pc + make_int_16(read_imm_16()));
+}
+
+static void d68000_divs(void)
+{
+	sprintf(g_dasm_str, "divs.w  %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_divu(void)
+{
+	sprintf(g_dasm_str, "divu.w  %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68020_divl(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+
+	if(BIT_A(extension))
+		sprintf(g_dasm_str, "div%c.l  %s, D%d:D%d; (2+)", BIT_B(extension) ? 's' : 'u', get_ea_mode_str_32(g_cpu_ir), extension&7, (extension>>12)&7);
+	else if((extension&7) == ((extension>>12)&7))
+		sprintf(g_dasm_str, "div%c.l  %s, D%d; (2+)", BIT_B(extension) ? 's' : 'u', get_ea_mode_str_32(g_cpu_ir), (extension>>12)&7);
+	else
+		sprintf(g_dasm_str, "div%cl.l %s, D%d:D%d; (2+)", BIT_B(extension) ? 's' : 'u', get_ea_mode_str_32(g_cpu_ir), extension&7, (extension>>12)&7);
+}
+
+static void d68000_eor_8(void)
+{
+	sprintf(g_dasm_str, "eor.b   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_eor_16(void)
+{
+	sprintf(g_dasm_str, "eor.w   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_eor_32(void)
+{
+	sprintf(g_dasm_str, "eor.l   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_eori_8(void)
+{
+	char* str = get_imm_str_u8();
+	sprintf(g_dasm_str, "eori.b  %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_eori_16(void)
+{
+	char* str = get_imm_str_u16();
+	sprintf(g_dasm_str, "eori.w  %s, %s", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_eori_32(void)
+{
+	char* str = get_imm_str_u32();
+	sprintf(g_dasm_str, "eori.l  %s, %s", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_eori_to_ccr(void)
+{
+	sprintf(g_dasm_str, "eori    %s, CCR", get_imm_str_u8());
+}
+
+static void d68000_eori_to_sr(void)
+{
+	sprintf(g_dasm_str, "eori    %s, SR", get_imm_str_u16());
+}
+
+static void d68000_exg_dd(void)
+{
+	sprintf(g_dasm_str, "exg     D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_exg_aa(void)
+{
+	sprintf(g_dasm_str, "exg     A%d, A%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_exg_da(void)
+{
+	sprintf(g_dasm_str, "exg     D%d, A%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_ext_16(void)
+{
+	sprintf(g_dasm_str, "ext.w   D%d", g_cpu_ir&7);
+}
+
+static void d68000_ext_32(void)
+{
+	sprintf(g_dasm_str, "ext.l   D%d", g_cpu_ir&7);
+}
+
+static void d68020_extb_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "extb.l  D%d; (2+)", g_cpu_ir&7);
+}
+
+static void d68000_jmp(void)
+{
+	sprintf(g_dasm_str, "jmp     %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_jsr(void)
+{
+	sprintf(g_dasm_str, "jsr     %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_lea(void)
+{
+	sprintf(g_dasm_str, "lea     %s, A%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_link_16(void)
+{
+	sprintf(g_dasm_str, "link    A%d, %s", g_cpu_ir&7, get_imm_str_s16());
+}
+
+static void d68020_link_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "link    A%d, %s; (2+)", g_cpu_ir&7, get_imm_str_s32());
+}
+
+static void d68000_lsr_s_8(void)
+{
+	sprintf(g_dasm_str, "lsr.b   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_lsr_s_16(void)
+{
+	sprintf(g_dasm_str, "lsr.w   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_lsr_s_32(void)
+{
+	sprintf(g_dasm_str, "lsr.l   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_lsr_r_8(void)
+{
+	sprintf(g_dasm_str, "lsr.b   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_lsr_r_16(void)
+{
+	sprintf(g_dasm_str, "lsr.w   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_lsr_r_32(void)
+{
+	sprintf(g_dasm_str, "lsr.l   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_lsr_ea(void)
+{
+	sprintf(g_dasm_str, "lsr.w   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_lsl_s_8(void)
+{
+	sprintf(g_dasm_str, "lsl.b   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_lsl_s_16(void)
+{
+	sprintf(g_dasm_str, "lsl.w   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_lsl_s_32(void)
+{
+	sprintf(g_dasm_str, "lsl.l   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_lsl_r_8(void)
+{
+	sprintf(g_dasm_str, "lsl.b   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_lsl_r_16(void)
+{
+	sprintf(g_dasm_str, "lsl.w   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_lsl_r_32(void)
+{
+	sprintf(g_dasm_str, "lsl.l   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_lsl_ea(void)
+{
+	sprintf(g_dasm_str, "lsl.w   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_move_8(void)
+{
+	char* str = get_ea_mode_str_8(g_cpu_ir);
+	sprintf(g_dasm_str, "move.b  %s, %s", str, get_ea_mode_str_8(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
+}
+
+static void d68000_move_16(void)
+{
+	char* str = get_ea_mode_str_16(g_cpu_ir);
+	sprintf(g_dasm_str, "move.w  %s, %s", str, get_ea_mode_str_16(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
+}
+
+static void d68000_move_32(void)
+{
+	char* str = get_ea_mode_str_32(g_cpu_ir);
+	sprintf(g_dasm_str, "move.l  %s, %s", str, get_ea_mode_str_32(((g_cpu_ir>>9) & 7) | ((g_cpu_ir>>3) & 0x38)));
+}
+
+static void d68000_movea_16(void)
+{
+	sprintf(g_dasm_str, "movea.w %s, A%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_movea_32(void)
+{
+	sprintf(g_dasm_str, "movea.l %s, A%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_move_to_ccr(void)
+{
+	sprintf(g_dasm_str, "move    %s, CCR", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68010_move_fr_ccr(void)
+{
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	sprintf(g_dasm_str, "move    CCR, %s; (1+)", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_move_fr_sr(void)
+{
+	sprintf(g_dasm_str, "move    SR, %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_move_to_sr(void)
+{
+	sprintf(g_dasm_str, "move    %s, SR", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_move_fr_usp(void)
+{
+	sprintf(g_dasm_str, "move    USP, A%d", g_cpu_ir&7);
+}
+
+static void d68000_move_to_usp(void)
+{
+	sprintf(g_dasm_str, "move    A%d, USP", g_cpu_ir&7);
+}
+
+static void d68010_movec(void)
+{
+	uint extension;
+	char* reg_name;
+	char* processor;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	extension = read_imm_16();
+
+	switch(extension & 0xfff)
+	{
+		case 0x000:
+			reg_name = "SFC";
+			processor = "1+";
+			break;
+		case 0x001:
+			reg_name = "DFC";
+			processor = "1+";
+			break;
+		case 0x800:
+			reg_name = "USP";
+			processor = "1+";
+			break;
+		case 0x801:
+			reg_name = "VBR";
+			processor = "1+";
+			break;
+		case 0x002:
+			reg_name = "CACR";
+			processor = "2+";
+			break;
+		case 0x802:
+			reg_name = "CAAR";
+			processor = "2,3";
+			break;
+		case 0x803:
+			reg_name = "MSP";
+			processor = "2+";
+			break;
+		case 0x804:
+			reg_name = "ISP";
+			processor = "2+";
+			break;
+		case 0x003:
+			reg_name = "TC";
+			processor = "4+";
+			break;
+		case 0x004:
+			reg_name = "ITT0";
+			processor = "4+";
+			break;
+		case 0x005:
+			reg_name = "ITT1";
+			processor = "4+";
+			break;
+		case 0x006:
+			reg_name = "DTT0";
+			processor = "4+";
+			break;
+		case 0x007:
+			reg_name = "DTT1";
+			processor = "4+";
+			break;
+		case 0x805:
+			reg_name = "MMUSR";
+			processor = "4+";
+			break;
+		case 0x806:
+			reg_name = "URP";
+			processor = "4+";
+			break;
+		case 0x807:
+			reg_name = "SRP";
+			processor = "4+";
+			break;
+		default:
+			reg_name = make_signed_hex_str_16(extension & 0xfff);
+			processor = "?";
+	}
+
+	if(BIT_1(g_cpu_ir))
+		sprintf(g_dasm_str, "movec %c%d, %s; (%s)", BIT_F(extension) ? 'A' : 'D', (extension>>12)&7, reg_name, processor);
+	else
+		sprintf(g_dasm_str, "movec %s, %c%d; (%s)", reg_name, BIT_F(extension) ? 'A' : 'D', (extension>>12)&7, processor);
+}
+
+static void d68000_movem_pd_16(void)
+{
+	uint data = read_imm_16();
+	char buffer[40];
+	uint first;
+	uint run_length;
+	uint i;
+
+	buffer[0] = 0;
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(15-i)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(15-(i+1)))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "D%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-D%d", first + run_length);
+		}
+	}
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(7-i)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(7-(i+1)))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "A%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-A%d", first + run_length);
+		}
+	}
+	sprintf(g_dasm_str, "movem.w %s, %s", buffer, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_movem_pd_32(void)
+{
+	uint data = read_imm_16();
+	char buffer[40];
+	uint first;
+	uint run_length;
+	uint i;
+
+	buffer[0] = 0;
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(15-i)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(15-(i+1)))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "D%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-D%d", first + run_length);
+		}
+	}
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(7-i)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(7-(i+1)))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "A%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-A%d", first + run_length);
+		}
+	}
+	sprintf(g_dasm_str, "movem.l %s, %s", buffer, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_movem_er_16(void)
+{
+	uint data = read_imm_16();
+	char buffer[40];
+	uint first;
+	uint run_length;
+	uint i;
+
+	buffer[0] = 0;
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<i))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "D%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-D%d", first + run_length);
+		}
+	}
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(i+8)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+8+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "A%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-A%d", first + run_length);
+		}
+	}
+	sprintf(g_dasm_str, "movem.w %s, %s", get_ea_mode_str_16(g_cpu_ir), buffer);
+}
+
+static void d68000_movem_er_32(void)
+{
+	uint data = read_imm_16();
+	char buffer[40];
+	uint first;
+	uint run_length;
+	uint i;
+
+	buffer[0] = 0;
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<i))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "D%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-D%d", first + run_length);
+		}
+	}
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(i+8)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+8+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "A%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-A%d", first + run_length);
+		}
+	}
+	sprintf(g_dasm_str, "movem.l %s, %s", get_ea_mode_str_32(g_cpu_ir), buffer);
+}
+
+static void d68000_movem_re_16(void)
+{
+	uint data = read_imm_16();
+	char buffer[40];
+	uint first;
+	uint run_length;
+	uint i;
+
+	buffer[0] = 0;
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<i))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "D%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-D%d", first + run_length);
+		}
+	}
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(i+8)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+8+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "A%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-A%d", first + run_length);
+		}
+	}
+	sprintf(g_dasm_str, "movem.w %s, %s", buffer, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_movem_re_32(void)
+{
+	uint data = read_imm_16();
+	char buffer[40];
+	uint first;
+	uint run_length;
+	uint i;
+
+	buffer[0] = 0;
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<i))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "D%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-D%d", first + run_length);
+		}
+	}
+	for(i=0;i<8;i++)
+	{
+		if(data&(1<<(i+8)))
+		{
+			first = i;
+			run_length = 0;
+			while(i<7 && (data&(1<<(i+8+1))))
+			{
+				i++;
+				run_length++;
+			}
+			if(buffer[0] != 0)
+				strcat(buffer, "/");
+			sprintf(buffer+strlen(buffer), "A%d", first);
+			if(run_length > 0)
+				sprintf(buffer+strlen(buffer), "-A%d", first + run_length);
+		}
+	}
+	sprintf(g_dasm_str, "movem.l %s, %s", buffer, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_movep_re_16(void)
+{
+	sprintf(g_dasm_str, "movep.w D%d, ($%x,A%d)", (g_cpu_ir>>9)&7, read_imm_16(), g_cpu_ir&7);
+}
+
+static void d68000_movep_re_32(void)
+{
+	sprintf(g_dasm_str, "movep.l D%d, ($%x,A%d)", (g_cpu_ir>>9)&7, read_imm_16(), g_cpu_ir&7);
+}
+
+static void d68000_movep_er_16(void)
+{
+	sprintf(g_dasm_str, "movep.w ($%x,A%d), D%d", read_imm_16(), g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_movep_er_32(void)
+{
+	sprintf(g_dasm_str, "movep.l ($%x,A%d), D%d", read_imm_16(), g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68010_moves_8(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	extension = read_imm_16();
+	if(BIT_B(extension))
+		sprintf(g_dasm_str, "moves.b %c%d, %s; (1+)", BIT_F(extension) ? 'A' : 'D', (extension>>12)&7, get_ea_mode_str_8(g_cpu_ir));
+	else
+		sprintf(g_dasm_str, "moves.b %s, %c%d; (1+)", get_ea_mode_str_8(g_cpu_ir), BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68010_moves_16(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	extension = read_imm_16();
+	if(BIT_B(extension))
+		sprintf(g_dasm_str, "moves.w %c%d, %s; (1+)", BIT_F(extension) ? 'A' : 'D', (extension>>12)&7, get_ea_mode_str_16(g_cpu_ir));
+	else
+		sprintf(g_dasm_str, "moves.w %s, %c%d; (1+)", get_ea_mode_str_16(g_cpu_ir), BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68010_moves_32(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	extension = read_imm_16();
+	if(BIT_B(extension))
+		sprintf(g_dasm_str, "moves.l %c%d, %s; (1+)", BIT_F(extension) ? 'A' : 'D', (extension>>12)&7, get_ea_mode_str_32(g_cpu_ir));
+	else
+		sprintf(g_dasm_str, "moves.l %s, %c%d; (1+)", get_ea_mode_str_32(g_cpu_ir), BIT_F(extension) ? 'A' : 'D', (extension>>12)&7);
+}
+
+static void d68000_moveq(void)
+{
+	sprintf(g_dasm_str, "moveq   #%s, D%d", make_signed_hex_str_8(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68040_move16_pi_pi(void)
+{
+	LIMIT_CPU_TYPES(M68040_PLUS);
+	sprintf(g_dasm_str, "move16  (A%d)+, (A%d)+; (4)", g_cpu_ir&7, (read_imm_16()>>12)&7);
+}
+
+static void d68040_move16_pi_al(void)
+{
+	LIMIT_CPU_TYPES(M68040_PLUS);
+	sprintf(g_dasm_str, "move16  (A%d)+, %s; (4)", g_cpu_ir&7, get_imm_str_u32());
+}
+
+static void d68040_move16_al_pi(void)
+{
+	LIMIT_CPU_TYPES(M68040_PLUS);
+	sprintf(g_dasm_str, "move16  %s, (A%d)+; (4)", get_imm_str_u32(), g_cpu_ir&7);
+}
+
+static void d68040_move16_ai_al(void)
+{
+	LIMIT_CPU_TYPES(M68040_PLUS);
+	sprintf(g_dasm_str, "move16  (A%d), %s; (4)", g_cpu_ir&7, get_imm_str_u32());
+}
+
+static void d68040_move16_al_ai(void)
+{
+	LIMIT_CPU_TYPES(M68040_PLUS);
+	sprintf(g_dasm_str, "move16  %s, (A%d); (4)", get_imm_str_u32(), g_cpu_ir&7);
+}
+
+static void d68000_muls(void)
+{
+	sprintf(g_dasm_str, "muls.w  %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_mulu(void)
+{
+	sprintf(g_dasm_str, "mulu.w  %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68020_mull(void)
+{
+	uint extension;
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	extension = read_imm_16();
+
+	if(BIT_A(extension))
+		sprintf(g_dasm_str, "mul%c.l %s, D%d:D%d; (2+)", BIT_B(extension) ? 's' : 'u', get_ea_mode_str_32(g_cpu_ir), extension&7, (extension>>12)&7);
+	else
+		sprintf(g_dasm_str, "mul%c.l  %s, D%d; (2+)", BIT_B(extension) ? 's' : 'u', get_ea_mode_str_32(g_cpu_ir), (extension>>12)&7);
+}
+
+static void d68000_nbcd(void)
+{
+	sprintf(g_dasm_str, "nbcd    %s", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_neg_8(void)
+{
+	sprintf(g_dasm_str, "neg.b   %s", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_neg_16(void)
+{
+	sprintf(g_dasm_str, "neg.w   %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_neg_32(void)
+{
+	sprintf(g_dasm_str, "neg.l   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_negx_8(void)
+{
+	sprintf(g_dasm_str, "negx.b  %s", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_negx_16(void)
+{
+	sprintf(g_dasm_str, "negx.w  %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_negx_32(void)
+{
+	sprintf(g_dasm_str, "negx.l  %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_nop(void)
+{
+	sprintf(g_dasm_str, "nop");
+}
+
+static void d68000_not_8(void)
+{
+	sprintf(g_dasm_str, "not.b   %s", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_not_16(void)
+{
+	sprintf(g_dasm_str, "not.w   %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_not_32(void)
+{
+	sprintf(g_dasm_str, "not.l   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_or_er_8(void)
+{
+	sprintf(g_dasm_str, "or.b    %s, D%d", get_ea_mode_str_8(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_or_er_16(void)
+{
+	sprintf(g_dasm_str, "or.w    %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_or_er_32(void)
+{
+	sprintf(g_dasm_str, "or.l    %s, D%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_or_re_8(void)
+{
+	sprintf(g_dasm_str, "or.b    D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_or_re_16(void)
+{
+	sprintf(g_dasm_str, "or.w    D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_or_re_32(void)
+{
+	sprintf(g_dasm_str, "or.l    D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_ori_8(void)
+{
+	char* str = get_imm_str_u8();
+	sprintf(g_dasm_str, "ori.b   %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_ori_16(void)
+{
+	char* str = get_imm_str_u16();
+	sprintf(g_dasm_str, "ori.w   %s, %s", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_ori_32(void)
+{
+	char* str = get_imm_str_u32();
+	sprintf(g_dasm_str, "ori.l   %s, %s", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_ori_to_ccr(void)
+{
+	sprintf(g_dasm_str, "ori     %s, CCR", get_imm_str_u8());
+}
+
+static void d68000_ori_to_sr(void)
+{
+	sprintf(g_dasm_str, "ori     %s, SR", get_imm_str_u16());
+}
+
+static void d68020_pack_rr(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "pack    D%d, D%d, %s; (2+)", g_cpu_ir&7, (g_cpu_ir>>9)&7, get_imm_str_u16());
+}
+
+static void d68020_pack_mm(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "pack    -(A%d), -(A%d), %s; (2+)", g_cpu_ir&7, (g_cpu_ir>>9)&7, get_imm_str_u16());
+}
+
+static void d68000_pea(void)
+{
+	sprintf(g_dasm_str, "pea     %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_reset(void)
+{
+	sprintf(g_dasm_str, "reset");
+}
+
+static void d68000_ror_s_8(void)
+{
+	sprintf(g_dasm_str, "ror.b   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_ror_s_16(void)
+{
+	sprintf(g_dasm_str, "ror.w   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7],g_cpu_ir&7);
+}
+
+static void d68000_ror_s_32(void)
+{
+	sprintf(g_dasm_str, "ror.l   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_ror_r_8(void)
+{
+	sprintf(g_dasm_str, "ror.b   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_ror_r_16(void)
+{
+	sprintf(g_dasm_str, "ror.w   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_ror_r_32(void)
+{
+	sprintf(g_dasm_str, "ror.l   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_ror_ea(void)
+{
+	sprintf(g_dasm_str, "ror.w   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_rol_s_8(void)
+{
+	sprintf(g_dasm_str, "rol.b   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_rol_s_16(void)
+{
+	sprintf(g_dasm_str, "rol.w   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_rol_s_32(void)
+{
+	sprintf(g_dasm_str, "rol.l   #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_rol_r_8(void)
+{
+	sprintf(g_dasm_str, "rol.b   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_rol_r_16(void)
+{
+	sprintf(g_dasm_str, "rol.w   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_rol_r_32(void)
+{
+	sprintf(g_dasm_str, "rol.l   D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_rol_ea(void)
+{
+	sprintf(g_dasm_str, "rol.w   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_roxr_s_8(void)
+{
+	sprintf(g_dasm_str, "roxr.b  #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_roxr_s_16(void)
+{
+	sprintf(g_dasm_str, "roxr.w  #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+
+static void d68000_roxr_s_32(void)
+{
+	sprintf(g_dasm_str, "roxr.l  #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_roxr_r_8(void)
+{
+	sprintf(g_dasm_str, "roxr.b  D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_roxr_r_16(void)
+{
+	sprintf(g_dasm_str, "roxr.w  D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_roxr_r_32(void)
+{
+	sprintf(g_dasm_str, "roxr.l  D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_roxr_ea(void)
+{
+	sprintf(g_dasm_str, "roxr.w  %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_roxl_s_8(void)
+{
+	sprintf(g_dasm_str, "roxl.b  #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_roxl_s_16(void)
+{
+	sprintf(g_dasm_str, "roxl.w  #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_roxl_s_32(void)
+{
+	sprintf(g_dasm_str, "roxl.l  #%d, D%d", g_3bit_qdata_table[(g_cpu_ir>>9)&7], g_cpu_ir&7);
+}
+
+static void d68000_roxl_r_8(void)
+{
+	sprintf(g_dasm_str, "roxl.b  D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_roxl_r_16(void)
+{
+	sprintf(g_dasm_str, "roxl.w  D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_roxl_r_32(void)
+{
+	sprintf(g_dasm_str, "roxl.l  D%d, D%d", (g_cpu_ir>>9)&7, g_cpu_ir&7);
+}
+
+static void d68000_roxl_ea(void)
+{
+	sprintf(g_dasm_str, "roxl.w  %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68010_rtd(void)
+{
+	LIMIT_CPU_TYPES(M68010_PLUS);
+	sprintf(g_dasm_str, "rtd     %s; (1+)", get_imm_str_s16());
+}
+
+static void d68000_rte(void)
+{
+	sprintf(g_dasm_str, "rte");
+}
+
+static void d68020_rtm(void)
+{
+	LIMIT_CPU_TYPES(M68020_ONLY);
+	sprintf(g_dasm_str, "rtm     %c%d; (2+)", BIT_3(g_cpu_ir) ? 'A' : 'D', g_cpu_ir&7);
+}
+
+static void d68000_rtr(void)
+{
+	sprintf(g_dasm_str, "rtr");
+}
+
+static void d68000_rts(void)
+{
+	sprintf(g_dasm_str, "rts");
+}
+
+static void d68000_sbcd_rr(void)
+{
+	sprintf(g_dasm_str, "sbcd    D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_sbcd_mm(void)
+{
+	sprintf(g_dasm_str, "sbcd    -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_scc(void)
+{
+	sprintf(g_dasm_str, "s%-2s     %s", g_cc[(g_cpu_ir>>8)&0xf], get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_stop(void)
+{
+	sprintf(g_dasm_str, "stop    %s", get_imm_str_s16());
+}
+
+static void d68000_sub_er_8(void)
+{
+	sprintf(g_dasm_str, "sub.b   %s, D%d", get_ea_mode_str_8(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_sub_er_16(void)
+{
+	sprintf(g_dasm_str, "sub.w   %s, D%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_sub_er_32(void)
+{
+	sprintf(g_dasm_str, "sub.l   %s, D%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_sub_re_8(void)
+{
+	sprintf(g_dasm_str, "sub.b   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_sub_re_16(void)
+{
+	sprintf(g_dasm_str, "sub.w   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_sub_re_32(void)
+{
+	sprintf(g_dasm_str, "sub.l   D%d, %s", (g_cpu_ir>>9)&7, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_suba_16(void)
+{
+	sprintf(g_dasm_str, "suba.w  %s, A%d", get_ea_mode_str_16(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_suba_32(void)
+{
+	sprintf(g_dasm_str, "suba.l  %s, A%d", get_ea_mode_str_32(g_cpu_ir), (g_cpu_ir>>9)&7);
+}
+
+static void d68000_subi_8(void)
+{
+	char* str = get_imm_str_s8();
+	sprintf(g_dasm_str, "subi.b  %s, %s", str, get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_subi_16(void)
+{
+	char* str = get_imm_str_s16();
+	sprintf(g_dasm_str, "subi.w  %s, %s", str, get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_subi_32(void)
+{
+	char* str = get_imm_str_s32();
+	sprintf(g_dasm_str, "subi.l  %s, %s", str, get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_subq_8(void)
+{
+	sprintf(g_dasm_str, "subq.b  #%d, %s", g_3bit_qdata_table[(g_cpu_ir>>9)&7], get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_subq_16(void)
+{
+	sprintf(g_dasm_str, "subq.w  #%d, %s", g_3bit_qdata_table[(g_cpu_ir>>9)&7], get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_subq_32(void)
+{
+	sprintf(g_dasm_str, "subq.l  #%d, %s", g_3bit_qdata_table[(g_cpu_ir>>9)&7], get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_subx_rr_8(void)
+{
+	sprintf(g_dasm_str, "subx.b  D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_subx_rr_16(void)
+{
+	sprintf(g_dasm_str, "subx.w  D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_subx_rr_32(void)
+{
+	sprintf(g_dasm_str, "subx.l  D%d, D%d", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_subx_mm_8(void)
+{
+	sprintf(g_dasm_str, "subx.b  -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_subx_mm_16(void)
+{
+	sprintf(g_dasm_str, "subx.w  -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_subx_mm_32(void)
+{
+	sprintf(g_dasm_str, "subx.l  -(A%d), -(A%d)", g_cpu_ir&7, (g_cpu_ir>>9)&7);
+}
+
+static void d68000_swap(void)
+{
+	sprintf(g_dasm_str, "swap    D%d", g_cpu_ir&7);
+}
+
+static void d68000_tas(void)
+{
+	sprintf(g_dasm_str, "tas     %s", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_trap(void)
+{
+	sprintf(g_dasm_str, "trap    #$%x", g_cpu_ir&0xf);
+}
+
+static void d68020_trapcc_0(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "trap%-2s; (2+)", g_cc[(g_cpu_ir>>8)&0xf]);
+}
+
+static void d68020_trapcc_16(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "trap%-2s  %s; (2+)", g_cc[(g_cpu_ir>>8)&0xf], get_imm_str_u16());
+}
+
+static void d68020_trapcc_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "trap%-2s  %s; (2+)", g_cc[(g_cpu_ir>>8)&0xf], get_imm_str_u32());
+}
+
+static void d68000_trapv(void)
+{
+	sprintf(g_dasm_str, "trapv");
+}
+
+static void d68000_tst_8(void)
+{
+	sprintf(g_dasm_str, "tst.b   %s", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_tst_pcdi_8(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.b   %s; (2+)", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_tst_pcix_8(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.b   %s; (2+)", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68020_tst_i_8(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.b   %s; (2+)", get_ea_mode_str_8(g_cpu_ir));
+}
+
+static void d68000_tst_16(void)
+{
+	sprintf(g_dasm_str, "tst.w   %s", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68020_tst_a_16(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.w   %s; (2+)", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68020_tst_pcdi_16(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.w   %s; (2+)", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68020_tst_pcix_16(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.w   %s; (2+)", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68020_tst_i_16(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.w   %s; (2+)", get_ea_mode_str_16(g_cpu_ir));
+}
+
+static void d68000_tst_32(void)
+{
+	sprintf(g_dasm_str, "tst.l   %s", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68020_tst_a_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.l   %s; (2+)", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68020_tst_pcdi_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.l   %s; (2+)", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68020_tst_pcix_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.l   %s; (2+)", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68020_tst_i_32(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "tst.l   %s; (2+)", get_ea_mode_str_32(g_cpu_ir));
+}
+
+static void d68000_unlk(void)
+{
+	sprintf(g_dasm_str, "unlk    A%d", g_cpu_ir&7);
+}
+
+static void d68020_unpk_rr(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "unpk    D%d, D%d, %s; (2+)", g_cpu_ir&7, (g_cpu_ir>>9)&7, get_imm_str_u16());
+}
+
+static void d68020_unpk_mm(void)
+{
+	LIMIT_CPU_TYPES(M68020_PLUS);
+	sprintf(g_dasm_str, "unpk    -(A%d), -(A%d), %s; (2+)", g_cpu_ir&7, (g_cpu_ir>>9)&7, get_imm_str_u16());
+}
+
+
+
+/* ======================================================================== */
+/* ======================= INSTRUCTION TABLE BUILDER ====================== */
+/* ======================================================================== */
+
+/* EA Masks:
+800 = data register direct
+400 = address register direct
+200 = address register indirect
+100 = ARI postincrement
+ 80 = ARI pre-decrement
+ 40 = ARI displacement
+ 20 = ARI index
+ 10 = absolute short
+  8 = absolute long
+  4 = immediate / sr
+  2 = pc displacement
+  1 = pc idx
+*/
+
+static opcode_struct g_opcode_info[] =
+{
+/*  opcode handler    mask    match   ea mask */
+	{d68000_1010         , 0xf000, 0xa000, 0x000},
+	{d68000_1111         , 0xf000, 0xf000, 0x000},
+	{d68000_abcd_rr      , 0xf1f8, 0xc100, 0x000},
+	{d68000_abcd_mm      , 0xf1f8, 0xc108, 0x000},
+	{d68000_add_er_8     , 0xf1c0, 0xd000, 0xbff},
+	{d68000_add_er_16    , 0xf1c0, 0xd040, 0xfff},
+	{d68000_add_er_32    , 0xf1c0, 0xd080, 0xfff},
+	{d68000_add_re_8     , 0xf1c0, 0xd100, 0x3f8},
+	{d68000_add_re_16    , 0xf1c0, 0xd140, 0x3f8},
+	{d68000_add_re_32    , 0xf1c0, 0xd180, 0x3f8},
+	{d68000_adda_16      , 0xf1c0, 0xd0c0, 0xfff},
+	{d68000_adda_32      , 0xf1c0, 0xd1c0, 0xfff},
+	{d68000_addi_8       , 0xffc0, 0x0600, 0xbf8},
+	{d68000_addi_16      , 0xffc0, 0x0640, 0xbf8},
+	{d68000_addi_32      , 0xffc0, 0x0680, 0xbf8},
+	{d68000_addq_8       , 0xf1c0, 0x5000, 0xbf8},
+	{d68000_addq_16      , 0xf1c0, 0x5040, 0xff8},
+	{d68000_addq_32      , 0xf1c0, 0x5080, 0xff8},
+	{d68000_addx_rr_8    , 0xf1f8, 0xd100, 0x000},
+	{d68000_addx_rr_16   , 0xf1f8, 0xd140, 0x000},
+	{d68000_addx_rr_32   , 0xf1f8, 0xd180, 0x000},
+	{d68000_addx_mm_8    , 0xf1f8, 0xd108, 0x000},
+	{d68000_addx_mm_16   , 0xf1f8, 0xd148, 0x000},
+	{d68000_addx_mm_32   , 0xf1f8, 0xd188, 0x000},
+	{d68000_and_er_8     , 0xf1c0, 0xc000, 0xbff},
+	{d68000_and_er_16    , 0xf1c0, 0xc040, 0xbff},
+	{d68000_and_er_32    , 0xf1c0, 0xc080, 0xbff},
+	{d68000_and_re_8     , 0xf1c0, 0xc100, 0x3f8},
+	{d68000_and_re_16    , 0xf1c0, 0xc140, 0x3f8},
+	{d68000_and_re_32    , 0xf1c0, 0xc180, 0x3f8},
+	{d68000_andi_to_ccr  , 0xffff, 0x023c, 0x000},
+	{d68000_andi_to_sr   , 0xffff, 0x027c, 0x000},
+	{d68000_andi_8       , 0xffc0, 0x0200, 0xbf8},
+	{d68000_andi_16      , 0xffc0, 0x0240, 0xbf8},
+	{d68000_andi_32      , 0xffc0, 0x0280, 0xbf8},
+	{d68000_asr_s_8      , 0xf1f8, 0xe000, 0x000},
+	{d68000_asr_s_16     , 0xf1f8, 0xe040, 0x000},
+	{d68000_asr_s_32     , 0xf1f8, 0xe080, 0x000},
+	{d68000_asr_r_8      , 0xf1f8, 0xe020, 0x000},
+	{d68000_asr_r_16     , 0xf1f8, 0xe060, 0x000},
+	{d68000_asr_r_32     , 0xf1f8, 0xe0a0, 0x000},
+	{d68000_asr_ea       , 0xffc0, 0xe0c0, 0x3f8},
+	{d68000_asl_s_8      , 0xf1f8, 0xe100, 0x000},
+	{d68000_asl_s_16     , 0xf1f8, 0xe140, 0x000},
+	{d68000_asl_s_32     , 0xf1f8, 0xe180, 0x000},
+	{d68000_asl_r_8      , 0xf1f8, 0xe120, 0x000},
+	{d68000_asl_r_16     , 0xf1f8, 0xe160, 0x000},
+	{d68000_asl_r_32     , 0xf1f8, 0xe1a0, 0x000},
+	{d68000_asl_ea       , 0xffc0, 0xe1c0, 0x3f8},
+	{d68000_bcc_8        , 0xf000, 0x6000, 0x000},
+	{d68000_bcc_16       , 0xf0ff, 0x6000, 0x000},
+	{d68020_bcc_32       , 0xf0ff, 0x60ff, 0x000},
+	{d68000_bchg_r       , 0xf1c0, 0x0140, 0xbf8},
+	{d68000_bchg_s       , 0xffc0, 0x0840, 0xbf8},
+	{d68000_bclr_r       , 0xf1c0, 0x0180, 0xbf8},
+	{d68000_bclr_s       , 0xffc0, 0x0880, 0xbf8},
+	{d68020_bfchg        , 0xffc0, 0xeac0, 0xa78},
+	{d68020_bfclr        , 0xffc0, 0xecc0, 0xa78},
+	{d68020_bfexts       , 0xffc0, 0xebc0, 0xa7b},
+	{d68020_bfextu       , 0xffc0, 0xe9c0, 0xa7b},
+	{d68020_bfffo        , 0xffc0, 0xedc0, 0xa7b},
+	{d68020_bfins        , 0xffc0, 0xefc0, 0xa78},
+	{d68020_bfset        , 0xffc0, 0xeec0, 0xa78},
+	{d68020_bftst        , 0xffc0, 0xe8c0, 0xa7b},
+	{d68010_bkpt         , 0xfff8, 0x4848, 0x000},
+	{d68000_bra_8        , 0xff00, 0x6000, 0x000},
+	{d68000_bra_16       , 0xffff, 0x6000, 0x000},
+	{d68020_bra_32       , 0xffff, 0x60ff, 0x000},
+	{d68000_bset_r       , 0xf1c0, 0x01c0, 0xbf8},
+	{d68000_bset_s       , 0xffc0, 0x08c0, 0xbf8},
+	{d68000_bsr_8        , 0xff00, 0x6100, 0x000},
+	{d68000_bsr_16       , 0xffff, 0x6100, 0x000},
+	{d68020_bsr_32       , 0xffff, 0x61ff, 0x000},
+	{d68000_btst_r       , 0xf1c0, 0x0100, 0xbff},
+	{d68000_btst_s       , 0xffc0, 0x0800, 0xbfb},
+	{d68020_callm        , 0xffc0, 0x06c0, 0x27b},
+	{d68020_cas_8        , 0xffc0, 0x0ac0, 0x3f8},
+	{d68020_cas_16       , 0xffc0, 0x0cc0, 0x3f8},
+	{d68020_cas_32       , 0xffc0, 0x0ec0, 0x3f8},
+	{d68020_cas2_16      , 0xffff, 0x0cfc, 0x000},
+	{d68020_cas2_32      , 0xffff, 0x0efc, 0x000},
+	{d68000_chk_16       , 0xf1c0, 0x4180, 0xbff},
+	{d68020_chk_32       , 0xf1c0, 0x4100, 0xbff},
+	{d68020_chk2_cmp2_8  , 0xffc0, 0x00c0, 0x27b},
+	{d68020_chk2_cmp2_16 , 0xffc0, 0x02c0, 0x27b},
+	{d68020_chk2_cmp2_32 , 0xffc0, 0x04c0, 0x27b},
+	{d68040_cinv         , 0xff20, 0xf400, 0x000},
+	{d68000_clr_8        , 0xffc0, 0x4200, 0xbf8},
+	{d68000_clr_16       , 0xffc0, 0x4240, 0xbf8},
+	{d68000_clr_32       , 0xffc0, 0x4280, 0xbf8},
+	{d68000_cmp_8        , 0xf1c0, 0xb000, 0xbff},
+	{d68000_cmp_16       , 0xf1c0, 0xb040, 0xfff},
+	{d68000_cmp_32       , 0xf1c0, 0xb080, 0xfff},
+	{d68000_cmpa_16      , 0xf1c0, 0xb0c0, 0xfff},
+	{d68000_cmpa_32      , 0xf1c0, 0xb1c0, 0xfff},
+	{d68000_cmpi_8       , 0xffc0, 0x0c00, 0xbf8},
+	{d68020_cmpi_pcdi_8  , 0xffff, 0x0c3a, 0x000},
+	{d68020_cmpi_pcix_8  , 0xffff, 0x0c3b, 0x000},
+	{d68000_cmpi_16      , 0xffc0, 0x0c40, 0xbf8},
+	{d68020_cmpi_pcdi_16 , 0xffff, 0x0c7a, 0x000},
+	{d68020_cmpi_pcix_16 , 0xffff, 0x0c7b, 0x000},
+	{d68000_cmpi_32      , 0xffc0, 0x0c80, 0xbf8},
+	{d68020_cmpi_pcdi_32 , 0xffff, 0x0cba, 0x000},
+	{d68020_cmpi_pcix_32 , 0xffff, 0x0cbb, 0x000},
+	{d68000_cmpm_8       , 0xf1f8, 0xb108, 0x000},
+	{d68000_cmpm_16      , 0xf1f8, 0xb148, 0x000},
+	{d68000_cmpm_32      , 0xf1f8, 0xb188, 0x000},
+	{d68020_cpbcc_16     , 0xf1c0, 0xf080, 0x000},
+	{d68020_cpbcc_32     , 0xf1c0, 0xf0c0, 0x000},
+	{d68020_cpdbcc       , 0xf1f8, 0xf048, 0x000},
+	{d68020_cpgen        , 0xf1c0, 0xf000, 0x000},
+	{d68020_cprestore    , 0xf1c0, 0xf140, 0x37f},
+	{d68020_cpsave       , 0xf1c0, 0xf100, 0x2f8},
+	{d68020_cpscc        , 0xf1c0, 0xf040, 0xbf8},
+	{d68020_cptrapcc_0   , 0xf1ff, 0xf07c, 0x000},
+	{d68020_cptrapcc_16  , 0xf1ff, 0xf07a, 0x000},
+	{d68020_cptrapcc_32  , 0xf1ff, 0xf07b, 0x000},
+	{d68040_cpush        , 0xff20, 0xf420, 0x000},
+	{d68000_dbcc         , 0xf0f8, 0x50c8, 0x000},
+	{d68000_dbra         , 0xfff8, 0x51c8, 0x000},
+	{d68000_divs         , 0xf1c0, 0x81c0, 0xbff},
+	{d68000_divu         , 0xf1c0, 0x80c0, 0xbff},
+	{d68020_divl         , 0xffc0, 0x4c40, 0xbff},
+	{d68000_eor_8        , 0xf1c0, 0xb100, 0xbf8},
+	{d68000_eor_16       , 0xf1c0, 0xb140, 0xbf8},
+	{d68000_eor_32       , 0xf1c0, 0xb180, 0xbf8},
+	{d68000_eori_to_ccr  , 0xffff, 0x0a3c, 0x000},
+	{d68000_eori_to_sr   , 0xffff, 0x0a7c, 0x000},
+	{d68000_eori_8       , 0xffc0, 0x0a00, 0xbf8},
+	{d68000_eori_16      , 0xffc0, 0x0a40, 0xbf8},
+	{d68000_eori_32      , 0xffc0, 0x0a80, 0xbf8},
+	{d68000_exg_dd       , 0xf1f8, 0xc140, 0x000},
+	{d68000_exg_aa       , 0xf1f8, 0xc148, 0x000},
+	{d68000_exg_da       , 0xf1f8, 0xc188, 0x000},
+	{d68020_extb_32      , 0xfff8, 0x49c0, 0x000},
+	{d68000_ext_16       , 0xfff8, 0x4880, 0x000},
+	{d68000_ext_32       , 0xfff8, 0x48c0, 0x000},
+	{d68000_illegal      , 0xffff, 0x4afc, 0x000},
+	{d68000_jmp          , 0xffc0, 0x4ec0, 0x27b},
+	{d68000_jsr          , 0xffc0, 0x4e80, 0x27b},
+	{d68000_lea          , 0xf1c0, 0x41c0, 0x27b},
+	{d68000_link_16      , 0xfff8, 0x4e50, 0x000},
+	{d68020_link_32      , 0xfff8, 0x4808, 0x000},
+	{d68000_lsr_s_8      , 0xf1f8, 0xe008, 0x000},
+	{d68000_lsr_s_16     , 0xf1f8, 0xe048, 0x000},
+	{d68000_lsr_s_32     , 0xf1f8, 0xe088, 0x000},
+	{d68000_lsr_r_8      , 0xf1f8, 0xe028, 0x000},
+	{d68000_lsr_r_16     , 0xf1f8, 0xe068, 0x000},
+	{d68000_lsr_r_32     , 0xf1f8, 0xe0a8, 0x000},
+	{d68000_lsr_ea       , 0xffc0, 0xe2c0, 0x3f8},
+	{d68000_lsl_s_8      , 0xf1f8, 0xe108, 0x000},
+	{d68000_lsl_s_16     , 0xf1f8, 0xe148, 0x000},
+	{d68000_lsl_s_32     , 0xf1f8, 0xe188, 0x000},
+	{d68000_lsl_r_8      , 0xf1f8, 0xe128, 0x000},
+	{d68000_lsl_r_16     , 0xf1f8, 0xe168, 0x000},
+	{d68000_lsl_r_32     , 0xf1f8, 0xe1a8, 0x000},
+	{d68000_lsl_ea       , 0xffc0, 0xe3c0, 0x3f8},
+	{d68000_move_8       , 0xf000, 0x1000, 0xbff},
+	{d68000_move_16      , 0xf000, 0x3000, 0xfff},
+	{d68000_move_32      , 0xf000, 0x2000, 0xfff},
+	{d68000_movea_16     , 0xf1c0, 0x3040, 0xfff},
+	{d68000_movea_32     , 0xf1c0, 0x2040, 0xfff},
+	{d68000_move_to_ccr  , 0xffc0, 0x44c0, 0xbff},
+	{d68010_move_fr_ccr  , 0xffc0, 0x42c0, 0xbf8},
+	{d68000_move_to_sr   , 0xffc0, 0x46c0, 0xbff},
+	{d68000_move_fr_sr   , 0xffc0, 0x40c0, 0xbf8},
+	{d68000_move_to_usp  , 0xfff8, 0x4e60, 0x000},
+	{d68000_move_fr_usp  , 0xfff8, 0x4e68, 0x000},
+	{d68010_movec        , 0xfffe, 0x4e7a, 0x000},
+	{d68000_movem_pd_16  , 0xfff8, 0x48a0, 0x000},
+	{d68000_movem_pd_32  , 0xfff8, 0x48e0, 0x000},
+	{d68000_movem_re_16  , 0xffc0, 0x4880, 0x2f8},
+	{d68000_movem_re_32  , 0xffc0, 0x48c0, 0x2f8},
+	{d68000_movem_er_16  , 0xffc0, 0x4c80, 0x37b},
+	{d68000_movem_er_32  , 0xffc0, 0x4cc0, 0x37b},
+	{d68000_movep_er_16  , 0xf1f8, 0x0108, 0x000},
+	{d68000_movep_er_32  , 0xf1f8, 0x0148, 0x000},
+	{d68000_movep_re_16  , 0xf1f8, 0x0188, 0x000},
+	{d68000_movep_re_32  , 0xf1f8, 0x01c8, 0x000},
+	{d68010_moves_8      , 0xffc0, 0x0e00, 0x3f8},
+	{d68010_moves_16     , 0xffc0, 0x0e40, 0x3f8},
+	{d68010_moves_32     , 0xffc0, 0x0e80, 0x3f8},
+	{d68000_moveq        , 0xf100, 0x7000, 0x000},
+	{d68040_move16_pi_pi , 0xfff8, 0xf620, 0x000},
+	{d68040_move16_pi_al , 0xfff8, 0xf600, 0x000},
+	{d68040_move16_al_pi , 0xfff8, 0xf608, 0x000},
+	{d68040_move16_ai_al , 0xfff8, 0xf610, 0x000},
+	{d68040_move16_al_ai , 0xfff8, 0xf618, 0x000},
+	{d68000_muls         , 0xf1c0, 0xc1c0, 0xbff},
+	{d68000_mulu         , 0xf1c0, 0xc0c0, 0xbff},
+	{d68020_mull         , 0xffc0, 0x4c00, 0xbff},
+	{d68000_nbcd         , 0xffc0, 0x4800, 0xbf8},
+	{d68000_neg_8        , 0xffc0, 0x4400, 0xbf8},
+	{d68000_neg_16       , 0xffc0, 0x4440, 0xbf8},
+	{d68000_neg_32       , 0xffc0, 0x4480, 0xbf8},
+	{d68000_negx_8       , 0xffc0, 0x4000, 0xbf8},
+	{d68000_negx_16      , 0xffc0, 0x4040, 0xbf8},
+	{d68000_negx_32      , 0xffc0, 0x4080, 0xbf8},
+	{d68000_nop          , 0xffff, 0x4e71, 0x000},
+	{d68000_not_8        , 0xffc0, 0x4600, 0xbf8},
+	{d68000_not_16       , 0xffc0, 0x4640, 0xbf8},
+	{d68000_not_32       , 0xffc0, 0x4680, 0xbf8},
+	{d68000_or_er_8      , 0xf1c0, 0x8000, 0xbff},
+	{d68000_or_er_16     , 0xf1c0, 0x8040, 0xbff},
+	{d68000_or_er_32     , 0xf1c0, 0x8080, 0xbff},
+	{d68000_or_re_8      , 0xf1c0, 0x8100, 0x3f8},
+	{d68000_or_re_16     , 0xf1c0, 0x8140, 0x3f8},
+	{d68000_or_re_32     , 0xf1c0, 0x8180, 0x3f8},
+	{d68000_ori_to_ccr   , 0xffff, 0x003c, 0x000},
+	{d68000_ori_to_sr    , 0xffff, 0x007c, 0x000},
+	{d68000_ori_8        , 0xffc0, 0x0000, 0xbf8},
+	{d68000_ori_16       , 0xffc0, 0x0040, 0xbf8},
+	{d68000_ori_32       , 0xffc0, 0x0080, 0xbf8},
+	{d68020_pack_rr      , 0xf1f8, 0x8140, 0x000},
+	{d68020_pack_mm      , 0xf1f8, 0x8148, 0x000},
+	{d68000_pea          , 0xffc0, 0x4840, 0x27b},
+	{d68000_reset        , 0xffff, 0x4e70, 0x000},
+	{d68000_ror_s_8      , 0xf1f8, 0xe018, 0x000},
+	{d68000_ror_s_16     , 0xf1f8, 0xe058, 0x000},
+	{d68000_ror_s_32     , 0xf1f8, 0xe098, 0x000},
+	{d68000_ror_r_8      , 0xf1f8, 0xe038, 0x000},
+	{d68000_ror_r_16     , 0xf1f8, 0xe078, 0x000},
+	{d68000_ror_r_32     , 0xf1f8, 0xe0b8, 0x000},
+	{d68000_ror_ea       , 0xffc0, 0xe6c0, 0x3f8},
+	{d68000_rol_s_8      , 0xf1f8, 0xe118, 0x000},
+	{d68000_rol_s_16     , 0xf1f8, 0xe158, 0x000},
+	{d68000_rol_s_32     , 0xf1f8, 0xe198, 0x000},
+	{d68000_rol_r_8      , 0xf1f8, 0xe138, 0x000},
+	{d68000_rol_r_16     , 0xf1f8, 0xe178, 0x000},
+	{d68000_rol_r_32     , 0xf1f8, 0xe1b8, 0x000},
+	{d68000_rol_ea       , 0xffc0, 0xe7c0, 0x3f8},
+	{d68000_roxr_s_8     , 0xf1f8, 0xe010, 0x000},
+	{d68000_roxr_s_16    , 0xf1f8, 0xe050, 0x000},
+	{d68000_roxr_s_32    , 0xf1f8, 0xe090, 0x000},
+	{d68000_roxr_r_8     , 0xf1f8, 0xe030, 0x000},
+	{d68000_roxr_r_16    , 0xf1f8, 0xe070, 0x000},
+	{d68000_roxr_r_32    , 0xf1f8, 0xe0b0, 0x000},
+	{d68000_roxr_ea      , 0xffc0, 0xe4c0, 0x3f8},
+	{d68000_roxl_s_8     , 0xf1f8, 0xe110, 0x000},
+	{d68000_roxl_s_16    , 0xf1f8, 0xe150, 0x000},
+	{d68000_roxl_s_32    , 0xf1f8, 0xe190, 0x000},
+	{d68000_roxl_r_8     , 0xf1f8, 0xe130, 0x000},
+	{d68000_roxl_r_16    , 0xf1f8, 0xe170, 0x000},
+	{d68000_roxl_r_32    , 0xf1f8, 0xe1b0, 0x000},
+	{d68000_roxl_ea      , 0xffc0, 0xe5c0, 0x3f8},
+	{d68010_rtd          , 0xffff, 0x4e74, 0x000},
+	{d68000_rte          , 0xffff, 0x4e73, 0x000},
+	{d68020_rtm          , 0xfff0, 0x06c0, 0x000},
+	{d68000_rtr          , 0xffff, 0x4e77, 0x000},
+	{d68000_rts          , 0xffff, 0x4e75, 0x000},
+	{d68000_sbcd_rr      , 0xf1f8, 0x8100, 0x000},
+	{d68000_sbcd_mm      , 0xf1f8, 0x8108, 0x000},
+	{d68000_scc          , 0xf0c0, 0x50c0, 0xbf8},
+	{d68000_stop         , 0xffff, 0x4e72, 0x000},
+	{d68000_sub_er_8     , 0xf1c0, 0x9000, 0xbff},
+	{d68000_sub_er_16    , 0xf1c0, 0x9040, 0xfff},
+	{d68000_sub_er_32    , 0xf1c0, 0x9080, 0xfff},
+	{d68000_sub_re_8     , 0xf1c0, 0x9100, 0x3f8},
+	{d68000_sub_re_16    , 0xf1c0, 0x9140, 0x3f8},
+	{d68000_sub_re_32    , 0xf1c0, 0x9180, 0x3f8},
+	{d68000_suba_16      , 0xf1c0, 0x90c0, 0xfff},
+	{d68000_suba_32      , 0xf1c0, 0x91c0, 0xfff},
+	{d68000_subi_8       , 0xffc0, 0x0400, 0xbf8},
+	{d68000_subi_16      , 0xffc0, 0x0440, 0xbf8},
+	{d68000_subi_32      , 0xffc0, 0x0480, 0xbf8},
+	{d68000_subq_8       , 0xf1c0, 0x5100, 0xbf8},
+	{d68000_subq_16      , 0xf1c0, 0x5140, 0xff8},
+	{d68000_subq_32      , 0xf1c0, 0x5180, 0xff8},
+	{d68000_subx_rr_8    , 0xf1f8, 0x9100, 0x000},
+	{d68000_subx_rr_16   , 0xf1f8, 0x9140, 0x000},
+	{d68000_subx_rr_32   , 0xf1f8, 0x9180, 0x000},
+	{d68000_subx_mm_8    , 0xf1f8, 0x9108, 0x000},
+	{d68000_subx_mm_16   , 0xf1f8, 0x9148, 0x000},
+	{d68000_subx_mm_32   , 0xf1f8, 0x9188, 0x000},
+	{d68000_swap         , 0xfff8, 0x4840, 0x000},
+	{d68000_tas          , 0xffc0, 0x4ac0, 0xbf8},
+	{d68000_trap         , 0xfff0, 0x4e40, 0x000},
+	{d68020_trapcc_0     , 0xf0ff, 0x50fc, 0x000},
+	{d68020_trapcc_16    , 0xf0ff, 0x50fa, 0x000},
+	{d68020_trapcc_32    , 0xf0ff, 0x50fb, 0x000},
+	{d68000_trapv        , 0xffff, 0x4e76, 0x000},
+	{d68000_tst_8        , 0xffc0, 0x4a00, 0xbf8},
+	{d68020_tst_pcdi_8   , 0xffff, 0x4a3a, 0x000},
+	{d68020_tst_pcix_8   , 0xffff, 0x4a3b, 0x000},
+	{d68020_tst_i_8      , 0xffff, 0x4a3c, 0x000},
+	{d68000_tst_16       , 0xffc0, 0x4a40, 0xbf8},
+	{d68020_tst_a_16     , 0xfff8, 0x4a48, 0x000},
+	{d68020_tst_pcdi_16  , 0xffff, 0x4a7a, 0x000},
+	{d68020_tst_pcix_16  , 0xffff, 0x4a7b, 0x000},
+	{d68020_tst_i_16     , 0xffff, 0x4a7c, 0x000},
+	{d68000_tst_32       , 0xffc0, 0x4a80, 0xbf8},
+	{d68020_tst_a_32     , 0xfff8, 0x4a88, 0x000},
+	{d68020_tst_pcdi_32  , 0xffff, 0x4aba, 0x000},
+	{d68020_tst_pcix_32  , 0xffff, 0x4abb, 0x000},
+	{d68020_tst_i_32     , 0xffff, 0x4abc, 0x000},
+	{d68000_unlk         , 0xfff8, 0x4e58, 0x000},
+	{d68020_unpk_rr      , 0xf1f8, 0x8180, 0x000},
+	{d68020_unpk_mm      , 0xf1f8, 0x8188, 0x000},
+	{0, 0, 0, 0}
+};
+
+/* Check if opcode is using a valid ea mode */
+static int valid_ea(uint opcode, uint mask)
+{
+	if(mask == 0)
+		return 1;
+
+	switch(opcode & 0x3f)
+	{
+		case 0x00: case 0x01: case 0x02: case 0x03:
+		case 0x04: case 0x05: case 0x06: case 0x07:
+			return (mask & 0x800) != 0;
+		case 0x08: case 0x09: case 0x0a: case 0x0b:
+		case 0x0c: case 0x0d: case 0x0e: case 0x0f:
+			return (mask & 0x400) != 0;
+		case 0x10: case 0x11: case 0x12: case 0x13:
+		case 0x14: case 0x15: case 0x16: case 0x17:
+			return (mask & 0x200) != 0;
+		case 0x18: case 0x19: case 0x1a: case 0x1b:
+		case 0x1c: case 0x1d: case 0x1e: case 0x1f:
+			return (mask & 0x100) != 0;
+		case 0x20: case 0x21: case 0x22: case 0x23:
+		case 0x24: case 0x25: case 0x26: case 0x27:
+			return (mask & 0x080) != 0;
+		case 0x28: case 0x29: case 0x2a: case 0x2b:
+		case 0x2c: case 0x2d: case 0x2e: case 0x2f:
+			return (mask & 0x040) != 0;
+		case 0x30: case 0x31: case 0x32: case 0x33:
+		case 0x34: case 0x35: case 0x36: case 0x37:
+			return (mask & 0x020) != 0;
+		case 0x38:
+			return (mask & 0x010) != 0;
+		case 0x39:
+			return (mask & 0x008) != 0;
+		case 0x3a:
+			return (mask & 0x002) != 0;
+		case 0x3b:
+			return (mask & 0x001) != 0;
+		case 0x3c:
+			return (mask & 0x004) != 0;
+	}
+	return 0;
+
+}
+
+/* Used by qsort */
+static int DECL_SPEC compare_nof_true_bits(const void *aptr, const void *bptr)
+{
+	uint a = ((const opcode_struct*)aptr)->mask;
+	uint b = ((const opcode_struct*)bptr)->mask;
+
+	a = ((a & 0xAAAA) >> 1) + (a & 0x5555);
+	a = ((a & 0xCCCC) >> 2) + (a & 0x3333);
+	a = ((a & 0xF0F0) >> 4) + (a & 0x0F0F);
+	a = ((a & 0xFF00) >> 8) + (a & 0x00FF);
+
+	b = ((b & 0xAAAA) >> 1) + (b & 0x5555);
+	b = ((b & 0xCCCC) >> 2) + (b & 0x3333);
+	b = ((b & 0xF0F0) >> 4) + (b & 0x0F0F);
+	b = ((b & 0xFF00) >> 8) + (b & 0x00FF);
+
+	return b - a; /* reversed to get greatest to least sorting */
+}
+
+/* build the opcode handler jump table */
+static void build_opcode_table(void)
+{
+	uint i;
+	uint opcode;
+	opcode_struct* ostruct;
+	uint opcode_info_length = 0;
+
+	for(ostruct = g_opcode_info;ostruct->opcode_handler != 0;ostruct++)
+		opcode_info_length++;
+
+	qsort((void *)g_opcode_info, opcode_info_length, sizeof(g_opcode_info[0]), compare_nof_true_bits);
+
+	for(i=0;i<0x10000;i++)
+	{
+		g_instruction_table[i] = d68000_illegal; /* default to illegal */
+		opcode = i;
+		/* search through opcode info for a match */
+		for(ostruct = g_opcode_info;ostruct->opcode_handler != 0;ostruct++)
+		{
+			/* match opcode mask and allowed ea modes */
+			if((opcode & ostruct->mask) == ostruct->match)
+			{
+				/* Handle destination ea for move instructions */
+				if((ostruct->opcode_handler == d68000_move_8 ||
+					 ostruct->opcode_handler == d68000_move_16 ||
+					 ostruct->opcode_handler == d68000_move_32) &&
+					 !valid_ea(((opcode>>9)&7) | ((opcode>>3)&0x38), 0xbf8))
+						continue;
+				if(valid_ea(opcode, ostruct->ea_mask))
+				{
+					g_instruction_table[i] = ostruct->opcode_handler;
+					break;
+				}
+			}
+		}
+	}
+}
+
+
+
+/* ======================================================================== */
+/* ================================= API ================================== */
+/* ======================================================================== */
+
+/* Disasemble one instruction at pc and store in str_buff */
+unsigned int m68k_disassemble(char* str_buff, unsigned int pc, unsigned int cpu_type)
+{
+	if(!g_initialized)
+	{
+		build_opcode_table();
+		g_initialized = 1;
+	}
+	switch(cpu_type)
+	{
+		case M68K_CPU_TYPE_68000:
+			g_cpu_type = TYPE_68000;
+			g_address_mask = 0x00ffffff;
+			break;
+		case M68K_CPU_TYPE_68010:
+			g_cpu_type = TYPE_68010;
+			g_address_mask = 0x00ffffff;
+			break;
+		case M68K_CPU_TYPE_68EC020:
+			g_cpu_type = TYPE_68020;
+			g_address_mask = 0x00ffffff;
+			break;
+		case M68K_CPU_TYPE_68020:
+			g_cpu_type = TYPE_68020;
+			g_address_mask = 0xffffffff;
+			break;
+		case M68K_CPU_TYPE_68030:
+			g_cpu_type = TYPE_68030;
+			g_address_mask = 0xffffffff;
+			break;
+		case M68K_CPU_TYPE_68040:
+			g_cpu_type = TYPE_68040;
+			g_address_mask = 0xffffffff;
+			break;
+		default:
+			return 0;
+	}
+
+	g_cpu_pc = pc;
+	g_helper_str[0] = 0;
+	g_cpu_ir = read_imm_16();
+	g_instruction_table[g_cpu_ir]();
+	sprintf(str_buff, "%s%s", g_dasm_str, g_helper_str);
+	return g_cpu_pc - pc;
+}
+
+char* m68ki_disassemble_quick(unsigned int pc, unsigned int cpu_type)
+{
+	static char buff[100];
+	buff[0] = 0;
+	m68k_disassemble(buff, pc, cpu_type);
+	return buff;
+}
+
+/* Check if the instruction is a valid one */
+unsigned int m68k_is_valid_instruction(unsigned int instruction, unsigned int cpu_type)
+{
+	if(!g_initialized)
+	{
+		build_opcode_table();
+		g_initialized = 1;
+	}
+
+	instruction &= 0xffff;
+	if(g_instruction_table[instruction] == d68000_illegal)
+		return 0;
+
+	switch(cpu_type)
+	{
+		case M68K_CPU_TYPE_68000:
+			if(g_instruction_table[instruction] == d68010_bkpt)
+				return 0;
+			if(g_instruction_table[instruction] == d68010_move_fr_ccr)
+				return 0;
+			if(g_instruction_table[instruction] == d68010_movec)
+				return 0;
+			if(g_instruction_table[instruction] == d68010_moves_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68010_moves_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68010_moves_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68010_rtd)
+				return 0;
+		case M68K_CPU_TYPE_68010:
+			if(g_instruction_table[instruction] == d68020_bcc_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bfchg)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bfclr)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bfexts)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bfextu)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bfffo)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bfins)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bfset)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bftst)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bra_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_bsr_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_callm)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cas_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cas_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cas_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cas2_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cas2_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_chk_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_chk2_cmp2_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_chk2_cmp2_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_chk2_cmp2_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cmpi_pcdi_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cmpi_pcix_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cmpi_pcdi_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cmpi_pcix_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cmpi_pcdi_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cmpi_pcix_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cpbcc_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cpbcc_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cpdbcc)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cpgen)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cprestore)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cpsave)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cpscc)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cptrapcc_0)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cptrapcc_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_cptrapcc_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_divl)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_extb_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_link_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_mull)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_pack_rr)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_pack_mm)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_rtm)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_trapcc_0)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_trapcc_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_trapcc_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_pcdi_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_pcix_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_i_8)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_a_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_pcdi_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_pcix_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_i_16)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_a_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_pcdi_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_pcix_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_tst_i_32)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_unpk_rr)
+				return 0;
+			if(g_instruction_table[instruction] == d68020_unpk_mm)
+				return 0;
+		case M68K_CPU_TYPE_68EC020:
+		case M68K_CPU_TYPE_68020:
+		case M68K_CPU_TYPE_68030:
+			if(g_instruction_table[instruction] == d68040_cinv)
+				return 0;
+			if(g_instruction_table[instruction] == d68040_cpush)
+				return 0;
+			if(g_instruction_table[instruction] == d68040_move16_pi_pi)
+				return 0;
+			if(g_instruction_table[instruction] == d68040_move16_pi_al)
+				return 0;
+			if(g_instruction_table[instruction] == d68040_move16_al_pi)
+				return 0;
+			if(g_instruction_table[instruction] == d68040_move16_ai_al)
+				return 0;
+			if(g_instruction_table[instruction] == d68040_move16_al_ai)
+				return 0;
+	}
+	if(cpu_type != M68K_CPU_TYPE_68020 && cpu_type != M68K_CPU_TYPE_68EC020 &&
+	  (g_instruction_table[instruction] == d68020_callm ||
+	  g_instruction_table[instruction] == d68020_rtm))
+		return 0;
+
+	return 1;
+}
+
+
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */

--- a/yabause/src/musashi/m68kmake.c
+++ b/yabause/src/musashi/m68kmake.c
@@ -1,0 +1,1429 @@
+/* ======================================================================== */
+/* ========================= LICENSING & COPYRIGHT ======================== */
+/* ======================================================================== */
+/*
+ *                                  MUSASHI
+ *                                Version 3.4
+ *
+ * A portable Motorola M680x0 processor emulation engine.
+ * Copyright 1998-2001 Karl Stenerud.  All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+
+/* ======================================================================== */
+/* ============================ CODE GENERATOR ============================ */
+/* ======================================================================== */
+/*
+ * This is the code generator program which will generate the opcode table
+ * and the final opcode handlers.
+ *
+ * It requires an input file to function (default m68k_in.c), but you can
+ * specify your own like so:
+ *
+ * m68kmake <output path> <input file>
+ *
+ * where output path is the path where the output files should be placed, and
+ * input file is the file to use for input.
+ *
+ * If you modify the input file greatly from its released form, you may have
+ * to tweak the configuration section a bit since I'm using static allocation
+ * to keep things simple.
+ *
+ *
+ * TODO: - build a better code generator for the move instruction.
+ *       - Add callm and rtm instructions
+ *       - Fix RTE to handle other format words
+ *       - Add address error (and bus error?) handling
+ */
+
+
+char* g_version = "3.3";
+
+/* ======================================================================== */
+/* =============================== INCLUDES =============================== */
+/* ======================================================================== */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdarg.h>
+
+
+
+/* ======================================================================== */
+/* ============================= CONFIGURATION ============================ */
+/* ======================================================================== */
+
+#define M68K_MAX_PATH 1024
+#define M68K_MAX_DIR  1024
+
+#define NUM_CPUS                          3	/* 000, 010, 020 */
+#define MAX_LINE_LENGTH                 200	/* length of 1 line */
+#define MAX_BODY_LENGTH                 300	/* Number of lines in 1 function */
+#define MAX_REPLACE_LENGTH               30	/* Max number of replace strings */
+#define MAX_INSERT_LENGTH              5000	/* Max size of insert piece */
+#define MAX_NAME_LENGTH                  30	/* Max length of ophandler name */
+#define MAX_SPEC_PROC_LENGTH              4	/* Max length of special processing str */
+#define MAX_SPEC_EA_LENGTH                5	/* Max length of specified EA str */
+#define EA_ALLOWED_LENGTH                11	/* Max length of ea allowed str */
+#define MAX_OPCODE_INPUT_TABLE_LENGTH  1000	/* Max length of opcode handler tbl */
+#define MAX_OPCODE_OUTPUT_TABLE_LENGTH 3000	/* Max length of opcode handler tbl */
+
+/* Default filenames */
+#define FILENAME_INPUT      "m68k_in.c"
+#define FILENAME_PROTOTYPE  "m68kops.h"
+#define FILENAME_TABLE      "m68kops.c"
+#define FILENAME_OPS_AC     "m68kopac.c"
+#define FILENAME_OPS_DM     "m68kopdm.c"
+#define FILENAME_OPS_NZ     "m68kopnz.c"
+
+
+/* Identifier sequences recognized by this program */
+
+#define ID_INPUT_SEPARATOR "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+#define ID_BASE                 "M68KMAKE"
+#define ID_PROTOTYPE_HEADER     ID_BASE "_PROTOTYPE_HEADER"
+#define ID_PROTOTYPE_FOOTER     ID_BASE "_PROTOTYPE_FOOTER"
+#define ID_TABLE_HEADER         ID_BASE "_TABLE_HEADER"
+#define ID_TABLE_FOOTER         ID_BASE "_TABLE_FOOTER"
+#define ID_TABLE_BODY           ID_BASE "_TABLE_BODY"
+#define ID_TABLE_START          ID_BASE "_TABLE_START"
+#define ID_OPHANDLER_HEADER     ID_BASE "_OPCODE_HANDLER_HEADER"
+#define ID_OPHANDLER_FOOTER     ID_BASE "_OPCODE_HANDLER_FOOTER"
+#define ID_OPHANDLER_BODY       ID_BASE "_OPCODE_HANDLER_BODY"
+#define ID_END                  ID_BASE "_END"
+
+#define ID_OPHANDLER_NAME       ID_BASE "_OP"
+#define ID_OPHANDLER_EA_AY_8    ID_BASE "_GET_EA_AY_8"
+#define ID_OPHANDLER_EA_AY_16   ID_BASE "_GET_EA_AY_16"
+#define ID_OPHANDLER_EA_AY_32   ID_BASE "_GET_EA_AY_32"
+#define ID_OPHANDLER_OPER_AY_8  ID_BASE "_GET_OPER_AY_8"
+#define ID_OPHANDLER_OPER_AY_16 ID_BASE "_GET_OPER_AY_16"
+#define ID_OPHANDLER_OPER_AY_32 ID_BASE "_GET_OPER_AY_32"
+#define ID_OPHANDLER_CC         ID_BASE "_CC"
+#define ID_OPHANDLER_NOT_CC     ID_BASE "_NOT_CC"
+
+
+#ifndef DECL_SPEC
+#define DECL_SPEC
+#endif /* DECL_SPEC */
+
+
+
+/* ======================================================================== */
+/* ============================== PROTOTYPES ============================== */
+/* ======================================================================== */
+
+#define CPU_TYPE_000 0
+#define CPU_TYPE_010 1
+#define CPU_TYPE_020 2
+
+#define UNSPECIFIED "."
+#define UNSPECIFIED_CH '.'
+
+#define HAS_NO_EA_MODE(A) (strcmp(A, "..........") == 0)
+#define HAS_EA_AI(A)   ((A)[0] == 'A')
+#define HAS_EA_PI(A)   ((A)[1] == '+')
+#define HAS_EA_PD(A)   ((A)[2] == '-')
+#define HAS_EA_DI(A)   ((A)[3] == 'D')
+#define HAS_EA_IX(A)   ((A)[4] == 'X')
+#define HAS_EA_AW(A)   ((A)[5] == 'W')
+#define HAS_EA_AL(A)   ((A)[6] == 'L')
+#define HAS_EA_PCDI(A) ((A)[7] == 'd')
+#define HAS_EA_PCIX(A) ((A)[8] == 'x')
+#define HAS_EA_I(A)    ((A)[9] == 'I')
+
+enum
+{
+	EA_MODE_NONE,	/* No special addressing mode */
+	EA_MODE_AI,		/* Address register indirect */
+	EA_MODE_PI,		/* Address register indirect with postincrement */
+	EA_MODE_PI7,	/* Address register 7 indirect with postincrement */
+	EA_MODE_PD,		/* Address register indirect with predecrement */
+	EA_MODE_PD7,	/* Address register 7 indirect with predecrement */
+	EA_MODE_DI,		/* Address register indirect with displacement */
+	EA_MODE_IX,		/* Address register indirect with index */
+	EA_MODE_AW,		/* Absolute word */
+	EA_MODE_AL,		/* Absolute long */
+	EA_MODE_PCDI,	/* Program counter indirect with displacement */
+	EA_MODE_PCIX,	/* Program counter indirect with index */
+	EA_MODE_I		/* Immediate */
+};
+
+
+/* Everything we need to know about an opcode */
+typedef struct
+{
+	char name[MAX_NAME_LENGTH];           /* opcode handler name */
+	unsigned char size;                   /* Size of operation */
+	char spec_proc[MAX_SPEC_PROC_LENGTH]; /* Special processing mode */
+	char spec_ea[MAX_SPEC_EA_LENGTH];     /* Specified effective addressing mode */
+	unsigned char bits;                   /* Number of significant bits (used for sorting the table) */
+	unsigned short op_mask;               /* Mask to apply for matching an opcode to a handler */
+	unsigned short op_match;              /* Value to match after masking */
+	char ea_allowed[EA_ALLOWED_LENGTH];   /* Effective addressing modes allowed */
+	char cpu_mode[NUM_CPUS];              /* User or supervisor mode */
+	char cpus[NUM_CPUS+1];                /* Allowed CPUs */
+	unsigned char cycles[NUM_CPUS];       /* cycles for 000, 010, 020 */
+} opcode_struct;
+
+
+/* All modifications necessary for a specific EA mode of an instruction */
+typedef struct
+{
+	char* fname_add;
+	char* ea_add;
+	unsigned int mask_add;
+	unsigned int match_add;
+} ea_info_struct;
+
+
+/* Holds the body of a function */
+typedef struct
+{
+	char body[MAX_BODY_LENGTH][MAX_LINE_LENGTH+1];
+	int length;
+} body_struct;
+
+
+/* Holds a sequence of search / replace strings */
+typedef struct
+{
+	char replace[MAX_REPLACE_LENGTH][2][MAX_LINE_LENGTH+1];
+	int length;
+} replace_struct;
+
+
+/* Function Prototypes */
+void error_exit(char* fmt, ...);
+void perror_exit(char* fmt, ...);
+int check_strsncpy(char* dst, char* src, int maxlength);
+int check_atoi(char* str, int *result);
+int skip_spaces(char* str);
+int num_bits(int value);
+int atoh(char* buff);
+int fgetline(char* buff, int nchars, FILE* file);
+int get_oper_cycles(opcode_struct* op, int ea_mode, int cpu_type);
+opcode_struct* find_opcode(char* name, int size, char* spec_proc, char* spec_ea);
+opcode_struct* find_illegal_opcode(void);
+int extract_opcode_info(char* src, char* name, int* size, char* spec_proc, char* spec_ea);
+void add_replace_string(replace_struct* replace, char* search_str, char* replace_str);
+void write_body(FILE* filep, body_struct* body, replace_struct* replace);
+void get_base_name(char* base_name, opcode_struct* op);
+void write_prototype(FILE* filep, char* base_name);
+void write_function_name(FILE* filep, char* base_name);
+void add_opcode_output_table_entry(opcode_struct* op, char* name);
+static int DECL_SPEC compare_nof_true_bits(const void* aptr, const void* bptr);
+void print_opcode_output_table(FILE* filep);
+void write_table_entry(FILE* filep, opcode_struct* op);
+void set_opcode_struct(opcode_struct* src, opcode_struct* dst, int ea_mode);
+void generate_opcode_handler(FILE* filep, body_struct* body, replace_struct* replace, opcode_struct* opinfo, int ea_mode);
+void generate_opcode_ea_variants(FILE* filep, body_struct* body, replace_struct* replace, opcode_struct* op);
+void generate_opcode_cc_variants(FILE* filep, body_struct* body, replace_struct* replace, opcode_struct* op_in, int offset);
+void process_opcode_handlers(void);
+void populate_table(void);
+void read_insert(char* insert);
+
+
+
+/* ======================================================================== */
+/* ================================= DATA ================================= */
+/* ======================================================================== */
+
+/* Name of the input file */
+char g_input_filename[M68K_MAX_PATH] = FILENAME_INPUT;
+
+/* File handles */
+FILE* g_input_file = NULL;
+FILE* g_prototype_file = NULL;
+FILE* g_table_file = NULL;
+FILE* g_ops_ac_file = NULL;
+FILE* g_ops_dm_file = NULL;
+FILE* g_ops_nz_file = NULL;
+
+int g_num_functions = 0;  /* Number of functions processed */
+int g_num_primitives = 0; /* Number of function primitives read */
+int g_line_number = 1;    /* Current line number */
+
+/* Opcode handler table */
+opcode_struct g_opcode_input_table[MAX_OPCODE_INPUT_TABLE_LENGTH];
+
+opcode_struct g_opcode_output_table[MAX_OPCODE_OUTPUT_TABLE_LENGTH];
+int g_opcode_output_table_length = 0;
+
+ea_info_struct g_ea_info_table[13] =
+{/* fname    ea        mask  match */
+	{"",     "",       0x00, 0x00}, /* EA_MODE_NONE */
+	{"ai",   "AY_AI",  0x38, 0x10}, /* EA_MODE_AI   */
+	{"pi",   "AY_PI",  0x38, 0x18}, /* EA_MODE_PI   */
+	{"pi7",  "A7_PI",  0x3f, 0x1f}, /* EA_MODE_PI7  */
+	{"pd",   "AY_PD",  0x38, 0x20}, /* EA_MODE_PD   */
+	{"pd7",  "A7_PD",  0x3f, 0x27}, /* EA_MODE_PD7  */
+	{"di",   "AY_DI",  0x38, 0x28}, /* EA_MODE_DI   */
+	{"ix",   "AY_IX",  0x38, 0x30}, /* EA_MODE_IX   */
+	{"aw",   "AW",     0x3f, 0x38}, /* EA_MODE_AW   */
+	{"al",   "AL",     0x3f, 0x39}, /* EA_MODE_AL   */
+	{"pcdi", "PCDI",   0x3f, 0x3a}, /* EA_MODE_PCDI */
+	{"pcix", "PCIX",   0x3f, 0x3b}, /* EA_MODE_PCIX */
+	{"i",    "I",      0x3f, 0x3c}, /* EA_MODE_I    */
+};
+
+
+char* g_cc_table[16][2] =
+{
+	{ "t",  "T"}, /* 0000 */
+	{ "f",  "F"}, /* 0001 */
+	{"hi", "HI"}, /* 0010 */
+	{"ls", "LS"}, /* 0011 */
+	{"cc", "CC"}, /* 0100 */
+	{"cs", "CS"}, /* 0101 */
+	{"ne", "NE"}, /* 0110 */
+	{"eq", "EQ"}, /* 0111 */
+	{"vc", "VC"}, /* 1000 */
+	{"vs", "VS"}, /* 1001 */
+	{"pl", "PL"}, /* 1010 */
+	{"mi", "MI"}, /* 1011 */
+	{"ge", "GE"}, /* 1100 */
+	{"lt", "LT"}, /* 1101 */
+	{"gt", "GT"}, /* 1110 */
+	{"le", "LE"}, /* 1111 */
+};
+
+/* size to index translator (0 -> 0, 8 and 16 -> 1, 32 -> 2) */
+int g_size_select_table[33] =
+{
+	0,												/* unsized */
+	0, 0, 0, 0, 0, 0, 0, 1,							/*    8    */
+	0, 0, 0, 0, 0, 0, 0, 1,							/*   16    */
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2	/*   32    */
+};
+
+/* Extra cycles required for certain EA modes */
+int g_ea_cycle_table[13][NUM_CPUS][3] =
+{/*       000           010           020   */
+	{{ 0,  0,  0}, { 0,  0,  0}, { 0,  0,  0}}, /* EA_MODE_NONE */
+	{{ 0,  4,  8}, { 0,  4,  8}, { 0,  4,  4}}, /* EA_MODE_AI   */
+	{{ 0,  4,  8}, { 0,  4,  8}, { 0,  4,  4}}, /* EA_MODE_PI   */
+	{{ 0,  4,  8}, { 0,  4,  8}, { 0,  4,  4}}, /* EA_MODE_PI7  */
+	{{ 0,  6, 10}, { 0,  6, 10}, { 0,  5,  5}}, /* EA_MODE_PD   */
+	{{ 0,  6, 10}, { 0,  6, 10}, { 0,  5,  5}}, /* EA_MODE_PD7  */
+	{{ 0,  8, 12}, { 0,  8, 12}, { 0,  5,  5}}, /* EA_MODE_DI   */
+	{{ 0, 10, 14}, { 0, 10, 14}, { 0,  7,  7}}, /* EA_MODE_IX   */
+	{{ 0,  8, 12}, { 0,  8, 12}, { 0,  4,  4}}, /* EA_MODE_AW   */
+	{{ 0, 12, 16}, { 0, 12, 16}, { 0,  4,  4}}, /* EA_MODE_AL   */
+	{{ 0,  8, 12}, { 0,  8, 12}, { 0,  5,  5}}, /* EA_MODE_PCDI */
+	{{ 0, 10, 14}, { 0, 10, 14}, { 0,  7,  7}}, /* EA_MODE_PCIX */
+	{{ 0,  4,  8}, { 0,  4,  8}, { 0,  2,  4}}, /* EA_MODE_I    */
+};
+
+/* Extra cycles for JMP instruction (000, 010) */
+int g_jmp_cycle_table[13] =
+{
+	 0, /* EA_MODE_NONE */
+	 4, /* EA_MODE_AI   */
+	 0, /* EA_MODE_PI   */
+	 0, /* EA_MODE_PI7  */
+	 0, /* EA_MODE_PD   */
+	 0, /* EA_MODE_PD7  */
+	 6, /* EA_MODE_DI   */
+	 10, /* EA_MODE_IX   */
+	 6, /* EA_MODE_AW   */
+	 8, /* EA_MODE_AL   */
+	 6, /* EA_MODE_PCDI */
+	10, /* EA_MODE_PCIX */
+	 0, /* EA_MODE_I    */
+};
+
+/* Extra cycles for JSR instruction (000, 010) */
+int g_jsr_cycle_table[13] =
+{
+	 0, /* EA_MODE_NONE */
+	 4, /* EA_MODE_AI   */
+	 0, /* EA_MODE_PI   */
+	 0, /* EA_MODE_PI7  */
+	 0, /* EA_MODE_PD   */
+	 0, /* EA_MODE_PD7  */
+	 6, /* EA_MODE_DI   */
+	10, /* EA_MODE_IX   */
+	 6, /* EA_MODE_AW   */
+	 8, /* EA_MODE_AL   */
+	 6, /* EA_MODE_PCDI */
+	10, /* EA_MODE_PCIX */
+	 0, /* EA_MODE_I    */
+};
+
+/* Extra cycles for LEA instruction (000, 010) */
+int g_lea_cycle_table[13] =
+{
+	 0, /* EA_MODE_NONE */
+	 4, /* EA_MODE_AI   */
+	 0, /* EA_MODE_PI   */
+	 0, /* EA_MODE_PI7  */
+	 0, /* EA_MODE_PD   */
+	 0, /* EA_MODE_PD7  */
+	 8, /* EA_MODE_DI   */
+	12, /* EA_MODE_IX   */
+	 8, /* EA_MODE_AW   */
+	12, /* EA_MODE_AL   */
+	 8, /* EA_MODE_PCDI */
+	12, /* EA_MODE_PCIX */
+	 0, /* EA_MODE_I    */
+};
+
+/* Extra cycles for PEA instruction (000, 010) */
+int g_pea_cycle_table[13] =
+{
+	 0, /* EA_MODE_NONE */
+	 6, /* EA_MODE_AI   */
+	 0, /* EA_MODE_PI   */
+	 0, /* EA_MODE_PI7  */
+	 0, /* EA_MODE_PD   */
+	 0, /* EA_MODE_PD7  */
+	10, /* EA_MODE_DI   */
+	14, /* EA_MODE_IX   */
+	10, /* EA_MODE_AW   */
+	14, /* EA_MODE_AL   */
+	10, /* EA_MODE_PCDI */
+	14, /* EA_MODE_PCIX */
+	 0, /* EA_MODE_I    */
+};
+
+/* Extra cycles for MOVES instruction (010) */
+int g_moves_cycle_table[13][3] =
+{
+	{ 0,  0,  0}, /* EA_MODE_NONE */
+	{ 0,  4,  6}, /* EA_MODE_AI   */
+	{ 0,  4,  6}, /* EA_MODE_PI   */
+	{ 0,  4,  6}, /* EA_MODE_PI7  */
+	{ 0,  6, 12}, /* EA_MODE_PD   */
+	{ 0,  6, 12}, /* EA_MODE_PD7  */
+	{ 0, 12, 16}, /* EA_MODE_DI   */
+	{ 0, 16, 20}, /* EA_MODE_IX   */
+	{ 0, 12, 16}, /* EA_MODE_AW   */
+	{ 0, 16, 20}, /* EA_MODE_AL   */
+	{ 0,  0,  0}, /* EA_MODE_PCDI */
+	{ 0,  0,  0}, /* EA_MODE_PCIX */
+	{ 0,  0,  0}, /* EA_MODE_I    */
+};
+
+/* Extra cycles for CLR instruction (010) */
+int g_clr_cycle_table[13][3] =
+{
+	{ 0,  0,  0}, /* EA_MODE_NONE */
+	{ 0,  4,  6}, /* EA_MODE_AI   */
+	{ 0,  4,  6}, /* EA_MODE_PI   */
+	{ 0,  4,  6}, /* EA_MODE_PI7  */
+	{ 0,  6,  8}, /* EA_MODE_PD   */
+	{ 0,  6,  8}, /* EA_MODE_PD7  */
+	{ 0,  8, 10}, /* EA_MODE_DI   */
+	{ 0, 10, 14}, /* EA_MODE_IX   */
+	{ 0,  8, 10}, /* EA_MODE_AW   */
+	{ 0, 10, 14}, /* EA_MODE_AL   */
+	{ 0,  0,  0}, /* EA_MODE_PCDI */
+	{ 0,  0,  0}, /* EA_MODE_PCIX */
+	{ 0,  0,  0}, /* EA_MODE_I    */
+};
+
+
+
+/* ======================================================================== */
+/* =========================== UTILITY FUNCTIONS ========================== */
+/* ======================================================================== */
+
+/* Print an error message and exit with status error */
+void error_exit(char* fmt, ...)
+{
+	va_list args;
+	fprintf(stderr, "In %s, near or on line %d:\n\t", g_input_filename, g_line_number);
+	va_start(args, fmt);
+	vfprintf(stderr, fmt, args);
+	va_end(args);
+	fprintf(stderr, "\n");
+
+	if(g_prototype_file) fclose(g_prototype_file);
+	if(g_table_file) fclose(g_table_file);
+	if(g_ops_ac_file) fclose(g_ops_ac_file);
+	if(g_ops_dm_file) fclose(g_ops_dm_file);
+	if(g_ops_nz_file) fclose(g_ops_nz_file);
+	if(g_input_file) fclose(g_input_file);
+
+	exit(EXIT_FAILURE);
+}
+
+/* Print an error message, call perror(), and exit with status error */
+void perror_exit(char* fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	vfprintf(stderr, fmt, args);
+	va_end(args);
+	perror("");
+
+	if(g_prototype_file) fclose(g_prototype_file);
+	if(g_table_file) fclose(g_table_file);
+	if(g_ops_ac_file) fclose(g_ops_ac_file);
+	if(g_ops_dm_file) fclose(g_ops_dm_file);
+	if(g_ops_nz_file) fclose(g_ops_nz_file);
+	if(g_input_file) fclose(g_input_file);
+
+	exit(EXIT_FAILURE);
+}
+
+
+/* copy until 0 or space and exit with error if we read too far */
+int check_strsncpy(char* dst, char* src, int maxlength)
+{
+	char* p = dst;
+	while(*src && *src != ' ')
+	{
+		*p++ = *src++;
+		if(p - dst > maxlength)
+			error_exit("Field too long");
+	}
+	*p = 0;
+	return p - dst;
+}
+
+/* copy until 0 or specified character and exit with error if we read too far */
+int check_strcncpy(char* dst, char* src, char delim, int maxlength)
+{
+	char* p = dst;
+	while(*src && *src != delim)
+	{
+		*p++ = *src++;
+		if(p - dst > maxlength)
+			error_exit("Field too long");
+	}
+	*p = 0;
+	return p - dst;
+}
+
+/* convert ascii to integer and exit with error if we find invalid data */
+int check_atoi(char* str, int *result)
+{
+	int accum = 0;
+	char* p = str;
+	while(*p >= '0' && *p <= '9')
+	{
+		accum *= 10;
+		accum += *p++ - '0';
+	}
+	if(*p != ' ' && *p != 0)
+		error_exit("Malformed integer value (%c)", *p);
+	*result = accum;
+	return p - str;
+}
+
+/* Skip past spaces in a string */
+int skip_spaces(char* str)
+{
+	char* p = str;
+
+	while(*p == ' ')
+		p++;
+
+	return p - str;
+}
+
+/* Count the number of set bits in a value */
+int num_bits(int value)
+{
+    value = ((value & 0xaaaa) >> 1) + (value & 0x5555);
+    value = ((value & 0xcccc) >> 2) + (value & 0x3333);
+    value = ((value & 0xf0f0) >> 4) + (value & 0x0f0f);
+    value = ((value & 0xff00) >> 8) + (value & 0x00ff);
+	return value;
+}
+
+/* Convert a hex value written in ASCII */
+int atoh(char* buff)
+{
+	int accum = 0;
+
+	for(;;buff++)
+	{
+		if(*buff >= '0' && *buff <= '9')
+		{
+			accum <<= 4;
+			accum += *buff - '0';
+		}
+		else if(*buff >= 'a' && *buff <= 'f')
+		{
+			accum <<= 4;
+			accum += *buff - 'a' + 10;
+		}
+		else break;
+	}
+	return accum;
+}
+
+/* Get a line of text from a file, discarding any end-of-line characters */
+int fgetline(char* buff, int nchars, FILE* file)
+{
+	int length;
+
+	if(fgets(buff, nchars, file) == NULL)
+		return -1;
+	if(buff[0] == '\r')
+		memcpy(buff, buff + 1, nchars - 1);
+
+	length = strlen(buff);
+	while(length && (buff[length-1] == '\r' || buff[length-1] == '\n'))
+		length--;
+	buff[length] = 0;
+	g_line_number++;
+
+	return length;
+}
+
+
+
+/* ======================================================================== */
+/* =========================== HELPER FUNCTIONS =========================== */
+/* ======================================================================== */
+
+/* Calculate the number of cycles an opcode requires */
+int get_oper_cycles(opcode_struct* op, int ea_mode, int cpu_type)
+{
+	int size = g_size_select_table[op->size];
+
+	if(op->cpus[cpu_type] == '.')
+		return 0;
+
+	if(cpu_type < CPU_TYPE_020)
+	{
+		if(cpu_type == CPU_TYPE_010)
+		{
+			if(strcmp(op->name, "moves") == 0)
+				return op->cycles[cpu_type] + g_moves_cycle_table[ea_mode][size];
+			if(strcmp(op->name, "clr") == 0)
+				return op->cycles[cpu_type] + g_clr_cycle_table[ea_mode][size];
+		}
+
+		/* ASG: added these cases -- immediate modes take 2 extra cycles here */
+		if(cpu_type == CPU_TYPE_000 && ea_mode == EA_MODE_I &&
+		   ((strcmp(op->name, "add") == 0 && strcmp(op->spec_proc, "er") == 0) ||
+			strcmp(op->name, "adda")   == 0                                    ||
+			(strcmp(op->name, "and") == 0 && strcmp(op->spec_proc, "er") == 0) ||
+			(strcmp(op->name, "or") == 0 && strcmp(op->spec_proc, "er") == 0)  ||
+			(strcmp(op->name, "sub") == 0 && strcmp(op->spec_proc, "er") == 0) ||
+			strcmp(op->name, "suba")   == 0))
+			return op->cycles[cpu_type] + g_ea_cycle_table[ea_mode][cpu_type][size] + 2;
+
+		if(strcmp(op->name, "jmp") == 0)
+			return op->cycles[cpu_type] + g_jmp_cycle_table[ea_mode];
+		if(strcmp(op->name, "jsr") == 0)
+			return op->cycles[cpu_type] + g_jsr_cycle_table[ea_mode];
+		if(strcmp(op->name, "lea") == 0)
+			return op->cycles[cpu_type] + g_lea_cycle_table[ea_mode];
+		if(strcmp(op->name, "pea") == 0)
+			return op->cycles[cpu_type] + g_pea_cycle_table[ea_mode];
+	}
+	return op->cycles[cpu_type] + g_ea_cycle_table[ea_mode][cpu_type][size];
+}
+
+/* Find an opcode in the opcode handler list */
+opcode_struct* find_opcode(char* name, int size, char* spec_proc, char* spec_ea)
+{
+	opcode_struct* op;
+
+
+	for(op = g_opcode_input_table;op->name != NULL;op++)
+	{
+		if(	strcmp(name, op->name) == 0 &&
+			(size == op->size) &&
+			strcmp(spec_proc, op->spec_proc) == 0 &&
+			strcmp(spec_ea, op->spec_ea) == 0)
+				return op;
+	}
+	return NULL;
+}
+
+/* Specifically find the illegal opcode in the list */
+opcode_struct* find_illegal_opcode(void)
+{
+	opcode_struct* op;
+
+	for(op = g_opcode_input_table;op->name != NULL;op++)
+	{
+		if(strcmp(op->name, "illegal") == 0)
+			return op;
+	}
+	return NULL;
+}
+
+/* Parse an opcode handler name */
+int extract_opcode_info(char* src, char* name, int* size, char* spec_proc, char* spec_ea)
+{
+	char* ptr = strstr(src, ID_OPHANDLER_NAME);
+
+	if(ptr == NULL)
+		return 0;
+
+	ptr += strlen(ID_OPHANDLER_NAME) + 1;
+
+	ptr += check_strcncpy(name, ptr, ',', MAX_NAME_LENGTH);
+	if(*ptr != ',') return 0;
+	ptr++;
+	ptr += skip_spaces(ptr);
+
+	*size = atoi(ptr);
+	ptr = strstr(ptr, ",");
+	if(ptr == NULL) return 0;
+    ptr++;
+	ptr += skip_spaces(ptr);
+
+	ptr += check_strcncpy(spec_proc, ptr, ',', MAX_SPEC_PROC_LENGTH);
+	if(*ptr != ',') return 0;
+	ptr++;
+	ptr += skip_spaces(ptr);
+
+	ptr += check_strcncpy(spec_ea, ptr, ')', MAX_SPEC_EA_LENGTH);
+	if(*ptr != ')') return 0;
+	ptr++;
+	ptr += skip_spaces(ptr);
+
+	return 1;
+}
+
+
+/* Add a search/replace pair to a replace structure */
+void add_replace_string(replace_struct* replace, char* search_str, char* replace_str)
+{
+	if(replace->length >= MAX_REPLACE_LENGTH)
+		error_exit("overflow in replace structure");
+
+	strcpy(replace->replace[replace->length][0], search_str);
+	strcpy(replace->replace[replace->length++][1], replace_str);
+}
+
+/* Write a function body while replacing any selected strings */
+void write_body(FILE* filep, body_struct* body, replace_struct* replace)
+{
+	int i;
+	int j;
+	char* ptr;
+	char output[MAX_LINE_LENGTH+1];
+	char temp_buff[MAX_LINE_LENGTH+1];
+	int found;
+
+	for(i=0;i<body->length;i++)
+	{
+		strcpy(output, body->body[i]);
+		/* Check for the base directive header */
+		if(strstr(output, ID_BASE) != NULL)
+		{
+			/* Search for any text we need to replace */
+			found = 0;
+			for(j=0;j<replace->length;j++)
+			{
+				ptr = strstr(output, replace->replace[j][0]);
+				if(ptr)
+				{
+					/* We found something to replace */
+					found = 1;
+					strcpy(temp_buff, ptr+strlen(replace->replace[j][0]));
+					strcpy(ptr, replace->replace[j][1]);
+					strcat(ptr, temp_buff);
+				}
+			}
+			/* Found a directive with no matching replace string */
+			if(!found)
+				error_exit("Unknown " ID_BASE " directive");
+		}
+		fprintf(filep, "%s\n", output);
+	}
+	fprintf(filep, "\n\n");
+}
+
+/* Generate a base function name from an opcode struct */
+void get_base_name(char* base_name, opcode_struct* op)
+{
+	sprintf(base_name, "m68k_op_%s", op->name);
+	if(op->size > 0)
+		sprintf(base_name+strlen(base_name), "_%d", op->size);
+	if(strcmp(op->spec_proc, UNSPECIFIED) != 0)
+		sprintf(base_name+strlen(base_name), "_%s", op->spec_proc);
+	if(strcmp(op->spec_ea, UNSPECIFIED) != 0)
+		sprintf(base_name+strlen(base_name), "_%s", op->spec_ea);
+}
+
+/* Write the prototype of an opcode handler function */
+void write_prototype(FILE* filep, char* base_name)
+{
+	fprintf(filep, "void %s(void);\n", base_name);
+}
+
+/* Write the name of an opcode handler function */
+void write_function_name(FILE* filep, char* base_name)
+{
+	fprintf(filep, "void %s(void)\n", base_name);
+}
+
+void add_opcode_output_table_entry(opcode_struct* op, char* name)
+{
+	opcode_struct* ptr;
+	if(g_opcode_output_table_length > MAX_OPCODE_OUTPUT_TABLE_LENGTH)
+		error_exit("Opcode output table overflow");
+
+	ptr = g_opcode_output_table + g_opcode_output_table_length++;
+
+	*ptr = *op;
+	strcpy(ptr->name, name);
+	ptr->bits = num_bits(ptr->op_mask);
+}
+
+/*
+ * Comparison function for qsort()
+ * For entries with an equal number of set bits in
+ * the mask compare the match values
+ */
+static int DECL_SPEC compare_nof_true_bits(const void* aptr, const void* bptr)
+{
+	const opcode_struct *a = aptr, *b = bptr;
+	if(a->bits != b->bits)
+		return a->bits - b->bits;
+	if(a->op_mask != b->op_mask)
+		return a->op_mask - b->op_mask;
+	return a->op_match - b->op_match;
+}
+
+void print_opcode_output_table(FILE* filep)
+{
+	int i;
+	qsort((void *)g_opcode_output_table, g_opcode_output_table_length, sizeof(g_opcode_output_table[0]), compare_nof_true_bits);
+
+	for(i=0;i<g_opcode_output_table_length;i++)
+		write_table_entry(filep, g_opcode_output_table+i);
+}
+
+/* Write an entry in the opcode handler table */
+void write_table_entry(FILE* filep, opcode_struct* op)
+{
+	int i;
+
+	fprintf(filep, "\t{%-28s, 0x%04x, 0x%04x, {",
+		op->name, op->op_mask, op->op_match);
+
+	for(i=0;i<NUM_CPUS;i++)
+	{
+		fprintf(filep, "%3d", op->cycles[i]);
+		if(i < NUM_CPUS-1)
+			fprintf(filep, ", ");
+	}
+
+	fprintf(filep, "}},\n");
+}
+
+/* Fill out an opcode struct with a specific addressing mode of the source opcode struct */
+void set_opcode_struct(opcode_struct* src, opcode_struct* dst, int ea_mode)
+{
+	int i;
+
+	*dst = *src;
+
+	for(i=0;i<NUM_CPUS;i++)
+		dst->cycles[i] = get_oper_cycles(dst, ea_mode, i);
+	if(strcmp(dst->spec_ea, UNSPECIFIED) == 0 && ea_mode != EA_MODE_NONE)
+		sprintf(dst->spec_ea, "%s", g_ea_info_table[ea_mode].fname_add);
+	dst->op_mask |= g_ea_info_table[ea_mode].mask_add;
+	dst->op_match |= g_ea_info_table[ea_mode].match_add;
+}
+
+
+/* Generate a final opcode handler from the provided data */
+void generate_opcode_handler(FILE* filep, body_struct* body, replace_struct* replace, opcode_struct* opinfo, int ea_mode)
+{
+	char str[MAX_LINE_LENGTH+1];
+	opcode_struct* op = malloc(sizeof(opcode_struct));
+
+	/* Set the opcode structure and write the tables, prototypes, etc */
+	set_opcode_struct(opinfo, op, ea_mode);
+	get_base_name(str, op);
+	write_prototype(g_prototype_file, str);
+	add_opcode_output_table_entry(op, str);
+	write_function_name(filep, str);
+
+	/* Add any replace strings needed */
+	if(ea_mode != EA_MODE_NONE)
+	{
+		sprintf(str, "EA_%s_8()", g_ea_info_table[ea_mode].ea_add);
+		add_replace_string(replace, ID_OPHANDLER_EA_AY_8, str);
+		sprintf(str, "EA_%s_16()", g_ea_info_table[ea_mode].ea_add);
+		add_replace_string(replace, ID_OPHANDLER_EA_AY_16, str);
+		sprintf(str, "EA_%s_32()", g_ea_info_table[ea_mode].ea_add);
+		add_replace_string(replace, ID_OPHANDLER_EA_AY_32, str);
+		sprintf(str, "OPER_%s_8()", g_ea_info_table[ea_mode].ea_add);
+		add_replace_string(replace, ID_OPHANDLER_OPER_AY_8, str);
+		sprintf(str, "OPER_%s_16()", g_ea_info_table[ea_mode].ea_add);
+		add_replace_string(replace, ID_OPHANDLER_OPER_AY_16, str);
+		sprintf(str, "OPER_%s_32()", g_ea_info_table[ea_mode].ea_add);
+		add_replace_string(replace, ID_OPHANDLER_OPER_AY_32, str);
+	}
+
+	/* Now write the function body with the selected replace strings */
+	write_body(filep, body, replace);
+	g_num_functions++;
+	free(op);
+}
+
+/* Generate opcode variants based on available addressing modes */
+void generate_opcode_ea_variants(FILE* filep, body_struct* body, replace_struct* replace, opcode_struct* op)
+{
+	int old_length = replace->length;
+
+	/* No ea modes available for this opcode */
+	if(HAS_NO_EA_MODE(op->ea_allowed))
+	{
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_NONE);
+		return;
+	}
+
+	/* Check for and create specific opcodes for each available addressing mode */
+	if(HAS_EA_AI(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_AI);
+	replace->length = old_length;
+	if(HAS_EA_PI(op->ea_allowed))
+	{
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_PI);
+		replace->length = old_length;
+		if(op->size == 8)
+			generate_opcode_handler(filep, body, replace, op, EA_MODE_PI7);
+	}
+	replace->length = old_length;
+	if(HAS_EA_PD(op->ea_allowed))
+	{
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_PD);
+		replace->length = old_length;
+		if(op->size == 8)
+			generate_opcode_handler(filep, body, replace, op, EA_MODE_PD7);
+	}
+	replace->length = old_length;
+	if(HAS_EA_DI(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_DI);
+	replace->length = old_length;
+	if(HAS_EA_IX(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_IX);
+	replace->length = old_length;
+	if(HAS_EA_AW(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_AW);
+	replace->length = old_length;
+	if(HAS_EA_AL(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_AL);
+	replace->length = old_length;
+	if(HAS_EA_PCDI(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_PCDI);
+	replace->length = old_length;
+	if(HAS_EA_PCIX(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_PCIX);
+	replace->length = old_length;
+	if(HAS_EA_I(op->ea_allowed))
+		generate_opcode_handler(filep, body, replace, op, EA_MODE_I);
+	replace->length = old_length;
+}
+
+/* Generate variants of condition code opcodes */
+void generate_opcode_cc_variants(FILE* filep, body_struct* body, replace_struct* replace, opcode_struct* op_in, int offset)
+{
+	char repl[20];
+	char replnot[20];
+	int i;
+	int old_length = replace->length;
+	opcode_struct* op = malloc(sizeof(opcode_struct));
+
+	*op = *op_in;
+
+	op->op_mask |= 0x0f00;
+
+	/* Do all condition codes except t and f */
+	for(i=2;i<16;i++)
+	{
+		/* Add replace strings for this condition code */
+		sprintf(repl, "COND_%s()", g_cc_table[i][1]);
+		sprintf(replnot, "COND_NOT_%s()", g_cc_table[i][1]);
+
+		add_replace_string(replace, ID_OPHANDLER_CC, repl);
+		add_replace_string(replace, ID_OPHANDLER_NOT_CC, replnot);
+
+		/* Set the new opcode info */
+		strcpy(op->name+offset, g_cc_table[i][0]);
+
+		op->op_match = (op->op_match & 0xf0ff) | (i<<8);
+
+		/* Generate all opcode variants for this modified opcode */
+		generate_opcode_ea_variants(filep, body, replace, op);
+		/* Remove the above replace strings */
+		replace->length = old_length;
+	}
+	free(op);
+}
+
+/* Process the opcode handlers section of the input file */
+void process_opcode_handlers(void)
+{
+	FILE* input_file = g_input_file;
+	FILE* output_file;
+	char func_name[MAX_LINE_LENGTH+1];
+	char oper_name[MAX_LINE_LENGTH+1];
+	int  oper_size;
+	char oper_spec_proc[MAX_LINE_LENGTH+1];
+	char oper_spec_ea[MAX_LINE_LENGTH+1];
+	opcode_struct* opinfo;
+	replace_struct* replace = malloc(sizeof(replace_struct));
+	body_struct* body = malloc(sizeof(body_struct));
+
+
+	output_file = g_ops_ac_file;
+
+	for(;;)
+	{
+		/* Find the first line of the function */
+		func_name[0] = 0;
+		while(strstr(func_name, ID_OPHANDLER_NAME) == NULL)
+		{
+			if(strcmp(func_name, ID_INPUT_SEPARATOR) == 0)
+			{
+				free(replace);
+				free(body);
+				return; /* all done */
+			}
+			if(fgetline(func_name, MAX_LINE_LENGTH, input_file) < 0)
+				error_exit("Premature end of file when getting function name");
+		}
+		/* Get the rest of the function */
+		for(body->length=0;;body->length++)
+		{
+			if(body->length > MAX_BODY_LENGTH)
+				error_exit("Function too long");
+
+			if(fgetline(body->body[body->length], MAX_LINE_LENGTH, input_file) < 0)
+				error_exit("Premature end of file when getting function body");
+
+			if(body->body[body->length][0] == '}')
+			{
+				body->length++;
+				break;
+			}
+		}
+
+		g_num_primitives++;
+
+		/* Extract the function name information */
+		if(!extract_opcode_info(func_name, oper_name, &oper_size, oper_spec_proc, oper_spec_ea))
+			error_exit("Invalid " ID_OPHANDLER_NAME " format");
+
+		/* Find the corresponding table entry */
+		opinfo = find_opcode(oper_name, oper_size, oper_spec_proc, oper_spec_ea);
+		if(opinfo == NULL)
+			error_exit("Unable to find matching table entry for %s", func_name);
+
+        /* Change output files if we pass 'c' or 'n' */
+		if(output_file == g_ops_ac_file && oper_name[0] > 'c')
+			output_file = g_ops_dm_file;
+		else if(output_file == g_ops_dm_file && oper_name[0] > 'm')
+			output_file = g_ops_nz_file;
+
+		replace->length = 0;
+
+		/* Generate opcode variants */
+		if(strcmp(opinfo->name, "bcc") == 0 || strcmp(opinfo->name, "scc") == 0)
+			generate_opcode_cc_variants(output_file, body, replace, opinfo, 1);
+		else if(strcmp(opinfo->name, "dbcc") == 0)
+			generate_opcode_cc_variants(output_file, body, replace, opinfo, 2);
+		else if(strcmp(opinfo->name, "trapcc") == 0)
+			generate_opcode_cc_variants(output_file, body, replace, opinfo, 4);
+		else
+			generate_opcode_ea_variants(output_file, body, replace, opinfo);
+	}
+
+	free(replace);
+	free(body);
+}
+
+
+/* Populate the opcode handler table from the input file */
+void populate_table(void)
+{
+	char* ptr;
+	char bitpattern[17];
+	opcode_struct* op;
+	char buff[MAX_LINE_LENGTH];
+	int i;
+	int temp;
+
+	buff[0] = 0;
+
+	/* Find the start of the table */
+	while(strcmp(buff, ID_TABLE_START) != 0)
+		if(fgetline(buff, MAX_LINE_LENGTH, g_input_file) < 0)
+			error_exit("Premature EOF while reading table");
+
+	/* Process the entire table */
+	for(op = g_opcode_input_table;;op++)
+	{
+		if(fgetline(buff, MAX_LINE_LENGTH, g_input_file) < 0)
+			error_exit("Premature EOF while reading table");
+		if(strlen(buff) == 0)
+			continue;
+		/* We finish when we find an input separator */
+		if(strcmp(buff, ID_INPUT_SEPARATOR) == 0)
+			break;
+
+		/* Extract the info from the table */
+		ptr = buff;
+
+		/* Name */
+		ptr += skip_spaces(ptr);
+		ptr += check_strsncpy(op->name, ptr, MAX_NAME_LENGTH);
+
+		/* Size */
+		ptr += skip_spaces(ptr);
+		ptr += check_atoi(ptr, &temp);
+		op->size = (unsigned char)temp;
+
+		/* Special processing */
+		ptr += skip_spaces(ptr);
+		ptr += check_strsncpy(op->spec_proc, ptr, MAX_SPEC_PROC_LENGTH);
+
+		/* Specified EA Mode */
+		ptr += skip_spaces(ptr);
+		ptr += check_strsncpy(op->spec_ea, ptr, MAX_SPEC_EA_LENGTH);
+
+		/* Bit Pattern (more processing later) */
+		ptr += skip_spaces(ptr);
+		ptr += check_strsncpy(bitpattern, ptr, 17);
+
+		/* Allowed Addressing Mode List */
+		ptr += skip_spaces(ptr);
+		ptr += check_strsncpy(op->ea_allowed, ptr, EA_ALLOWED_LENGTH);
+
+		/* CPU operating mode (U = user or supervisor, S = supervisor only */
+		ptr += skip_spaces(ptr);
+		for(i=0;i<NUM_CPUS;i++)
+		{
+			op->cpu_mode[i] = *ptr++;
+			ptr += skip_spaces(ptr);
+		}
+
+		/* Allowed CPUs for this instruction */
+		for(i=0;i<NUM_CPUS;i++)
+		{
+			ptr += skip_spaces(ptr);
+			if(*ptr == UNSPECIFIED_CH)
+			{
+				op->cpus[i] = UNSPECIFIED_CH;
+				op->cycles[i] = 0;
+				ptr++;
+			}
+			else
+			{
+				op->cpus[i] = '0' + i;
+				ptr += check_atoi(ptr, &temp);
+				op->cycles[i] = (unsigned char)temp;
+			}
+		}
+
+		/* generate mask and match from bitpattern */
+		op->op_mask = 0;
+		op->op_match = 0;
+		for(i=0;i<16;i++)
+		{
+			op->op_mask |= (bitpattern[i] != '.') << (15-i);
+			op->op_match |= (bitpattern[i] == '1') << (15-i);
+		}
+	}
+	/* Terminate the list */
+	op->name[0] = 0;
+}
+
+/* Read a header or footer insert from the input file */
+void read_insert(char* insert)
+{
+	char* ptr = insert;
+	char* overflow = insert + MAX_INSERT_LENGTH - MAX_LINE_LENGTH;
+	int length;
+	char* first_blank = NULL;
+
+	first_blank = NULL;
+
+	/* Skip any leading blank lines */
+	for(length = 0;length == 0;length = fgetline(ptr, MAX_LINE_LENGTH, g_input_file))
+		if(ptr >= overflow)
+			error_exit("Buffer overflow reading inserts");
+	if(length < 0)
+		error_exit("Premature EOF while reading inserts");
+
+	/* Advance and append newline */
+	ptr += length;
+	strcpy(ptr++, "\n");
+
+	/* Read until next separator */
+	for(;;)
+	{
+		/* Read a new line */
+		if(ptr >= overflow)
+			error_exit("Buffer overflow reading inserts");
+		if((length = fgetline(ptr, MAX_LINE_LENGTH, g_input_file)) < 0)
+			error_exit("Premature EOF while reading inserts");
+
+		/* Stop if we read a separator */
+		if(strcmp(ptr, ID_INPUT_SEPARATOR) == 0)
+			break;
+
+		/* keep track in case there are trailing blanks */
+		if(length == 0)
+		{
+			if(first_blank == NULL)
+				first_blank = ptr;
+		}
+		else
+			first_blank = NULL;
+
+		/* Advance and append newline */
+		ptr += length;
+		strcpy(ptr++, "\n");
+	}
+
+	/* kill any trailing blank lines */
+	if(first_blank)
+		ptr = first_blank;
+	*ptr++ = 0;
+}
+
+
+
+/* ======================================================================== */
+/* ============================= MAIN FUNCTION ============================ */
+/* ======================================================================== */
+
+int main(int argc, char **argv)
+{
+	/* File stuff */
+	char output_path[M68K_MAX_DIR] = "";
+	char filename[M68K_MAX_PATH];
+	/* Section identifier */
+	char section_id[MAX_LINE_LENGTH+1];
+	/* Inserts */
+	char temp_insert[MAX_INSERT_LENGTH+1];
+	char prototype_footer_insert[MAX_INSERT_LENGTH+1];
+	char table_footer_insert[MAX_INSERT_LENGTH+1];
+	char ophandler_footer_insert[MAX_INSERT_LENGTH+1];
+	/* Flags if we've processed certain parts already */
+	int prototype_header_read = 0;
+	int prototype_footer_read = 0;
+	int table_header_read = 0;
+	int table_footer_read = 0;
+	int ophandler_header_read = 0;
+	int ophandler_footer_read = 0;
+	int table_body_read = 0;
+	int ophandler_body_read = 0;
+
+	printf("\n\t\tMusashi v%s 68000, 68010, 68EC020, 68020 emulator\n", g_version);
+	printf("\t\tCopyright 1998-2000 Karl Stenerud (karl@mame.net)\n\n");
+
+	/* Check if output path and source for the input file are given */
+    if(argc > 1)
+	{
+		char *ptr;
+		strcpy(output_path, argv[1]);
+
+		for(ptr = strchr(output_path, '\\'); ptr; ptr = strchr(ptr, '\\'))
+			*ptr = '/';
+        if(output_path[strlen(output_path)-1] != '/')
+			strcat(output_path, "/");
+		if(argc > 2)
+			strcpy(g_input_filename, argv[2]);
+	}
+
+
+	/* Open the files we need */
+	sprintf(filename, "%s%s", output_path, FILENAME_PROTOTYPE);
+	if((g_prototype_file = fopen(filename, "wt")) == NULL)
+		perror_exit("Unable to create prototype file (%s)\n", filename);
+
+	sprintf(filename, "%s%s", output_path, FILENAME_TABLE);
+	if((g_table_file = fopen(filename, "wt")) == NULL)
+		perror_exit("Unable to create table file (%s)\n", filename);
+
+	sprintf(filename, "%s%s", output_path, FILENAME_OPS_AC);
+	if((g_ops_ac_file = fopen(filename, "wt")) == NULL)
+		perror_exit("Unable to create ops ac file (%s)\n", filename);
+
+	sprintf(filename, "%s%s", output_path, FILENAME_OPS_DM);
+	if((g_ops_dm_file = fopen(filename, "wt")) == NULL)
+		perror_exit("Unable to create ops dm file (%s)\n", filename);
+
+	sprintf(filename, "%s%s", output_path, FILENAME_OPS_NZ);
+	if((g_ops_nz_file = fopen(filename, "wt")) == NULL)
+		perror_exit("Unable to create ops nz file (%s)\n", filename);
+
+	if((g_input_file=fopen(g_input_filename, "rt")) == NULL)
+		perror_exit("can't open %s for input", g_input_filename);
+
+
+	/* Get to the first section of the input file */
+	section_id[0] = 0;
+	while(strcmp(section_id, ID_INPUT_SEPARATOR) != 0)
+		if(fgetline(section_id, MAX_LINE_LENGTH, g_input_file) < 0)
+			error_exit("Premature EOF while reading input file");
+
+	/* Now process all sections */
+	for(;;)
+	{
+		if(fgetline(section_id, MAX_LINE_LENGTH, g_input_file) < 0)
+			error_exit("Premature EOF while reading input file");
+		if(strcmp(section_id, ID_PROTOTYPE_HEADER) == 0)
+		{
+			if(prototype_header_read)
+				error_exit("Duplicate prototype header");
+			read_insert(temp_insert);
+			fprintf(g_prototype_file, "%s\n\n", temp_insert);
+			prototype_header_read = 1;
+		}
+		else if(strcmp(section_id, ID_TABLE_HEADER) == 0)
+		{
+			if(table_header_read)
+				error_exit("Duplicate table header");
+			read_insert(temp_insert);
+			fprintf(g_table_file, "%s", temp_insert);
+			table_header_read = 1;
+		}
+		else if(strcmp(section_id, ID_OPHANDLER_HEADER) == 0)
+		{
+			if(ophandler_header_read)
+				error_exit("Duplicate opcode handler header");
+			read_insert(temp_insert);
+			fprintf(g_ops_ac_file, "%s\n\n", temp_insert);
+			fprintf(g_ops_dm_file, "%s\n\n", temp_insert);
+			fprintf(g_ops_nz_file, "%s\n\n", temp_insert);
+			ophandler_header_read = 1;
+		}
+		else if(strcmp(section_id, ID_PROTOTYPE_FOOTER) == 0)
+		{
+			if(prototype_footer_read)
+				error_exit("Duplicate prototype footer");
+			read_insert(prototype_footer_insert);
+			prototype_footer_read = 1;
+		}
+		else if(strcmp(section_id, ID_TABLE_FOOTER) == 0)
+		{
+			if(table_footer_read)
+				error_exit("Duplicate table footer");
+			read_insert(table_footer_insert);
+			table_footer_read = 1;
+		}
+		else if(strcmp(section_id, ID_OPHANDLER_FOOTER) == 0)
+		{
+			if(ophandler_footer_read)
+				error_exit("Duplicate opcode handler footer");
+			read_insert(ophandler_footer_insert);
+			ophandler_footer_read = 1;
+		}
+		else if(strcmp(section_id, ID_TABLE_BODY) == 0)
+		{
+			if(!prototype_header_read)
+				error_exit("Table body encountered before prototype header");
+			if(!table_header_read)
+				error_exit("Table body encountered before table header");
+			if(!ophandler_header_read)
+				error_exit("Table body encountered before opcode handler header");
+
+			if(table_body_read)
+				error_exit("Duplicate table body");
+
+			populate_table();
+			table_body_read = 1;
+		}
+		else if(strcmp(section_id, ID_OPHANDLER_BODY) == 0)
+		{
+			if(!prototype_header_read)
+				error_exit("Opcode handlers encountered before prototype header");
+			if(!table_header_read)
+				error_exit("Opcode handlers encountered before table header");
+			if(!ophandler_header_read)
+				error_exit("Opcode handlers encountered before opcode handler header");
+			if(!table_body_read)
+				error_exit("Opcode handlers encountered before table body");
+
+			if(ophandler_body_read)
+				error_exit("Duplicate opcode handler section");
+
+			process_opcode_handlers();
+
+			ophandler_body_read = 1;
+		}
+		else if(strcmp(section_id, ID_END) == 0)
+		{
+			/* End of input file.  Do a sanity check and then write footers */
+			if(!prototype_header_read)
+				error_exit("Missing prototype header");
+			if(!prototype_footer_read)
+				error_exit("Missing prototype footer");
+			if(!table_header_read)
+				error_exit("Missing table header");
+			if(!table_footer_read)
+				error_exit("Missing table footer");
+			if(!table_body_read)
+				error_exit("Missing table body");
+			if(!ophandler_header_read)
+				error_exit("Missing opcode handler header");
+			if(!ophandler_footer_read)
+				error_exit("Missing opcode handler footer");
+			if(!ophandler_body_read)
+				error_exit("Missing opcode handler body");
+
+			print_opcode_output_table(g_table_file);
+
+			fprintf(g_prototype_file, "%s\n\n", prototype_footer_insert);
+			fprintf(g_table_file, "%s\n\n", table_footer_insert);
+			fprintf(g_ops_ac_file, "%s\n\n", ophandler_footer_insert);
+			fprintf(g_ops_dm_file, "%s\n\n", ophandler_footer_insert);
+			fprintf(g_ops_nz_file, "%s\n\n", ophandler_footer_insert);
+
+			break;
+		}
+		else
+		{
+			error_exit("Unknown section identifier: %s", section_id);
+		}
+	}
+
+	/* Close all files and exit */
+	fclose(g_prototype_file);
+	fclose(g_table_file);
+	fclose(g_ops_ac_file);
+	fclose(g_ops_dm_file);
+	fclose(g_ops_nz_file);
+	fclose(g_input_file);
+
+	printf("Generated %d opcode handlers from %d primitives\n", g_num_functions, g_num_primitives);
+
+	return 0;
+}
+
+
+
+/* ======================================================================== */
+/* ============================== END OF FILE ============================= */
+/* ======================================================================== */

--- a/yabause/src/musashi/readme.txt
+++ b/yabause/src/musashi/readme.txt
@@ -1,0 +1,305 @@
+                                    MUSASHI
+                                    =======
+
+                                  Version 3.4
+
+             A portable Motorola M680x0 processor emulation engine.
+            Copyright 1998-2002 Karl Stenerud.  All rights reserved.
+
+
+
+INTRODUCTION:
+------------
+
+Musashi is a Motorola 68000, 68010, 68EC020, and 68020 emulator written in C.
+This emulator was written with two goals in mind: portability and speed.
+
+The emulator is written to ANSI C89 specifications.  It also uses inline
+functions, which are C9X compliant.
+
+It has been successfully running in the MAME project (www.mame.net) for years
+and so has had time to mature.
+
+
+
+LICENSE AND COPYRIGHT:
+---------------------
+
+Copyright © 1998-2001 Karl Stenerud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+AVAILABILITY:
+------------
+The latest version of this code can be obtained at:
+https://github.com/kstenerud/Musashi
+
+
+
+CONTACTING THE AUTHOR:
+---------------------
+I can be reached at kstenerud@gmail.com
+
+
+
+BASIC CONFIGURATION:
+-------------------
+The basic configuration will give you a standard 68000 that has sufficient
+functionality to work in a primitive environment.
+
+This setup assumes that you only have 1 device interrupting it, that the
+device will always request an autovectored interrupt, and it will always clear
+the interrupt before the interrupt service routine finishes (but could
+possibly re-assert the interrupt).
+You will have only one address space, no tracing, and no instruction prefetch.
+
+To implement the basic configuration:
+
+- Open m68kconf.h and verify that the settings for INLINE will work with your
+  compiler. (Currently set to "static __inline__", which works in gcc 2.9.
+  For C9X compliance, it should be "inline")
+
+- In your host program, implement the following functions:
+    unsigned int  m68k_read_memory_8(unsigned int address);
+    unsigned int  m68k_read_memory_16(unsigned int address);
+    unsigned int  m68k_read_memory_32(unsigned int address);
+    void m68k_write_memory_8(unsigned int address, unsigned int value);
+    void m68k_write_memory_16(unsigned int address, unsigned int value);
+    void m68k_write_memory_32(unsigned int address, unsigned int value);
+
+- In your host program, be sure to call m68k_pulse_reset() once before calling
+  any of the other functions as this initializes the core.
+
+- Use m68k_execute() to execute instructions and m68k_set_irq() to cause an
+  interrupt.
+
+
+
+ADDING PROPER INTERRUPT HANDLING:
+--------------------------------
+The interrupt handling in the basic configuration doesn't emulate the
+interrupt acknowledge phase of the CPU and automatically clears an interrupt
+request during interrupt processing.
+While this works for most systems, you may need more accurate interrupt
+handling.
+
+To add proper interrupt handling:
+
+- In m68kconf.h, set M68K_EMULATE_INT_ACK to OPT_SPECIFY_HANDLER
+
+- In m68kconf.h, set M68K_INT_ACK_CALLBACK(A) to your interrupt acknowledge
+  routine
+
+- Your interrupt acknowledge routine must return an interrupt vector,
+  M68K_INT_ACK_AUTOVECTOR, or M68K_INT_ACK_SPURIOUS.  most m68k
+  implementations just use autovectored interrupts.
+
+- When the interrupting device is satisfied, you must call m68k_set_irq(0) to
+  remove the interrupt request.
+
+
+
+MULTIPLE INTERRUPTS:
+-------------------
+The above system will work if you have only one device interrupting the CPU,
+but if you have more than one device, you must do a bit more.
+
+To add multiple interrupts:
+
+- You must make an interrupt arbitration device that will take the highest
+  priority interrupt and encode it onto the IRQ pins on the CPU.
+
+- The interrupt arbitration device should use m68k_set_irq() to set the
+  highest pending interrupt, or 0 for no interrupts pending.
+
+
+
+SEPARATE IMMEDIATE READS:
+------------------------
+You can write faster memory access functions if you know whether you are
+fetching from ROM or RAM.  Immediate reads are always from the program space
+(Always in ROM unless it is running self-modifying code).
+
+To enable separate immediate reads:
+
+- In m68kconf.h, turn on M68K_SEPARATE_READ_IMM.
+
+- In your host program, implement the following functions:
+    unsigned int  m68k_read_immediate_16(unsigned int address);
+    unsigned int  m68k_read_immediate_32(unsigned int address);
+
+- If you need to know the current PC (for banking and such), set
+  M68K_MONITOR_PC to OPT_SPECIFY_HANDLER, and set M68K_SET_PC_CALLBACK(A) to
+  your routine.
+
+
+
+ADDRESS SPACES:
+--------------
+Most systems will only implement one address space, placing ROM at the lower
+addresses and RAM at the higher.  However, there is the possibility that a
+system will implement ROM and RAM in the same address range, but in different
+address spaces.
+
+In this case, you might get away with assuming that immediate reads are in the
+program space and all other reads are in the data space, if it weren't for the
+fact that the exception vectors are fetched from the data space.  As a result,
+anyone implementing this kind of system will have to copy the vector table
+from ROM to RAM using pc-relative instructions.
+
+This makes things bad for emulation, because this means that a non-immediate
+read is not necessarily in the data space.
+The m68k deals with this by encoding the requested address space on the
+function code pins:
+
+                       FC
+    Address Space      210
+    ------------------ ---
+    USER DATA          001
+    USER PROGRAM       010
+    SUPERVISOR DATA    101
+    SUPERVISOR PROGRAM 110
+    CPU SPACE          111 <-- not emulated in this core since we emulate
+                               interrupt acknowledge in another way.
+
+To emulate the function code pins:
+
+- In m68kconf.h, set M68K_EMULATE_FC to OPT_SPECIFY_HANDLER and set
+  M68K_SET_FC_CALLBACK(A) to your function code handler function.
+
+- Your function code handler should select the proper address space for
+  subsequent calls to m68k_read_xx (and m68k_write_xx for 68010+).
+
+Note: immediate reads are always done from program space, so technically you
+      don't need to implement the separate immediate reads, although you could
+      gain more speed improvements leaving them in and doing some clever
+      programming.
+
+
+
+USING DIFFERENT CPU TYPES:
+-------------------------
+The default is to enable only the 68000 cpu type.  To change this, change the
+settings for M68K_EMULATE_010 etc in m68kconf.h.
+
+To set the CPU type you want to use:
+
+- Make sure it is enabled in m68kconf.h.  Current switches are:
+    M68K_EMULATE_010
+    M68K_EMULATE_EC020
+    M68K_EMULATE_020
+
+- In your host program, call m68k_set_cpu_type() and then call
+  m68k_pulse_reset().  Valid CPU types are:
+    M68K_CPU_TYPE_68000,
+    M68K_CPU_TYPE_68010,
+    M68K_CPU_TYPE_68EC020,
+    M68K_CPU_TYPE_68020
+
+
+
+CLOCK FREQUENCY:
+---------------
+In order to emulate the correct clock frequency, you will have to calculate
+how long it takes the emulation to execute a certain number of "cycles" and
+vary your calls to m68k_execute() accordingly.
+As well, it is a good idea to take away the CPU's timeslice when it writes to
+a memory-mapped port in order to give the device it wrote to a chance to
+react.
+
+You can use the functions m68k_cycles_run(), m68k_cycles_remaining(),
+m68k_modify_timeslice(), and m68k_end_timeslice() to do this.
+Try to use large cycle values in your calls to m68k_execute() since it will
+increase throughput.  You can always take away the timeslice later.
+
+
+
+MORE CORRECT EMULATION:
+----------------------
+You may need to enable these in order to properly emulate some of the more
+obscure functions of the m68k:
+
+- M68K_EMULATE_BKPT_ACK causes the CPU to call a breakpoint handler on a BKPT
+  instruction
+
+- M68K_EMULATE_TRACE causes the CPU to generate trace exceptions when the
+  trace bits are set
+
+- M68K_EMULATE_RESET causes the CPU to call a reset handler on a RESET
+  instruction.
+
+- M68K_EMULATE_PREFETCH emulates the 4-word instruction prefetch that is part
+  of the 68000/68010 (needed for Amiga emulation).
+  NOTE: if the CPU fetches a word or longword at an odd address when this
+  option is on, it will yield unpredictable results, which is why a real
+  68000 will generate an address error exception.
+
+- M68K_EMULATE_ADDRESS_ERROR will cause the CPU to generate address error
+  exceptions if it attempts to read a word or longword at an odd address.
+
+- call m68k_pulse_halt() to emulate the HALT pin.
+
+
+
+CONVENIENCE FUNCTIONS:
+---------------------
+These are in here for programmer convenience:
+
+- M68K_INSTRUCTION_HOOK lets you call a handler before each instruction.
+
+- M68K_LOG_ENABLE and M68K_LOG_1010_1111 lets you log illegal and A/F-line
+  instructions.
+
+
+
+MULTIPLE CPU EMULATION:
+----------------------
+The default is to use only one CPU.  To use more than one CPU in this core,
+there are some things to keep in mind:
+
+- To have different cpus call different functions, use OPT_ON instead of
+  OPT_SPECIFY_HANDLER, and use the m68k_set_xxx_callback() functions to set
+  your callback handlers on a per-cpu basis.
+
+- Be sure to call set_cpu_type() for each CPU you use.
+
+- Use m68k_set_context() and m68k_get_context() to switch to another CPU.
+
+
+
+LOAD AND SAVE CPU CONTEXTS FROM DISK:
+------------------------------------
+You can use them68k_load_context() and m68k_save_context() functions to load
+and save the CPU state to disk.
+
+
+
+GET/SET INFORMATION FROM THE CPU:
+--------------------------------
+You can use m68k_get_reg() and m68k_set_reg() to gain access to the internals
+of the CPU.
+
+
+
+EXAMPLE:
+-------
+
+The subdir example contains a full example (currently DOS only).

--- a/yabause/src/qt/QtYabause.cpp
+++ b/yabause/src/qt/QtYabause.cpp
@@ -42,6 +42,9 @@ M68K_struct * M68KCoreList[] = {
 #ifdef HAVE_C68K
 &M68KC68K,
 #endif
+#ifdef HAVE_MUSASHI
+&M68KMusashi,
+#endif
 NULL
 };
 
@@ -449,9 +452,20 @@ PerInterface_struct QtYabause::defaultPERCore()
 #endif
 }
 
+M68K_struct QtYabause::default68kCore()
+{
+#ifdef HAVE_C68K
+   return M68KC68K;
+#elif HAVE_MUSASHI
+   return M68KMusashi;
+#else
+   return M68KDummy;
+#endif
+}
+
 SH2Interface_struct QtYabause::defaultSH2Core()
 {
-	return SH2Interpreter;
+   return SH2Interpreter;
 }
 
 QMap<uint, PerPad_struct*>* QtYabause::portPadsBits( uint portNumber )

--- a/yabause/src/qt/QtYabause.h
+++ b/yabause/src/qt/QtYabause.h
@@ -118,6 +118,7 @@ namespace QtYabause
 	OSD_struct defaultOSDCore();
 	PerInterface_struct defaultPERCore();
 	SH2Interface_struct defaultSH2Core();
+   M68K_struct default68kCore();
 	
 	// padsbits
 	QMap<uint, PerPad_struct*>* portPadsBits( uint portNumber );

--- a/yabause/src/qt/YabauseThread.cpp
+++ b/yabause/src/qt/YabauseThread.cpp
@@ -286,7 +286,7 @@ void YabauseThread::reloadSettings()
 	resetYabauseConf();
 
 	// read & apply settings
-	mYabauseConf.m68kcoretype = vs->value( "Advanced/M68KCore", mYabauseConf.m68kcoretype ).toInt();
+   mYabauseConf.m68kcoretype = vs->value("Advanced/68kCore", mYabauseConf.m68kcoretype).toInt();
 	mYabauseConf.percoretype = vs->value( "Input/PerCore", mYabauseConf.percoretype ).toInt();
 	mYabauseConf.sh2coretype = vs->value( "Advanced/SH2Interpreter", mYabauseConf.sh2coretype ).toInt();
 	mYabauseConf.vidcoretype = vs->value( "Video/VideoCore", mYabauseConf.vidcoretype ).toInt();

--- a/yabause/src/qt/ui/UISettings.cpp
+++ b/yabause/src/qt/ui/UISettings.cpp
@@ -326,6 +326,10 @@ void UISettings::loadCores()
 	for ( int i = 0; SH2CoreList[i] != NULL; i++ )
 		cbSH2Interpreter->addItem( QtYabause::translate( SH2CoreList[i]->Name ), SH2CoreList[i]->id );
 
+   //68k cores
+   for (int i = 0; M68KCoreList[i] != NULL; i++)
+      cb68kCore->addItem(QtYabause::translate(M68KCoreList[i]->Name), M68KCoreList[i]->id);
+
 	cbAspectRatio->addItem( QtYabause::translate( "Fit to window" ), 0 );
 	cbAspectRatio->addItem( QtYabause::translate( "Fixed aspect ratio: 4:3" ), 1 );
 	cbAspectRatio->addItem( QtYabause::translate( "Fixed aspect ratio: 16:9" ), 2 );
@@ -476,6 +480,7 @@ void UISettings::loadSettings()
 	// advanced
 	cbRegion->setCurrentIndex( cbRegion->findData( s->value( "Advanced/Region", mRegions.at( 0 ).id ).toString() ) );
 	cbSH2Interpreter->setCurrentIndex( cbSH2Interpreter->findData( s->value( "Advanced/SH2Interpreter", QtYabause::defaultSH2Core().id ).toInt() ) );
+   cb68kCore->setCurrentIndex(cb68kCore->findData(s->value("Advanced/68kCore", QtYabause::default68kCore().id).toInt()));
 
 	// view
 	bgShowMenubar->setId( rbMenubarNever, BD_NEVERHIDE );
@@ -567,6 +572,7 @@ void UISettings::saveSettings()
 	// advanced
 	s->setValue( "Advanced/Region", cbRegion->itemData( cbRegion->currentIndex() ).toString() );
 	s->setValue( "Advanced/SH2Interpreter", cbSH2Interpreter->itemData( cbSH2Interpreter->currentIndex() ).toInt() );
+   s->setValue("Advanced/68kCore", cb68kCore->itemData(cb68kCore->currentIndex()).toInt());
 
 	// view
 	s->setValue( "View/Menubar", bgShowMenubar->checkedId() );

--- a/yabause/src/qt/ui/UISettings.ui
+++ b/yabause/src/qt/ui/UISettings.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="twPages">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="wGeneral">
       <attribute name="title">
@@ -695,6 +695,22 @@
         <widget class="QComboBox" name="cbSH2Interpreter"/>
        </item>
        <item>
+        <widget class="QLabel" name="l68kCore">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>68000 Core</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cb68kCore"/>
+       </item>
+       <item>
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -963,8 +979,8 @@
   </connection>
  </connections>
  <buttongroups>
+  <buttongroup name="bgShowToolbar"/>
   <buttongroup name="bgShowMenubar"/>
   <buttongroup name="bgShowLogWindow"/>
-  <buttongroup name="bgShowToolbar"/>
  </buttongroups>
 </ui>

--- a/yabause/src/qt/ui/UIYabause.cpp
+++ b/yabause/src/qt/ui/UIYabause.cpp
@@ -748,6 +748,7 @@ void UIYabause::on_aFileSettings_triggered()
 			newhash["Memory/Path"]!=hash["Memory/Path"] ||
 			newhash["MpegROM/Path" ]!=hash["MpegROM/Path" ] ||
 			newhash["Advanced/SH2Interpreter" ]!=hash["Advanced/SH2Interpreter" ] ||
+         newhash["Advanced/68kCore"] != hash["Advanced/68kCore"] ||
 			newhash["General/CdRom"]!=hash["General/CdRom"] ||
 			newhash["General/CdRomISO"]!=hash["General/CdRomISO"] ||
 			newhash["General/ClockSync"]!=hash["General/ClockSync"] ||
@@ -850,7 +851,7 @@ void UIYabause::on_aFileOpenSSF_triggered()
    const QString fn = CommonDialogs::getOpenFileName(
       QtYabause::volatileSettings()->value("Recents/SSFs").toString(), 
       QtYabause::translate("Select your ssf file"), 
-      QtYabause::translate("Sega Saturn Sound Format files (*.ssf)"));
+      QtYabause::translate("Sega Saturn Sound Format files (*.ssf *.minissf)"));
 
    if (!fn.isEmpty())
    {


### PR DESCRIPTION
This adds Musashi as one of the 68k core options. Musashi was relicensed to MIT in 2013 and is compatible with with GPL now. Musashi has a few advantages:

Well tested
Compiles quickly
About 10% fps increase on my system

There is no 68k core selection option in the Qt port so it has to be set manually at the moment.