### PR TITLE
fix #154 no background sound on SEGA RALLY CHAMPIONSHIP

### DIFF
--- a/yabause/src/cs2.c
+++ b/yabause/src/cs2.c
@@ -1629,6 +1629,8 @@ void Cs2PlayDisc(void) {
   }
   else if (pdepos != 0)
   {
+	 pdepos += 0x100; // to the next track
+
      // Track Mode
      if ((pdepos & 0xFF) == 0)
         Cs2Area->playendFAD = Cs2TrackToFAD((u16)(pdepos | 0x0063));


### PR DESCRIPTION
Hi there,
This is a patch from uoYabause.
https://github.com/devmiyax/yabause/issues/154

(cherry picked from commit 7b49752d54f911656e3f27b30421a7664a435928)