### PR TITLE
Enable all color calculation modes for RGB

### DIFF
--- a/yabause/src/vidsoft.c
+++ b/yabause/src/vidsoft.c
@@ -3676,11 +3676,37 @@ void VidsoftDrawSprite(Vdp2 * vdp2_regs, u8 * spr_window_mask, u8* vdp1_front_fr
                {
                   // 16 BPP               
                   u8 alpha = 0x3F;
-                  if ((SPCCCS == 3) && TestBothWindow(vdp2_regs->WCTLD >> 8, colorcalcwindow, i, i2) && (vdp2_regs->CCCTL & 0x40))
+                  if (TestBothWindow(vdp2_regs->WCTLD >> 8, colorcalcwindow, i, i2) && (vdp2_regs->CCCTL & 0x40))
                   {
-                     alpha = colorcalctable[0];
-                     if (vdp2_regs->CCCTL & 0x300) alpha |= 0x80;
+                     switch (SPCCCS) {
+                     case 0:
+                        if (prioritytable[0] <= SPCCN)
+                        {
+                           alpha = colorcalctable[0];
+                           if (vdp2_regs->CCCTL & 0x300) alpha |= 0x80;
+                        }
+                        break;
+                     case 1:
+                        if (prioritytable[0] == SPCCN)
+                        {
+                           alpha = colorcalctable[0];
+                           if (vdp2_regs->CCCTL & 0x300) alpha |= 0x80;
+                        }
+                        break;
+                     case 2:
+                        if (prioritytable[0] >= SPCCN)
+                        {
+                           alpha = colorcalctable[0];
+                           if (vdp2_regs->CCCTL & 0x300) alpha |= 0x80;
+                        }
+                        break;
+                     case 3:
+                        alpha = colorcalctable[0];
+                        if (vdp2_regs->CCCTL & 0x300) alpha |= 0x80;
+                        break;
+                     }
                   }
+
                   // if pixel is 0x8000, only draw pixel if sprite window
                   // is disabled/sprite type 2-7. sprite types 0 and 1 are
                   // -always- drawn and sprite types 8-F are always


### PR DESCRIPTION
It seems all color calculation modes can be used when
sprites are RGB, and not only the MSB one.

It could explains a number of transparency problems.

This fix the transparency problem on Asuka 120% menu.