### PR TITLE
vidsoft: improve winter heat screen transitions

### DIFF
--- a/yabause/src/musashi/CMakeLists.txt
+++ b/yabause/src/musashi/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 2.6)
 
 add_executable(m68kmake m68kmake.c)
 
+if (MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif (MSVC)
+
 add_custom_command(OUTPUT m68kops.h
                    COMMAND m68kmake ${CMAKE_CURRENT_BINARY_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/m68k_in.c
                    DEPENDS m68kmake.c

--- a/yabause/src/vdp1.c
+++ b/yabause/src/vdp1.c
@@ -1384,6 +1384,7 @@ void VIDDummyGetGlSize(int *width, int *height);
 void VIDDummVdp1ReadFrameBuffer(u32 type, u32 addr, void * out);
 void VIDDummVdp1WriteFrameBuffer(u32 type, u32 addr, u32 val);
 void VIDDummyGetNativeResolution(int *width, int * height, int *interlace);
+void VIDDummyVdp2DispOff(void);
 
 VideoInterface_struct VIDDummy = {
 VIDCORE_DUMMY,
@@ -1411,7 +1412,8 @@ VIDDummyVdp2DrawStart,
 VIDDummyVdp2DrawEnd,
 VIDDummyVdp2DrawScreens,
 VIDDummyGetGlSize,
-VIDDummyGetNativeResolution
+VIDDummyGetNativeResolution,
+VIDDummyVdp2DispOff,
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1565,4 +1567,10 @@ void VIDDummyGetNativeResolution(int *width, int * height, int * interlace)
    *width = 0;
    *height = 0;
    *interlace = 0;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void VIDDummyVdp2DispOff(void)
+{
 }

--- a/yabause/src/vdp1.h
+++ b/yabause/src/vdp1.h
@@ -86,6 +86,7 @@ typedef struct
    void (*Vdp2DrawScreens)(void);
    void (*GetGlSize)(int *width, int *height);
    void (*GetNativeResolution)(int *width, int *height, int * interlace);
+   void(*Vdp2DispOff)(void);
 } VideoInterface_struct;
 
 extern VideoInterface_struct *VIDCore;

--- a/yabause/src/vdp2.c
+++ b/yabause/src/vdp2.c
@@ -373,7 +373,10 @@ void Vdp2VBlankOUT(void) {
       if (Vdp1Regs->PTMR == 2) Vdp1Draw();
    }
    else
-	   if (Vdp1Regs->PTMR == 2) Vdp1Draw();
+   {
+      VIDCore->Vdp2DispOff();
+      if (Vdp1Regs->PTMR == 2) Vdp1Draw();
+   }
 
    FPSDisplay();
    if ((Vdp1Regs->FBCR & 2) && (Vdp1Regs->TVMR & 8))

--- a/yabause/src/vidogl.c
+++ b/yabause/src/vidogl.c
@@ -87,6 +87,7 @@ void VIDOGLVdp2SetResolution(u16 TVMD);
 void YglGetGlSize(int *width, int *height);
 void VIDOGLGetNativeResolution(int *width, int *height, int*interlace);
 void VIDOGLVdp1ReadFrameBuffer(u32 type, u32 addr, void * out);
+void VIDOGLVdp2DispOff(void);
 
 VideoInterface_struct VIDOGL = {
 VIDCORE_OGL,
@@ -115,6 +116,7 @@ VIDOGLVdp2DrawEnd,
 VIDOGLVdp2DrawScreens,
 YglGetGlSize,
 VIDOGLGetNativeResolution,
+VIDOGLVdp2DispOff
 };
 
 float vdp1wratio=1;
@@ -5468,6 +5470,10 @@ void VIDOGLGetNativeResolution(int *width, int *height, int*interlace)
    *width = 0;
    *height = 0;
    *interlace = 0;
+}
+
+void VIDOGLVdp2DispOff()
+{
 }
 
 vdp2rotationparameter_struct * FASTCALL vdp2rGetKValue2W( vdp2rotationparameter_struct * param, int index )

--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -101,6 +101,7 @@ void VIDSoftVdp1SwapFrameBuffer(void);
 void VIDSoftVdp1EraseFrameBuffer(Vdp1* regs, u8 * back_framebuffer);
 void VidsoftDrawSprite(Vdp2 * vdp2_regs, u8 * sprite_window_mask, u8* vdp1_front_framebuffer, u8 * vdp2_ram, Vdp1* vdp1_regs, Vdp2* vdp2_lines, u8*color_ram);
 void VIDSoftGetNativeResolution(int *width, int *height, int*interlace);
+void VIDSoftVdp2DispOff(void);
 
 VideoInterface_struct VIDSoft = {
 VIDCORE_SOFT,
@@ -132,7 +133,8 @@ VIDSoftVdp2DrawStart,
 VIDSoftVdp2DrawEnd,
 VIDSoftVdp2DrawScreens,
 VIDSoftGetGlSize,
-VIDSoftGetNativeResolution
+VIDSoftGetNativeResolution,
+VIDSoftVdp2DispOff
 };
 
 pixel_t *dispbuffer=NULL;
@@ -4168,4 +4170,9 @@ void VIDSoftGetNativeResolution(int *width, int *height, int* interlace)
    *width = vdp2width;
    *height = vdp2height;
    *interlace = vdp2_interlace;
+}
+
+void VIDSoftVdp2DispOff()
+{
+   TitanErase();
 }


### PR DESCRIPTION
Winter Heat blanks the screen using the Vdp2 disp register, which requires erasing the layers drawn previously.