### PR TITLE
Improve Android build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,22 +100,9 @@ matrix:
         - wget http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip
         - unzip -q android-ndk-r11c-linux-x86_64.zip
 
-        - export PATH=${PATH}:$(pwd)/android-ndk-r11c/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/
-        - export NDK=$(pwd)/android-ndk-r11c/
-        - export SYSROOT=$NDK/platforms/android-24/arch-arm
+        - export ANDROID_NDK_HOME=$(pwd)/android-ndk-r11c/
 
-        - echo 'SET(CMAKE_SYSTEM_NAME Linux)' > toolchain.cmake
-        - echo 'SET(CMAKE_SYSTEM_VERSION 1)' >> toolchain.cmake
-        - echo 'SET(CMAKE_C_COMPILER   arm-linux-androideabi-gcc)' >> toolchain.cmake
-        - echo 'SET(CMAKE_CXX_COMPILER arm-linux-androideabi-g++)' >> toolchain.cmake
-        - echo 'SET(CMAKE_ASM-ATT_COMPILER arm-linux-androideabi-as)' >> toolchain.cmake
-        - echo 'set(CMAKE_C_FLAGS "--sysroot=$ENV{SYSROOT}/usr/" CACHE STRING "GCC flags" FORCE)' >> toolchain.cmake
-        - echo 'set(CMAKE_CXX_FLAGS "--sysroot=$ENV{SYSROOT}/usr/" CACHE STRING "G++ flags" FORCE)' >> toolchain.cmake
-        - echo 'SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)' >> toolchain.cmake
-        - echo 'SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)' >> toolchain.cmake
-        - echo 'SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)' >> toolchain.cmake
-        - echo 'SET(ANDROID ON)' >> toolchain.cmake
-        - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_ROOT_PATH=$SYSROOT/usr/ -DNDK_BUILD=$NDK/build/ndk-build -DSDK_ANDROID=$ANDROID_HOME/tools/android -DSH2_DYNAREC=OFF -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake -DYAB_PORTS=android ..
+        - cmake -DCMAKE_BUILD_TYPE=Release -DSH2_DYNAREC=OFF -DCMAKE_TOOLCHAIN_FILE=../src/android/android.cmake -DYAB_PORTS=android ..
         - make
 
       after_success:

--- a/yabause/src/android/CMakeLists.txt
+++ b/yabause/src/android/CMakeLists.txt
@@ -1,10 +1,10 @@
-find_program(NDK_BUILD ndk-build)
+find_program(NDK_BUILD ndk-build PATHS $ENV{ANDROID_NDK_HOME})
 
 if(NOT NDK_BUILD)
     message(FATAL_ERROR "ndk build not found, bye")
 endif()
 
-find_program(SDK_ANDROID android)
+find_program(SDK_ANDROID android PATHS $ENV{ANDROID_HOME} PATH_SUFFIXES tools)
 
 if(NOT SDK_ANDROID)
     message(FATAL_ERROR "sdk android tool not found, bye")
@@ -18,6 +18,7 @@ if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
 		gradlew.bat
 		gradle/wrapper/gradle-wrapper.jar
 		gradle/wrapper/gradle-wrapper.properties
+		jni/Application.mk
 		jni/yui.c
 		jni/miniegl.h
 		jni/sndaudiotrack.c
@@ -172,6 +173,7 @@ add_custom_command(
 	DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/gradle.properties"
 	DEPENDS ${yabause_android_RES}
 	DEPENDS ${yabause_android_GRADLEW}
+	DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/jni/Application.mk"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 

--- a/yabause/src/android/android.cmake
+++ b/yabause/src/android/android.cmake
@@ -1,9 +1,22 @@
 SET(CMAKE_SYSTEM_NAME Linux)
 SET(CMAKE_SYSTEM_VERSION 1)
 
-SET(CMAKE_C_COMPILER   arm-linux-androideabi-gcc)
-SET(CMAKE_CXX_COMPILER arm-linux-androideabi-g++)
-SET(CMAKE_ASM-ATT_COMPILER arm-linux-androideabi-as)
+if (NOT DEFINED ENV{ANDROID_NDK_HOME})
+	message(FATAL_ERROR "Please set ANDROID_NDK_HOME environment variable")
+endif()
+
+set(TOOLCHAIN "$ENV{ANDROID_NDK_HOME}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/")
+
+SET(CMAKE_C_COMPILER ${TOOLCHAIN}/arm-linux-androideabi-gcc)
+SET(CMAKE_CXX_COMPILER ${TOOLCHAIN}/arm-linux-androideabi-g++)
+SET(CMAKE_ASM-ATT_COMPILER ${TOOLCHAIN}/arm-linux-androideabi-as)
+
+set(SYSROOT "$ENV{ANDROID_NDK_HOME}/platforms/android-24/arch-arm/usr")
+
+set(CMAKE_C_FLAGS "--sysroot=${SYSROOT}" CACHE STRING "GCC flags" FORCE)
+set(CMAKE_CXX_FLAGS "--sysroot=${SYSROOT}" CACHE STRING "G++ flags" FORCE)
+
+set(CMAKE_FIND_ROOT_PATH ${SYSROOT})
 
 SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/yabause/src/android/jni/Application.mk
+++ b/yabause/src/android/jni/Application.mk
@@ -1,0 +1,1 @@
+APP_ABI := armeabi


### PR DESCRIPTION
With this change, the Android port can be compiled by only
setting ANDROID_HOME and ANDROID_NDK_HOME.

It's based on d356 script for travis.