### PR TITLE
Enumerate each command table in QT VDP1 debug window

### DIFF
--- a/yabause/src/qt/ui/UIDebugVDP1.cpp
+++ b/yabause/src/qt/ui/UIDebugVDP1.cpp
@@ -37,12 +37,13 @@ UIDebugVDP1::UIDebugVDP1( QWidget* p )
    {
       for (int i=0;;i++)
       {
-         char *string;
+         char outstring[256];
 
-         if ((string = Vdp1DebugGetCommandNumberName(i)) == NULL)
+         Vdp1DebugGetCommandNumberName(i, outstring);
+         if (*outstring == '\0')
             break;
 
-         lwCommandList->addItem(QtYabause::translate(string));
+         lwCommandList->addItem(QtYabause::translate(outstring));
       }
    }
 

--- a/yabause/src/vdp1.c
+++ b/yabause/src/vdp1.c
@@ -789,6 +789,7 @@ void Vdp1DebugGetCommandNumberName(u32 number, char *outstring)
 {
    u32 addr;
    u16 command;
+   char *command_name;
 
    *outstring = '\0';
 
@@ -800,8 +801,6 @@ void Vdp1DebugGetCommandNumberName(u32 number, char *outstring)
          outstring = "Draw End";
          return;
       }
-
-      char *command_name;
 
       // Figure out command name
       switch (command & 0x000F)

--- a/yabause/src/vdp1.c
+++ b/yabause/src/vdp1.c
@@ -785,51 +785,70 @@ static u32 Vdp1DebugGetCommandNumberAddr(u32 number)
 
 //////////////////////////////////////////////////////////////////////////////
 
-char *Vdp1DebugGetCommandNumberName(u32 number)
+void Vdp1DebugGetCommandNumberName(u32 number, char *outstring)
 {
    u32 addr;
    u16 command;
+
+   *outstring = '\0';
 
    if ((addr = Vdp1DebugGetCommandNumberAddr(number)) != 0xFFFFFFFF)
    {
       command = T1ReadWord(Vdp1Ram, addr);
 
-      if (command & 0x8000)
-         return "Draw End";
+      if (command & 0x8000) {
+         outstring = "Draw End";
+         return;
+      }
+
+      char *command_name;
 
       // Figure out command name
       switch (command & 0x000F)
       {
          case 0:
-            return "Normal Sprite";
+            command_name = "Normal Sprite";
+            break;
          case 1:
-            return "Scaled Sprite";
+            command_name = "Scaled Sprite";
+            break;
          case 2:
-            return "Distorted Sprite";
+            command_name = "Distorted Sprite";
+            break;
          case 3:
-            return "Distorted Sprite *";
+            command_name = "Distorted Sprite *";
+            break;
          case 4:
-            return "Polygon";
+            command_name = "Polygon";
+            break;
          case 5:
-            return "Polyline";
+            command_name = "Polyline";
+            break;
          case 6:
-            return "Line";
+            command_name = "Line";
+            break;
          case 7:
-            return "Polyline *";
+            command_name = "Polyline *";
+            break;
          case 8:
-            return "User Clipping Coordinates";
+            command_name = "User Clipping Coordinates";
+            break;
          case 9:
-            return "System Clipping Coordinates";
+            command_name = "System Clipping Coordinates";
+            break;
          case 10:
-            return "Local Coordinates";
+            command_name = "Local Coordinates";
+            break;
          case 11:
-            return "User Clipping Coordinates *";
+            command_name = "User Clipping Coordinates *";
+            break;
          default:
-             return "Bad command";
+            outstring = "Bad command";
+            return;
       }
+
+      sprintf(outstring, "%03u %s", number, command_name);
    }
-   else
-      return NULL;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/yabause/src/vdp1.h
+++ b/yabause/src/vdp1.h
@@ -181,7 +181,7 @@ void FASTCALL Vdp1ReadCommand(vdp1cmd_struct *cmd, u32 addr, u8* ram);
 int Vdp1SaveState(FILE *fp);
 int Vdp1LoadState(FILE *fp, int version, int size);
 
-char *Vdp1DebugGetCommandNumberName(u32 number);
+void Vdp1DebugGetCommandNumberName(u32 number, char *outstring);
 void Vdp1DebugCommand(u32 number, char *outstring);
 u32 *Vdp1DebugTexture(u32 number, int *w, int *h);
 void ToggleVDP1(void);


### PR DESCRIPTION
Not a fix, but a simple change to enumerate all command tables in VDP1 debug.

It's also nice to know how many command tables are being processed :)