### PR TITLE
build: fix warnings on gcc/clang linux

### DIFF
--- a/yabause/src/gameinfo.c
+++ b/yabause/src/gameinfo.c
@@ -46,6 +46,7 @@ int LoadStateSlotScreenshot(const char * dirpath, const char * itemnum, int slot
    int version, chunksize;
    FILE * fp;
    int totalsize;
+   size_t fread_result = 0;
 
    sprintf(filename, "%s/%s_%03d.yss", dirpath, itemnum, slot);
 
@@ -98,14 +99,14 @@ int LoadStateSlotScreenshot(const char * dirpath, const char * itemnum, int slot
 
    fseek(fp, sizeof(int) * 9, SEEK_CUR);
 
-   fread((void *) outputwidth, sizeof(int), 1, fp);
-   fread((void *) outputheight, sizeof(int), 1, fp);
+   fread_result = fread((void *) outputwidth, sizeof(int), 1, fp);
+   fread_result = fread((void *) outputheight, sizeof(int), 1, fp);
 
    totalsize = *outputwidth * *outputheight * sizeof(u32);
 
    *buffer = malloc(totalsize);
 
-   fread(*buffer, totalsize, 1, fp);
+   fread_result = fread(*buffer, totalsize, 1, fp);
 
    fclose(fp);
 

--- a/yabause/src/sh2_dynarec/assem_arm.c
+++ b/yabause/src/sh2_dynarec/assem_arm.c
@@ -567,7 +567,7 @@ void alloc_arm_reg(struct regstat *cur,int i,signed char reg,char hr)
 }
 
 // Alloc cycle count into dedicated register
-alloc_cc(struct regstat *cur,int i)
+void alloc_cc(struct regstat *cur,int i)
 {
   alloc_arm_reg(cur,i,CCREG,HOST_CCREG);
 }
@@ -2736,7 +2736,7 @@ void literal_pool_jumpover(int n)
   set_jump_target(jaddr,(int)out);
 }
 
-emit_extjump(pointer addr, int target)
+void emit_extjump(pointer addr, int target)
 {
   u8 *ptr=(u8 *)addr;
   assert((ptr[3]&0x0e)==0xa);
@@ -2756,7 +2756,7 @@ emit_extjump(pointer addr, int target)
   emit_jmp((pointer)dyna_linker);
 }
 
-do_readstub(int n)
+void do_readstub(int n)
 {
   assem_debug("do_readstub %x\n",start+stubs[n][3]*2);
   literal_pool(256);
@@ -2844,7 +2844,7 @@ do_readstub(int n)
   emit_jmp(stubs[n][2]); // return address
 }
 
-inline_readstub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
+void inline_readstub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
 {
   assem_debug("inline_readstub\n");
   //int rs=get_reg(regmap,target);
@@ -2881,7 +2881,7 @@ inline_readstub(int type, int i, u32 addr, signed char regmap[], int target, int
   restore_regs(reglist);
 }
 
-do_writestub(int n)
+void do_writestub(int n)
 {
   assem_debug("do_writestub %x\n",start+stubs[n][3]*2);
   literal_pool(256);
@@ -2936,7 +2936,7 @@ do_writestub(int n)
   emit_jmp(stubs[n][2]); // return address
 }
 
-inline_writestub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
+void inline_writestub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
 {
   assem_debug("inline_writestub\n");
   //int rs=get_reg(regmap,-1);
@@ -2956,7 +2956,7 @@ inline_writestub(int type, int i, u32 addr, signed char regmap[], int target, in
   restore_regs(reglist);
 }
 
-do_rmwstub(int n)
+void do_rmwstub(int n)
 {
   assem_debug("do_rmwstub %x\n",start+stubs[n][3]*2);
   set_jump_target(stubs[n][1],(int)out);
@@ -3013,7 +3013,7 @@ do_rmwstub(int n)
   emit_jmp(stubs[n][2]); // return address
 }
 
-do_unalignedwritestub(int n)
+void do_unalignedwritestub(int n)
 {
   set_jump_target(stubs[n][1],(int)out);
   output_w32(0xef000000);
@@ -3084,7 +3084,7 @@ int do_map_r_branch(int map, int c, u32 addr, int *jaddr)
   return map;
 }
 
-int gen_tlb_addr_r(int ar, int map) {
+void gen_tlb_addr_r(int ar, int map) {
   if(map>=0) {
     assem_debug("add %s,%s,%s lsl #2\n",regname[ar],regname[ar],regname[map]);
     output_w32(0xe0800100|rd_rn_rm(ar,ar,map));
@@ -3116,7 +3116,7 @@ int do_map_w(int s,int ar,int map,int cache,int x,int c,u32 addr)
   }
   return map;
 }
-int do_map_w_branch(int map, int c, u32 addr, int *jaddr)
+void do_map_w_branch(int map, int c, u32 addr, int *jaddr)
 {
   if(!c||can_direct_write(addr)) {
     emit_testimm(map,0x40000000);
@@ -3125,7 +3125,7 @@ int do_map_w_branch(int map, int c, u32 addr, int *jaddr)
   }
 }
 
-int gen_tlb_addr_w(int ar, int map) {
+void gen_tlb_addr_w(int ar, int map) {
   if(map>=0) {
     assem_debug("add %s,%s,%s lsl #2\n",regname[ar],regname[ar],regname[map]);
     output_w32(0xe0800100|rd_rn_rm(ar,ar,map));
@@ -3141,7 +3141,7 @@ int gen_orig_addr_w(int ar, int map) {
 }
 
 // Generate the address of the memory_map entry, relative to dynarec_local
-generate_map_const(u32 addr,int reg) {
+void generate_map_const(u32 addr,int reg) {
   //printf("generate_map_const(%x,%s)\n",addr,regname[reg]);
   emit_movimm((addr>>12)+(((u32)memory_map-(u32)&dynarec_local)>>2),reg);
 }

--- a/yabause/src/sh2_dynarec/assem_x86.c
+++ b/yabause/src/sh2_dynarec/assem_x86.c
@@ -459,7 +459,7 @@ void alloc_x86_reg(struct regstat *cur,int i,signed char reg,char hr)
 }
 
 // Alloc cycle count into dedicated register
-alloc_cc(struct regstat *cur,int i)
+void alloc_cc(struct regstat *cur,int i)
 {
   alloc_x86_reg(cur,i,CCREG,ESI);
 }
@@ -2771,7 +2771,7 @@ void restore_regs(u32 reglist)
 
 /* Stubs/epilogue */
 
-emit_extjump(pointer addr, int target)
+void emit_extjump(pointer addr, int target)
 {
   u8 *ptr=(u8 *)addr;
   if(*ptr==0x0f)
@@ -2801,7 +2801,7 @@ emit_extjump(pointer addr, int target)
   emit_jmp((pointer)dyna_linker);
 }
 
-do_readstub(int n)
+void do_readstub(int n)
 {
   assem_debug("do_readstub %x\n",start+stubs[n][3]*2);
   set_jump_target(stubs[n][1],(int)out);
@@ -2924,7 +2924,7 @@ do_readstub(int n)
   emit_jmp(stubs[n][2]); // return address
 }
 
-inline_readstub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
+void inline_readstub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
 {
   assem_debug("inline_readstub\n");
   //int rs=get_reg(regmap,target);
@@ -2960,7 +2960,7 @@ inline_readstub(int type, int i, u32 addr, signed char regmap[], int target, int
   restore_regs(reglist);
 }
 
-do_writestub(int n)
+void do_writestub(int n)
 {
   assem_debug("do_writestub %x\n",start+stubs[n][3]*2);
   set_jump_target(stubs[n][1],(int)out);
@@ -3056,7 +3056,7 @@ do_writestub(int n)
   emit_jmp(stubs[n][2]); // return address
 }
 
-inline_writestub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
+void inline_writestub(int type, int i, u32 addr, signed char regmap[], int target, int adj, u32 reglist)
 {
   assem_debug("inline_writestub\n");
   //int rs=get_reg(regmap,-1);
@@ -3076,7 +3076,7 @@ inline_writestub(int type, int i, u32 addr, signed char regmap[], int target, in
   restore_regs(reglist);
 }
 
-do_rmwstub(int n)
+void do_rmwstub(int n)
 {
   assem_debug("do_rmwstub %x\n",start+stubs[n][3]*2);
   set_jump_target(stubs[n][1],(int)out);
@@ -3161,7 +3161,7 @@ do_rmwstub(int n)
   emit_jmp(stubs[n][2]); // return address
 }
 
-do_unalignedwritestub(int n)
+void do_unalignedwritestub(int n)
 {
   set_jump_target(stubs[n][1],(int)out);
   output_byte(0xCC);
@@ -3222,7 +3222,7 @@ int do_map_r_branch(int map, int c, u32 addr, int *jaddr)
   return map;
 }
 
-int gen_tlb_addr_r(int ar, int map) {
+void gen_tlb_addr_r(int ar, int map) {
   if(map>=0) {
     emit_leairrx4(0,ar,map,ar);
   }
@@ -3248,7 +3248,7 @@ int do_map_w(int s,int ar,int map,int cache,int x,int c,u32 addr)
   emit_shlimm(map,2,map);
   return map;
 }
-int do_map_w_branch(int map, int c, u32 addr, int *jaddr)
+void do_map_w_branch(int map, int c, u32 addr, int *jaddr)
 {
   if(!c||can_direct_write(addr)) {
     *jaddr=(int)out;
@@ -3256,14 +3256,14 @@ int do_map_w_branch(int map, int c, u32 addr, int *jaddr)
   }
 }
 
-int gen_tlb_addr_w(int ar, int map) {
+void gen_tlb_addr_w(int ar, int map) {
   if(map>=0) {
     emit_leairrx1(0,ar,map,ar);
   }
 }
 
 // We don't need this for x86
-generate_map_const(u32 addr,int reg) {
+void generate_map_const(u32 addr,int reg) {
   // void *mapaddr=memory_map+(addr>>12);
 }
 

--- a/yabause/src/sh2d.c
+++ b/yabause/src/sh2d.c
@@ -419,7 +419,7 @@ void SH2Disasm(u32 v_addr, u16 op, int mode, sh2regs_struct *regs, char *string)
 			   {
 				   if ((op & 0xf000) == 0x9000)    /* .W */
 				   {
-					   sprintf(string, trace[i].mnem, (op & 0xff) * trace[i].dat + 4, rtype_2), regs->R[rtype_2];
+					   sprintf(string, trace[i].mnem, (op & 0xff) * trace[i].dat + 4, rtype_2, regs->R[rtype_2]);
 					   string += strlen(string);
 					   sprintf(string, " ; 0x%08X", ((op & 0xff) * trace[i].dat + 4 + (unsigned int)v_addr));
 				   }

--- a/yabause/src/vidogl.c
+++ b/yabause/src/vidogl.c
@@ -3096,7 +3096,7 @@ void VIDOGLVdp1DrawStart(void)
      glActiveTexture(GL_TEXTURE0);
      glBindTexture(GL_TEXTURE_2D, _Ygl->texture);
      glBindBuffer(GL_PIXEL_UNPACK_BUFFER, _Ygl->pixelBufferID);
-     YglTM->texture = (int*)glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, 2048 * 1024 * 4, GL_MAP_WRITE_BIT);
+     YglTM->texture = (unsigned int*)glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, 2048 * 1024 * 4, GL_MAP_WRITE_BIT);
 	 if (YglTM->texture == NULL){
 		 abort();
 	 }
@@ -5362,7 +5362,7 @@ void VIDOGLVdp2DrawScreens(void)
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, _Ygl->texture);
 		glBindBuffer(GL_PIXEL_UNPACK_BUFFER, _Ygl->pixelBufferID);
-		YglTM->texture = (int*)glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, 2048 * 1024 * 4, GL_MAP_WRITE_BIT);
+		YglTM->texture = (unsigned int*)glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, 2048 * 1024 * 4, GL_MAP_WRITE_BIT);
 		if (YglTM->texture == NULL){
 			abort();
 		}

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -715,7 +715,7 @@ int YglGLInit(int width, int height) {
 
    _Ygl->pFrameBuffer = NULL;
 
-   if( strstr(glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
+   if( strstr((const char*)glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
    {
       if( _Ygl->rboid_depth != 0 ) glDeleteRenderbuffers(1,&_Ygl->rboid_depth);
       glGenRenderbuffers(1, &_Ygl->rboid_depth);
@@ -857,7 +857,7 @@ int YglInit(int width, int height, unsigned int depth) {
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if( strstr(glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
+    if( strstr((const char*)glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
    {
       if( _Ygl->rboid_depth != 0 ) glDeleteRenderbuffers(1,&_Ygl->rboid_depth);
       glGenRenderbuffers(1, &_Ygl->rboid_depth);
@@ -2332,7 +2332,7 @@ void YglRender(void) {
    glDisable(GL_SCISSOR_TEST);
    YuiSwapBuffers();
    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, _Ygl->pixelBufferID);
-   YglTM->texture = (int*)glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, 2048 * 1024 * 4, GL_MAP_WRITE_BIT);
+   YglTM->texture = (unsigned int*)glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, 2048 * 1024 * 4, GL_MAP_WRITE_BIT);
    if (YglTM->texture == NULL){
 	   abort();
    }

--- a/yabause/src/yglshaderes.c
+++ b/yabause/src/yglshaderes.c
@@ -915,10 +915,14 @@ int Ygl_uniformVDP2DrawFramebuffer_addcolor(void * p, float from, float to, floa
 	_Ygl->renderfb.mtxModelView = glGetUniformLocation(_prgid[PG_VDP2_DRAWFRAMEBUFF_ADDCOLOR], (const GLchar *)"u_mvpMatrix");
 
 	glBlendFunc(GL_ONE, GL_SRC_ALPHA);
+
+   return 0;
 }
 
 int Ygl_cleanupVDP2DrawFramebuffer_addcolor(void * p){
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+   return 0;
 }
 
 /*------------------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes all warnings on Travis CI for GCC and clang on Linux except for some clang warnings caused by Qt include files.