### PR TITLE
sh2 cache: fix astal when using a real bios

### DIFF
--- a/yabause/src/sh2cache.c
+++ b/yabause/src/sh2cache.c
@@ -70,9 +70,7 @@ void cache_clear(cache_enty * ca){
 }
 
 void cache_enable(cache_enty * ca){
-	if (ca->enable == 0){
-		cache_clear(ca);
-	}
+   //cache enable does not clear the cache
 	ca->enable = 1;
 }
 
@@ -115,13 +113,13 @@ static INLINE void update_lru(int way, u32*lru)
 
 static INLINE int select_way_to_replace(u32 lru)
 {
-   if (lru & 0x38)
+   if ((lru & 0x38) == 0x38)//bits 5, 4, 3 must be 1
       return 0;
-   else if ((lru & 0x26) == 0x6)
+   else if ((lru & 0x26) == 0x6)//bit 5 must be zero. bits 2 and 1 must be 1
       return 1;
-   else if ((lru & 0x15) == 1)
+   else if ((lru & 0x15) == 1)//bits 4, 2 must be zero. bit 0 must be 1
       return 2;
-   else if ((lru & 0xB) == 0)
+   else if ((lru & 0xB) == 0)//bits 3, 1, 0 must be zero
       return 3;
 
    //should not happen

--- a/yabause/src/sh2int.c
+++ b/yabause/src/sh2int.c
@@ -132,14 +132,22 @@ fetchfunc fetchlist[0x100];
 
 static u32 FASTCALL FetchBios(u32 addr)
 {
+#if CACHE_ENABLE
+   return cache_memory_read_w(&CurrentSH2->onchip.cache, addr);
+#else
    return T2ReadWord(BiosRom, addr & 0x7FFFF);
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
 static u32 FASTCALL FetchCs0(u32 addr)
 {
+#if CACHE_ENABLE
+   return cache_memory_read_w(&CurrentSH2->onchip.cache, addr);
+#else
    return CartridgeArea->Cs0ReadWord(addr);
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
YAB_WANT_SH2_CACHE has to be enabled.