### PR TITLE
scsp/qt: add new scsp option to settings, fix minissf loading

### DIFF
--- a/yabause/src/aosdk/ao.h
+++ b/yabause/src/aosdk/ao.h
@@ -36,7 +36,7 @@ typedef struct
 extern ao_display_info ssf_info;
 
 int ao_get_lib(char *filename, u8 **buffer, u64 *length);
-s32 ssf_start(u8 *buffer, u32 length, int m68k_core, int sndcore);
+s32 ssf_start(u8 *buffer, u32 length, int m68k_core, int sndcore, char* filename);
 s32 ssf_fill_info(ao_display_info *);
 
 #ifdef _MSC_VER

--- a/yabause/src/aosdk/eng_ssf.c
+++ b/yabause/src/aosdk/eng_ssf.c
@@ -81,7 +81,29 @@ static corlett_t	*c = NULL;
 static char 		psfby[256];
 static u32		decaybegin, decayend, total_samples;
 
-s32 ssf_start(u8 *buffer, u32 length, int m68k_core, int sndcore)
+//get current directory then append the libfile name
+int get_lib_file(char* path, char* libfile, char * output)
+{
+   char * end = NULL;
+   size_t len = 0;
+   if (!path || !libfile || !output)
+      return 0;
+
+   len = strlen(path);
+
+   end = path + len - 1;
+
+   while (end > path && *end != '/')
+      end--;
+
+   strncpy(output, path, (end - path)+1);
+
+   strcat(output, libfile);
+
+   return 1;//success
+}
+
+s32 ssf_start(u8 *buffer, u32 length, int m68k_core, int sndcore, char* filename)
 {
 	u8 *file, *lib_decoded, *lib_raw_file;
 	u32 offset, lengthMS, fadeMS;
@@ -113,11 +135,15 @@ s32 ssf_start(u8 *buffer, u32 length, int m68k_core, int sndcore)
 		if (libfile[0] != 0)
 		{
 			u64 tmp_length;
-	
+         char libfile_path[2048] = { 0 };
+
+         if (!get_lib_file(filename, libfile, libfile_path))
+            return AO_FAIL;
+         
 			#if DEBUG_LOADER	
 			printf("Loading library: %s\n", c->lib);
 			#endif
-			if (ao_get_lib(libfile, &lib_raw_file, &tmp_length) != AO_SUCCESS)
+			if (ao_get_lib(libfile_path, &lib_raw_file, &tmp_length) != AO_SUCCESS)
 			{
 				return AO_FAIL;
 			}

--- a/yabause/src/aosdk/ssf.c
+++ b/yabause/src/aosdk/ssf.c
@@ -121,7 +121,7 @@ int load_ssf(char *filename, int m68k_core, int sndcore)
 		return 0;//false
 	}
 
-	if ((ret = ssf_start(buffer, size, m68k_core, sndcore)) != AO_SUCCESS)
+	if ((ret = ssf_start(buffer, size, m68k_core, sndcore, filename)) != AO_SUCCESS)
 	{
 		free(buffer);
 		return ret;

--- a/yabause/src/qt/YabauseThread.cpp
+++ b/yabause/src/qt/YabauseThread.cpp
@@ -324,6 +324,7 @@ void YabauseThread::reloadSettings()
 	mYabauseConf.modemip = strdup( vs->value( "Cartridge/ModemIP", mYabauseConf.modemip ).toString().toLatin1().constData() );
 	mYabauseConf.modemport = strdup( vs->value( "Cartridge/ModemPort", mYabauseConf.modemport ).toString().toLatin1().constData() );
 	mYabauseConf.videoformattype = vs->value( "Video/VideoFormat", mYabauseConf.videoformattype ).toInt();
+   mYabauseConf.use_new_scsp = (int)vs->value("Sound/NewScsp", mYabauseConf.use_new_scsp).toBool();
 	
 	emit requestSize( QSize( vs->value( "Video/WinWidth", 0 ).toInt(), vs->value( "Video/WinHeight", 0 ).toInt() ) );
 	emit requestFullscreen( vs->value( "Video/Fullscreen", false ).toBool() );

--- a/yabause/src/qt/ui/UISettings.cpp
+++ b/yabause/src/qt/ui/UISettings.cpp
@@ -464,6 +464,7 @@ void UISettings::loadSettings()
 
 	// sound
 	cbSoundCore->setCurrentIndex( cbSoundCore->findData( s->value( "Sound/SoundCore", QtYabause::defaultSNDCore().id ).toInt() ) );
+   cbNewScsp->setChecked(s->value("Sound/NewScsp", false).toBool());
 
 	// cartridge/memory
 	cbCartridge->setCurrentIndex( cbCartridge->findData( s->value( "Cartridge/Type", mCartridgeTypes.at( 0 ).id ).toInt() ) );
@@ -556,6 +557,7 @@ void UISettings::saveSettings()
 
 	// sound
 	s->setValue( "Sound/SoundCore", cbSoundCore->itemData( cbSoundCore->currentIndex() ).toInt() );
+   s->setValue( "Sound/NewScsp", cbNewScsp->isChecked());
 
 	// cartridge/memory
 	s->setValue( "Cartridge/Type", cbCartridge->itemData( cbCartridge->currentIndex() ).toInt() );

--- a/yabause/src/qt/ui/UISettings.ui
+++ b/yabause/src/qt/ui/UISettings.ui
@@ -408,6 +408,13 @@
         <widget class="QComboBox" name="cbSoundCore"/>
        </item>
        <item>
+        <widget class="QCheckBox" name="cbNewScsp">
+         <property name="text">
+          <string>Use new scsp</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -979,8 +986,8 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="bgShowToolbar"/>
-  <buttongroup name="bgShowMenubar"/>
   <buttongroup name="bgShowLogWindow"/>
+  <buttongroup name="bgShowMenubar"/>
+  <buttongroup name="bgShowToolbar"/>
  </buttongroups>
 </ui>

--- a/yabause/src/qt/ui/UIYabause.cpp
+++ b/yabause/src/qt/ui/UIYabause.cpp
@@ -796,7 +796,10 @@ void UIYabause::on_aFileSettings_triggered()
 		
 		if (newhash["Sound/SoundCore"] != hash["Sound/SoundCore"])
 			ScspChangeSoundCore(newhash["Sound/SoundCore"].toInt());
-		
+
+      if (newhash["Sound/NewScsp"].toBool() != hash["Sound/NewScsp"])
+         scsp_set_use_new(newhash["Sound/NewScsp"].toInt());
+
 		if (newhash["Video/WindowWidth"] != hash["Video/WindowWidth"] || newhash["Video/WindowHeight"] != hash["Video/WindowHeight"] ||
           newhash["View/Menubar"] != hash["View/Menubar"] || newhash["View/Toolbar"] != hash["View/Toolbar"] || 
 			 newhash["Input/GunMouseSensitivity"] != hash["Input/GunMouseSensitivity"])

--- a/yabause/src/scsp.h
+++ b/yabause/src/scsp.h
@@ -149,5 +149,6 @@ void scsp_debug_instrument_set_mute(u32 sa, int mute);
 void scsp_debug_instrument_clear();
 void scsp_debug_get_envelope(int chan, int * env, int * state);
 void scsp_debug_set_mode(int mode);
+void scsp_set_use_new(int which);
 
 #endif

--- a/yabause/src/yabause.c
+++ b/yabause/src/yabause.c
@@ -346,6 +346,8 @@ int YabauseInit(yabauseinit_struct *init)
       VIDSoftSetNumPriorityThreads(0);
    }
 
+   scsp_set_use_new(init->use_new_scsp);
+
    return 0;
 }
 

--- a/yabause/src/yabause.h
+++ b/yabause/src/yabause.h
@@ -51,6 +51,7 @@ typedef struct
    int osdcoretype;
    int skip_load;//skip loading in YabauseInit so tests can be run without a bios
    int play_ssf;
+   int use_new_scsp;
 } yabauseinit_struct;
 
 #define CLKTYPE_26MHZ           0


### PR DESCRIPTION
The new scsp has been added as a run-time option to the Qt port under Settings -> Sound. 
The minissf loader was previously unable to find library files because the path was not present in the filename.
Also an out of bounds read of the efreg registers was fixed.