### PR TITLE
Specify GL context as Core 3.3 in Qt targets

### DIFF
--- a/yabause/src/qt/CMakeLists.txt
+++ b/yabause/src/qt/CMakeLists.txt
@@ -43,12 +43,21 @@ else()
 		set( QT_USE_QTMAIN TRUE )
 	endif()
 	
-	find_package(Qt4)
+	# Qt Version >=4.8 is required to use the GL Core profile
+	if (OPENGL_FOUND)
+		find_package(Qt4 4.8)
 
-	if (NOT QT4_FOUND)
-		message(STATUS "NO QT4_FOUND OR Qt5_FOUND")
-		return ()
-	endif ()
+		if (NOT QT4_FOUND)
+			message(STATUS "NO QT4_FOUND (V4.8 required) OR Qt5_FOUND")
+			return ()
+		endif ()
+	else()
+		find_package(Qt4)
+		if (NOT QT4_FOUND)
+			message(STATUS "NO QT4_FOUND OR Qt5_FOUND")
+			return ()
+		endif ()
+	endif()
 
 	message (WARNING "Qt4 is deprecated. Support will be removed in the future.")
 

--- a/yabause/src/qt/YabauseGL.cpp
+++ b/yabause/src/qt/YabauseGL.cpp
@@ -30,6 +30,14 @@ YabauseGL::YabauseGL( QWidget* p )
 		p->setFocusPolicy( Qt::StrongFocus );
 		setFocusProxy( p );
 	}
+
+    // Configure GL context version to 3.3
+    QGLFormat glFormat;
+    glFormat.setVersion( 3, 3 );
+    glFormat.setProfile( QGLFormat::CoreProfile ); // Requires >=Qt-4.8.0
+    glFormat.setSampleBuffers( true );
+
+    this->setFormat(glFormat);
 }
 
 void YabauseGL::showEvent( QShowEvent* e )

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -630,6 +630,24 @@ void VIDOGLVdp1ReadFrameBuffer(u32 type, u32 addr, void * out) {
 
 }
 
+//////////////////////////////////////////////////////////////////////////////
+int IsExtensionPresent(const char* name_substr)
+{
+    int i;
+    GLint num_ext = 0;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &num_ext);
+
+
+    for (i = 0; i < num_ext; i++)
+    {
+        if (strstr((const char*)glGetStringi(GL_EXTENSIONS, i), name_substr) != NULL)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -714,7 +732,7 @@ int YglGLInit(int width, int height) {
 
    _Ygl->pFrameBuffer = NULL;
 
-   if( strstr((const char*)glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
+   if(IsExtensionPresent("packed_depth_stencil"))
    {
       if( _Ygl->rboid_depth != 0 ) glDeleteRenderbuffers(1,&_Ygl->rboid_depth);
       glGenRenderbuffers(1, &_Ygl->rboid_depth);
@@ -856,7 +874,7 @@ int YglInit(int width, int height, unsigned int depth) {
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if( strstr((const char*)glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
+   if(IsExtensionPresent("packed_depth_stencil"))
    {
       if( _Ygl->rboid_depth != 0 ) glDeleteRenderbuffers(1,&_Ygl->rboid_depth);
       glGenRenderbuffers(1, &_Ygl->rboid_depth);


### PR DESCRIPTION
Fixes blank screen with Software Renderer on OS X and maybe other platforms.

Tested with Qt 5 on OS X with Software Renderer.

Changes:
- Specify 3.3 Core GL Context for Qt.
- Fixes obselete usage of glGetString(GL_EXTENSIONS) in HW renderer which is not supported in 3.3.
- Require Qt >=4.8 in CMake for OpenGL builds.
