### PR TITLE
OpenGL: Fix potential segmentation fault from calling strstr on a null pointer

### DIFF
--- a/yabause/src/ygl.h
+++ b/yabause/src/ygl.h
@@ -39,6 +39,7 @@
   #endif
 
 #elif  defined(__APPLE__)
+    #define GL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED
     #include <OpenGL/gl.h>
     #include <OpenGL/gl3.h>
 

--- a/yabause/src/ygles.c
+++ b/yabause/src/ygles.c
@@ -636,6 +636,7 @@ void VIDOGLVdp1ReadFrameBuffer(u32 type, u32 addr, void * out) {
 int YglGLInit(int width, int height) {
    int status;
    GLuint error;
+   const char* extensions;
 
    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
 
@@ -714,7 +715,8 @@ int YglGLInit(int width, int height) {
 
    _Ygl->pFrameBuffer = NULL;
 
-   if( strstr((const char*)glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
+   extensions = (const char*)glGetString(GL_EXTENSIONS);
+   if( extensions != NULL && strstr(extensions, "packed_depth_stencil") != NULL )
    {
       if( _Ygl->rboid_depth != 0 ) glDeleteRenderbuffers(1,&_Ygl->rboid_depth);
       glGenRenderbuffers(1, &_Ygl->rboid_depth);
@@ -786,6 +788,7 @@ int YglInit(int width, int height, unsigned int depth) {
    unsigned int i,j;
    GLuint status;
    void * dataPointer=NULL;
+   const char* extensions;
 
    YGLLOG("YglInit(%d,%d,%d);",width,height,depth );
 
@@ -856,7 +859,8 @@ int YglInit(int width, int height, unsigned int depth) {
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if( strstr((const char*)glGetString(GL_EXTENSIONS),"packed_depth_stencil") != NULL )
+   extensions = (const char*)glGetString(GL_EXTENSIONS);
+   if( extensions != NULL && strstr(extensions, "packed_depth_stencil") != NULL )
    {
       if( _Ygl->rboid_depth != 0 ) glDeleteRenderbuffers(1,&_Ygl->rboid_depth);
       glGenRenderbuffers(1, &_Ygl->rboid_depth);


### PR DESCRIPTION
I noticed that Yabause was crashing when attempting to create an OpenGL window on my Mac. It looks like `glGetString(GL_EXTENSIONS)` is returning a null pointer - I'm not sure why, but there's probably another bug at play. This doesn't fix that bug, but it at least means that Yabause pops up a "Cannot initialize Video" window instead of crashing.

I've also added a commit which suppresses the build warning about building multiple OpenGL headers on OS X.