### PR TITLE
fix wrong Category and building in openSUSE OBS

### DIFF
--- a/yabause/src/qt/yabause.desktop.in
+++ b/yabause/src/qt/yabause.desktop.in
@@ -5,4 +5,4 @@ Comment=Sega Saturn emulator
 TryExec=yabause
 Exec=@YAB_PORT_NAME@
 Icon=yabause
-Categories=Game;Emulator;
+Categories=Qt;Game;Emulator;

--- a/yabause/src/qt/yabause.desktop.in
+++ b/yabause/src/qt/yabause.desktop.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Type=Application
-Name=Yabause (Qt port)
+Name=Yabause
 Comment=Sega Saturn emulator
 TryExec=yabause
 Exec=@YAB_PORT_NAME@
 Icon=yabause
-Categories=KDE;Qt;Game;
+Categories=Game;Emulator;


### PR DESCRIPTION
In openSUSE obs package don't build because wrong Category in .desktop file.
P.S. (Qt port) removed for aesthetics.