### PR TITLE
ci: enable -Werror for linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
         - rm CMakeLists.txt
         - mv temp2.txt CMakeLists.txt
         - cd ../build
+      script:
+        - cmake ..
+        - make
 
     # mingw-w64 windows cross compile, libyabause only
     # needs qt and other deps built
@@ -103,5 +106,5 @@ before_install:
   - cd build
 
 script:
-  - cmake -DYAB_FORCE_SECURE_STRINGS=ON ..
+  - cmake -DYAB_WERROR=ON -DYAB_FORCE_SECURE_STRINGS=ON ..
   - make

--- a/yabause/src/CMakeLists.txt
+++ b/yabause/src/CMakeLists.txt
@@ -671,6 +671,11 @@ if (CMAKE_COMPILER_IS_GNUCC AND YAB_FORCE_SECURE_STRINGS)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat -Werror=format-security")
 endif()
 
+option(YAB_WERROR "Treat all warnings as errors." OFF)
+if (YAB_WERROR)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
+
 add_definitions(-DPACKAGE=\"${YAB_PACKAGE}\")
 add_definitions(-DVERSION=\"${YAB_VERSION}\")
 


### PR DESCRIPTION
This commit enables warnings as errors for Linux clang and GCC builds on Travis CI.