### PR TITLE
new scsp: run sound subsystem at sample-level timing

### DIFF
--- a/yabause/src/scsp.h
+++ b/yabause/src/scsp.h
@@ -150,5 +150,7 @@ void scsp_debug_instrument_clear();
 void scsp_debug_get_envelope(int chan, int * env, int * state);
 void scsp_debug_set_mode(int mode);
 void scsp_set_use_new(int which);
+void new_scsp_exec(s32 cycles);
 
+extern int use_new_scsp;
 #endif


### PR DESCRIPTION
This commit improves the synchronization of the new scsp and 68k to a sample level. Some things I've noticed to have improved are:

Radiant Silvergun press start sound
Bios advanced controls button sound
Scorcher track 3 has no missing notes