### PR TITLE
Using QFile::encodeName to convert paths

### DIFF
--- a/yabause/src/qt/YabauseThread.cpp
+++ b/yabause/src/qt/YabauseThread.cpp
@@ -29,6 +29,7 @@
 #include <QDateTime>
 #include <QStringList>
 #include <QDebug>
+#include <QFile>
 
 YabauseThread::YabauseThread( QObject* o )
 	: QObject( o )
@@ -105,7 +106,7 @@ bool YabauseThread::pauseEmulation( bool pause, bool reset )
 				vs->value("autostart/binary/address").toUInt());
 		}
 		else if (vs->value("autostart/load").toBool()) {
-			YabLoadStateSlot( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString().toLatin1().constData(), vs->value("autostart/load/slot").toInt() );
+			YabLoadStateSlot( QFile::encodeName( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString() ).constData(), vs->value("autostart/load/slot").toInt() );
 		}
 		vs->setValue("autostart", false);
 	}
@@ -368,17 +369,18 @@ void YabauseThread::reloadSettings()
 	if (vs->value("General/EnableEmulatedBios", false).toBool())
 		mYabauseConf.biospath = strdup( "" );
 	else
-		mYabauseConf.biospath = strdup( vs->value( "General/Bios", mYabauseConf.biospath ).toString().toLatin1().constData() );
-	mYabauseConf.cdpath = strdup( vs->value( "General/CdRomISO", mYabauseConf.cdpath ).toString().toLatin1().constData() );
-   mYabauseConf.ssfpath = strdup(vs->value("General/SSFPath", mYabauseConf.ssfpath).toString().toLatin1().constData());
-   mYabauseConf.play_ssf = vs->value("General/PlaySSF", false).toBool();
-   showFPS = vs->value( "General/ShowFPS", false ).toBool();
+		mYabauseConf.biospath = strdup( QFile::encodeName( vs->value( "General/Bios", mYabauseConf.biospath ).toString()).constData() );
+
+	mYabauseConf.cdpath = strdup( QFile::encodeName( vs->value( "General/CdRomISO", mYabauseConf.cdpath ).toString()).constData());
+	mYabauseConf.ssfpath = strdup( QFile::encodeName( vs->value("General/SSFPath", mYabauseConf.ssfpath).toString()).constData());
+	mYabauseConf.play_ssf = vs->value("General/PlaySSF", false).toBool();
+	showFPS = vs->value( "General/ShowFPS", false ).toBool();
 	mYabauseConf.usethreads = (int)vs->value( "General/EnableMultiThreading", mYabauseConf.usethreads ).toBool();
 	mYabauseConf.numthreads = vs->value( "General/NumThreads", mYabauseConf.numthreads ).toInt();
-	mYabauseConf.buppath = strdup( vs->value( "Memory/Path", mYabauseConf.buppath ).toString().toLatin1().constData() );
-	mYabauseConf.sh1rompath = strdup( vs->value( "SH1ROM/Path", mYabauseConf.mpegpath ).toString().toLatin1().constData() );
-	mYabauseConf.mpegpath = strdup( vs->value( "MpegROM/Path", mYabauseConf.mpegpath ).toString().toLatin1().constData() );
-	mYabauseConf.cartpath = strdup( vs->value( "Cartridge/Path", mYabauseConf.cartpath ).toString().toLatin1().constData() );
+	mYabauseConf.buppath = strdup( QFile::encodeName( vs->value( "Memory/Path", mYabauseConf.buppath ).toString()).constData() );
+	mYabauseConf.sh1rompath = strdup( QFile::encodeName( vs->value( "SH1ROM/Path", mYabauseConf.mpegpath ).toString()).constData() );
+	mYabauseConf.mpegpath = strdup( QFile::encodeName( vs->value( "MpegROM/Path", mYabauseConf.mpegpath ).toString()).constData() );
+	mYabauseConf.cartpath = strdup( QFile::encodeName( vs->value( "Cartridge/Path", mYabauseConf.cartpath ).toString()).constData() );
 	mYabauseConf.modemip = strdup( vs->value( "Cartridge/ModemIP", mYabauseConf.modemip ).toString().toLatin1().constData() );
 	mYabauseConf.modemport = strdup( vs->value( "Cartridge/ModemPort", mYabauseConf.modemport ).toString().toLatin1().constData() );
 	mYabauseConf.videoformattype = vs->value( "Video/VideoFormat", mYabauseConf.videoformattype ).toInt();

--- a/yabause/src/qt/ui/UIDebugSCUDSP.cpp
+++ b/yabause/src/qt/ui/UIDebugSCUDSP.cpp
@@ -207,7 +207,7 @@ void UIDebugSCUDSP::reserved1()
 	if (!ScuRegs)
 		return;
    if ( !s.isNull() )
-      ScuDspSaveProgram(s.toLatin1());
+      ScuDspSaveProgram(QFile::encodeName(s));
 }
 
 void UIDebugSCUDSP::reserved2()
@@ -216,7 +216,7 @@ void UIDebugSCUDSP::reserved2()
 	if (!ScuRegs)
 		return;
    if ( !s.isNull() )
-      ScuDspSaveMD(s.toLatin1(), 0);
+      ScuDspSaveMD(QFile::encodeName(s), 0);
 }
 
 void UIDebugSCUDSP::reserved3()
@@ -225,7 +225,7 @@ void UIDebugSCUDSP::reserved3()
 	if (!ScuRegs)
 		return;
    if ( !s.isNull() )
-      ScuDspSaveMD(s.toLatin1(), 1);
+      ScuDspSaveMD(QFile::encodeName(s), 1);
 }
 
 void UIDebugSCUDSP::reserved4()
@@ -234,7 +234,7 @@ void UIDebugSCUDSP::reserved4()
 	if (!ScuRegs)
 		return;
    if ( !s.isNull() )
-      ScuDspSaveMD(s.toLatin1(), 2);
+      ScuDspSaveMD(QFile::encodeName(s), 2);
 }
 
 void UIDebugSCUDSP::reserved5()
@@ -243,6 +243,6 @@ void UIDebugSCUDSP::reserved5()
 	if (!ScuRegs)
 		return;
    if ( !s.isNull() )
-      ScuDspSaveMD(s.toLatin1(), 3);
+      ScuDspSaveMD(QFile::encodeName(s), 3);
 }
 

--- a/yabause/src/qt/ui/UIHexEditor.cpp
+++ b/yabause/src/qt/ui/UIHexEditor.cpp
@@ -22,6 +22,7 @@
 #include <QPainter>
 #include <QPaintEvent>
 #include <QScrollBar>
+#include <QFile>
 
 UIHexEditor::UIHexEditor( QWidget* p )
 {
@@ -1053,7 +1054,7 @@ bool UIHexEditorWnd::saveTab(QString filename)
 
 bool UIHexEditorWnd::saveMemory(QString filename, u32 startAddress, u32 endAddress)
 {
-	FILE *fp = fopen(filename.toLatin1(), "wb");
+	FILE *fp = fopen(QFile::encodeName( filename ), "wb");
 	u32 size = (u32)(endAddress - startAddress);
 
 	if (fp == NULL)

--- a/yabause/src/qt/ui/UIYabause.cpp
+++ b/yabause/src/qt/ui/UIYabause.cpp
@@ -47,6 +47,7 @@
 #include <QUrl>
 #include <QDesktopServices>
 #include <QDateTime>
+#include <QFile>
 
 #include <QDebug>
 
@@ -910,7 +911,7 @@ void UIYabause::on_mFileSaveState_triggered( QAction* a )
 	if ( a == aFileSaveStateAs )
 		return;
 	YabauseLocker locker( mYabauseThread );
-	if ( YabSaveStateSlot( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString().toLatin1().constData(), a->data().toInt() ) != 0 )
+	if ( YabSaveStateSlot( QFile::encodeName( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString()).constData(), a->data().toInt() ) != 0 )
 		CommonDialogs::information( QtYabause::translate( "Couldn't save state file" ) );
 	else
 		refreshStatesActions();
@@ -921,7 +922,7 @@ void UIYabause::on_mFileLoadState_triggered( QAction* a )
 	if ( a == aFileLoadStateAs )
 		return;
 	YabauseLocker locker( mYabauseThread );
-	if ( YabLoadStateSlot( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString().toLatin1().constData(), a->data().toInt() ) != 0 )
+	if ( YabLoadStateSlot( QFile::encodeName( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString()).constData(), a->data().toInt() ) != 0 )
 		CommonDialogs::information( QtYabause::translate( "Couldn't load state file" ) );
 }
 
@@ -931,7 +932,7 @@ void UIYabause::on_aFileSaveStateAs_triggered()
 	const QString fn = CommonDialogs::getSaveFileName( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString(), QtYabause::translate( "Choose a file to save your state" ), QtYabause::translate( "Yabause Save State (*.yss)" ) );
 	if ( fn.isNull() )
 		return;
-	if ( YabSaveState( fn.toLatin1().constData() ) != 0 )
+	if ( YabSaveState( QFile::encodeName(fn).constData() ) != 0 )
 		CommonDialogs::information( QtYabause::translate( "Couldn't save state file" ) );
 }
 
@@ -941,7 +942,7 @@ void UIYabause::on_aFileLoadStateAs_triggered()
 	const QString fn = CommonDialogs::getOpenFileName( QtYabause::volatileSettings()->value( "General/SaveStates", getDataDirPath() ).toString(), QtYabause::translate( "Select a file to load your state" ), QtYabause::translate( "Yabause Save State (*.yss)" ) );
 	if ( fn.isNull() )
 		return;
-	if ( YabLoadState( fn.toLatin1().constData() ) != 0 )
+	if ( YabLoadState( QFile::encodeName(fn).constData() ) != 0 )
 		CommonDialogs::information( QtYabause::translate( "Couldn't load state file" ) );
 	else
 		aEmulationRun->trigger();


### PR DESCRIPTION
It is now possible to use non-ascii characters in paths/filenames.