### PR TITLE
System language change functionality

### DIFF
--- a/yabause/src/android/jni/yui.c
+++ b/yabause/src/android/jni/yui.c
@@ -498,6 +498,7 @@ Java_org_yabause_android_YabauseRunnable_init( JNIEnv* env, jobject obj, jobject
     yinit.cdcoretype = CDCORE_ISO;
     yinit.carttype = GetCartridgeType();
     yinit.regionid = 0;
+    yinit.syslanguageid = 0;
     yinit.biospath = GetBiosPath();
     yinit.cdpath = GetGamePath();
     yinit.buppath = GetMemoryPath();

--- a/yabause/src/cocoa/YabauseController.m
+++ b/yabause/src/cocoa/YabauseController.m
@@ -256,6 +256,7 @@ static void FlipToggle(NSMenuItem *item) {
         yinit.cdcoretype = cdcore;
         yinit.carttype = [prefs cartType];
         yinit.regionid = [prefs region];
+	yinit.syslanguageid = [prefs system language];
         yinit.biospath = ([bios length] > 0 && ![prefs emulateBios]) ?
             [bios UTF8String] : NULL;
         yinit.cdpath = fn;

--- a/yabause/src/dreamcast/yui.c
+++ b/yabause/src/dreamcast/yui.c
@@ -87,6 +87,7 @@ int YuiInit(int sh2core)   {
     yinit.cdcoretype = CDCORE_ARCH;
     yinit.carttype = CART_NONE;
     yinit.regionid = REGION_AUTODETECT;
+    Support for language configuration from settings
     yinit.biospath = emulate_bios ? NULL : bios;
     yinit.cdpath = NULL;
     yinit.buppath = NULL;

--- a/yabause/src/dreamcast/yui.c
+++ b/yabause/src/dreamcast/yui.c
@@ -87,7 +87,7 @@ int YuiInit(int sh2core)   {
     yinit.cdcoretype = CDCORE_ARCH;
     yinit.carttype = CART_NONE;
     yinit.regionid = REGION_AUTODETECT;
-    Support for language configuration from settings
+    yinit.syslanguageid = 0;
     yinit.biospath = emulate_bios ? NULL : bios;
     yinit.cdpath = NULL;
     yinit.buppath = NULL;

--- a/yabause/src/gtk/main.c
+++ b/yabause/src/gtk/main.c
@@ -134,6 +134,11 @@ GtkWidget * yui;
 GKeyFile * keyfile;
 yabauseinit_struct yinit;
 
+char* toLower(char* s) {
+  for(char *p=s; *p; p++) *p=tolower(*p);
+  return s;
+}
+
 static int yui_main(gpointer data) {
 	PERCore->HandleEvents();
 	return TRUE;
@@ -161,6 +166,7 @@ static void yui_settings_init(void) {
 	yinit.carttype = CART_NONE;
 	yinit.regionid = 0;
 	yinit.biospath = biospath;
+	yinit.syslanguageid = 0;
 	yinit.cdpath = cdpath;
 	yinit.buppath = buppath;
 	yinit.mpegpath = mpegpath;
@@ -225,6 +231,28 @@ static gboolean yui_settings_load(void) {
 		Cs2ChangeCDCore(yinit.cdcoretype, yinit.cdpath);
 	}
 
+	/* SystemLanguageID */
+	{
+		char * syslang = g_key_file_get_value(keyfile, "General", "SystemLanguageID", 0);
+		tmp = yinit.syslanguageid;
+		if ((syslang == 0) || !strcmp(syslang, "0")) {
+			yinit.syslanguageid = 0;
+		} else {
+			switch(syslang[0]) {
+				case '0': yinit.syslanguageid = 0; break;
+				case '1': yinit.syslanguageid = 1; break;
+				case '2': yinit.syslanguageid = 2; break;
+				case '3': yinit.syslanguageid = 3; break;
+				case '4': yinit.syslanguageid = 4; break;
+				case '5': yinit.syslanguageid = 5; break;
+			}
+		}
+
+		if ((YUI_WINDOW(yui)->state & YUI_IS_INIT) && (tmp != yinit.syslanguageid)) {
+			mustRestart = TRUE;
+		}
+	}
+	
 	/* region */
 	{
 		char * region = g_key_file_get_value(keyfile, "General", "Region", 0);
@@ -493,6 +521,24 @@ int main(int argc, char *argv[]) {
             g_strlcpy(biospath, argv[i] + strlen("--bios="), 256);
             yinit.biospath = biospath;
 	 }
+         //set System Language
+         if (0 == strcmp(argv[i], "-l") && argv[i + 1]) {
+            g_strlcpy(strsyslangeid, argv[i + 1], 256);
+            if (toLower(strsyslangeid) == "english") { yinit.syslanguageid = 0; }
+            if (toLower(strsyslangeid) == "deutsch") { yinit.syslanguageid = 1; }
+            if (toLower(strsyslangeid) == "french") { yinit.syslanguageid = 2; }
+            if (toLower(strsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
+            if (toLower(strsyslangeid) == "italian") { yinit.syslanguageid = 4; }
+            if (toLower(strsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
+	 } else if (strstr(argv[i], "--language=")) {
+            g_strlcpy(strsyslangeid, argv[i] + strlen("--language="), 256);
+            if (toLower(strsyslangeid) == "english") { yinit.syslanguageid = 0; }
+            if (toLower(strsyslangeid) == "deutsch") { yinit.syslanguageid = 1; }
+            if (toLower(strsyslangeid) == "french") { yinit.syslanguageid = 2; }
+            if (toLower(strsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
+            if (toLower(strsyslangeid) == "italian") { yinit.syslanguageid = 4; }
+            if (toLower(strsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
+	 }   
          //set iso
          else if (0 == strcmp(argv[i], "-i") && argv[i + 1]) {
             g_strlcpy(cdpath, argv[i + 1], 256);

--- a/yabause/src/gtk/main.c
+++ b/yabause/src/gtk/main.c
@@ -538,7 +538,7 @@ int main(int argc, char *argv[]) {
             if (toLower(strsyslangeid) == "spanish") { yinit.syslanguageid = 3; }
             if (toLower(strsyslangeid) == "italian") { yinit.syslanguageid = 4; }
             if (toLower(strsyslangeid) == "japanese") { yinit.syslanguageid = 5; }
-	 }   
+	 }
          //set iso
          else if (0 == strcmp(argv[i], "-i") && argv[i + 1]) {
             g_strlcpy(cdpath, argv[i + 1], 256);

--- a/yabause/src/gtk/settings.c
+++ b/yabause/src/gtk/settings.c
@@ -80,6 +80,16 @@ YuiRangeItem * osdcores = NULL;
 YuiRangeItem * sndcores = NULL;
 YuiRangeItem * percores = NULL;
 
+YuiRangeItem syslanguage[] = {
+	{ "0" , "English" },
+	{ "1" , "Deutsch" },
+	{ "2" , "French" },
+	{ "3" , "Spanish" },
+	{ "4" , "Italian" },
+	{ "5" , "Japanese" },
+	{ 0, 0 }
+};
+
 YuiRangeItem regions[] = {
 	{ "Auto" , "Auto-detect" },
 	{ "J" , "Japan (NTSC)" },
@@ -325,6 +335,9 @@ GtkWidget* create_dialog1(void) {
   box = yui_page_add(YUI_PAGE(general), _("Save States"));
   gtk_container_add(GTK_CONTAINER(box), yui_file_entry_new(keyfile, "General", "StatePath", YUI_FILE_ENTRY_BROWSE | YUI_FILE_ENTRY_DIRECTORY, NULL));
   
+  box = yui_page_add(YUI_PAGE(general), _("System Language"));
+  gtk_container_add(GTK_CONTAINER(box), yui_range_new(keyfile, "General", "SystemLanguageID", syslanguage));
+	
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook1), general, gtk_label_new (_("General")));
   gtk_widget_show_all(general);
 

--- a/yabause/src/qt/Arguments.cpp
+++ b/yabause/src/qt/Arguments.cpp
@@ -23,6 +23,7 @@ namespace Arguments
 	void autostart(const QString& param);
 	void binary(const QString& param);
 	void bios(const QString& param);
+	void syslangid(const QString& param);
 	void cdrom(const QString& param);
 	void fullscreen(const QString& param);
 	void help(const QString& param);
@@ -50,6 +51,7 @@ namespace Arguments
 		{ "-a",  "--autostart", NULL,       "Automatically start emulation.",                      1, autostart },
 		{ NULL,  "--binary=", "<FILE>[:ADDRESS]", "Use a binary file.",                           1, binary },
 		{ "-b",  "--bios=", "<BIOS>",       "Choose a bios file.",                                3, bios },
+		{ "-l",  "--language=", "<language>","Choose the system language: english, deutsch, french, spanish, italian, japanese",                     7, syslangid },
 		{ "-c",  "--cdrom=", "<CDROM>",     "Choose the cdrom device.",                           4, cdrom },
 		{ "-f",  "--fullscreen", NULL,      "Start the emulator in fullscreen.",                  5, fullscreen },
 		{ "-h",  "--help", NULL,            "Show this help and exit.",                           0, help },
@@ -62,8 +64,8 @@ namespace Arguments
 
 	void parse()
 	{
-		QVector<Option *> choosenOptions(7);
-		QVector<QString> params(7);
+		QVector<Option *> choosenOptions(8);
+		QVector<QString> params(8);
 
 		QStringList arguments = QApplication::arguments();
 		QStringListIterator argit(arguments);
@@ -90,7 +92,7 @@ namespace Arguments
 			}
 		}
 		
-		for(int i = 0;i < 7;i++)
+		for(int i = 0;i < 8;i++)
 		{
 			Option * option = choosenOptions[i];
 			if (option)
@@ -143,6 +145,17 @@ namespace Arguments
 		vs->setValue("General/Bios", param);
 	}
 
+	void syslangid(const QString& param)
+	{
+		VolatileSettings * vs = QtYabause::volatileSettings();
+		if (param.toLower() == "english") { vs->setValue("General/SystemLanguageID", 0); }
+		if (param.toLower() == "deutsch") { vs->setValue("General/SystemLanguageID", 1); }
+		if (param.toLower() == "french") { vs->setValue("General/SystemLanguageID", 2); }
+		if (param.toLower() == "spanish") { vs->setValue("General/SystemLanguageID", 3); }
+		if (param.toLower() == "italian") { vs->setValue("General/SystemLanguageID", 4); }
+		if (param.toLower() == "japanese") { vs->setValue("General/SystemLanguageID", 5); }
+	}
+	
 	void cdrom(const QString& param)
 	{
 		VolatileSettings * vs = QtYabause::volatileSettings();

--- a/yabause/src/qt/YabauseThread.cpp
+++ b/yabause/src/qt/YabauseThread.cpp
@@ -374,6 +374,21 @@ void YabauseThread::reloadSettings()
 			case 'L': mYabauseConf.regionid = 0xD; break;
 		}
 	}
+	const QString r1 = vs->value( "General/SystemLanguageID", mYabauseConf.syslanguageid ).toString();
+	if ( r1.isEmpty() || r1 == "0" )
+		mYabauseConf.syslanguageid = 0;
+	else
+	{
+		switch ( r1[0].toLatin1() )
+		{
+			case '0': mYabauseConf.syslanguageid = 0; break;
+			case '1': mYabauseConf.syslanguageid = 1; break;
+			case '2': mYabauseConf.syslanguageid = 2; break;
+			case '3': mYabauseConf.syslanguageid = 3; break;
+			case '4': mYabauseConf.syslanguageid = 4; break;
+			case '5': mYabauseConf.syslanguageid = 5; break;
+		}
+	}
 	if (vs->value("General/EnableEmulatedBios", false).toBool())
 		mYabauseConf.biospath = strdup( "" );
 	else
@@ -431,6 +446,7 @@ void YabauseThread::resetYabauseConf()
 	mYabauseConf.cdcoretype = QtYabause::defaultCDCore().id;
 	mYabauseConf.carttype = CART_NONE;
 	mYabauseConf.regionid = 0;
+	mYabauseConf.syslanguageid = 0;
 	mYabauseConf.biospath = 0;
 	mYabauseConf.cdpath = 0;
 	mYabauseConf.buppath = 0;

--- a/yabause/src/qt/ui/UISettings.cpp
+++ b/yabause/src/qt/ui/UISettings.cpp
@@ -51,6 +51,14 @@ struct Item
 
 typedef QList<Item> Items;
 
+const Items mSysLanguageID = Items()
+	<< Item( "0", "English" )
+	<< Item( "1", "Deutsch" )
+	<< Item( "2", "French" )
+	<< Item( "3", "Spanish" )
+	<< Item( "4", "Italian" )
+	<< Item( "5", "Japanese" );
+
 const Items mRegions = Items()
 	<< Item( "Auto" , "Auto-detect" )
 	<< Item( "J" , "Japan (NTSC)" )
@@ -332,6 +340,10 @@ void UISettings::loadCores()
 	foreach ( const Item& it, mRegions )
 		cbRegion->addItem( QtYabause::translate( it.Name ), it.id );
 	
+	// System Language
+	foreach ( const Item& it, mSysLanguageID  )
+		cbSysLanguageID ->addItem( QtYabause::translate( it.Name ), it.id );
+	
 	// SH2 Interpreters
 	for ( int i = 0; SH2CoreList[i] != NULL; i++ )
 	{
@@ -432,6 +444,7 @@ void UISettings::loadSettings()
 		cbCdDrive->setCurrentIndex(leCdRom->text().isEmpty() ? 0 : cbCdDrive->findText(leCdRom->text()));
 
 	leSaveStates->setText( s->value( "General/SaveStates", getDataDirPath() ).toString() );
+	cbSysLanguageID->setCurrentIndex( cbSysLanguageID->findData( s->value( "General/SystemLanguageID", mSysLanguageID.at( 0 ).id ).toString() ) );
 #ifdef HAVE_LIBMINI18N
 	int i;
 	if ((i=cbTranslation->findData(s->value( "General/Translation" ).toString())) != -1)
@@ -537,6 +550,7 @@ void UISettings::saveSettings()
 	else
 		s->setValue( "General/CdRomISO", leCdRom->text() );
 	s->setValue( "General/SaveStates", leSaveStates->text() );
+	s->setValue( "General/SystemLanguageID", cbSysLanguageID->itemData( cbSysLanguageID->currentIndex() ).toString() );
 #ifdef HAVE_LIBMINI18N
 	s->setValue( "General/Translation", cbTranslation->itemData(cbTranslation->currentIndex()).toString() );
 #endif

--- a/yabause/src/qt/ui/UISettings.ui
+++ b/yabause/src/qt/ui/UISettings.ui
@@ -138,7 +138,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0" colspan="2">
+       <item row="11" column="0" colspan="2">
         <widget class="QComboBox" name="cbSysLanguageID"/>
        </item>
        <item row="12" column="0" colspan="2">
@@ -211,7 +211,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0" colspan="2">
+       <item row="13" column="0" colspan="2">
         <widget class="QComboBox" name="cbTranslation"/>
        </item>
        <item row="20" column="0">

--- a/yabause/src/qt/ui/UISettings.ui
+++ b/yabause/src/qt/ui/UISettings.ui
@@ -123,6 +123,25 @@
         </widget>
        </item>
        <item row="10" column="0" colspan="2">
+        <widget class="QLabel" name="lSysLanguageID">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>System Language</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0" colspan="2">
+        <widget class="QComboBox" name="cbSysLanguageID"/>
+       </item>
+       <item row="12" column="0" colspan="2">
         <widget class="QLabel" name="lTranslation">
          <property name="font">
           <font>

--- a/yabause/src/qt/ui/UIYabause.cpp
+++ b/yabause/src/qt/ui/UIYabause.cpp
@@ -757,6 +757,7 @@ void UIYabause::on_aFileSettings_triggered()
          newhash["Advanced/68kCore"] != hash["Advanced/68kCore"] ||
 			newhash["General/CdRom"]!=hash["General/CdRom"] ||
 			newhash["General/CdRomISO"]!=hash["General/CdRomISO"] ||
+		   	newhash["General/SystemLanguageID"]!=hash["General/SystemLanguageID"] ||
 			newhash["General/ClockSync"]!=hash["General/ClockSync"] ||
 			newhash["General/FixedBaseTime"]!=hash["General/FixedBaseTime"] ||
          newhash["Advanced/EnableScuDspDynarec"] != hash["Advanced/EnableScuDspDynarec"] ||

--- a/yabause/src/runner/yui.cpp
+++ b/yabause/src/runner/yui.cpp
@@ -552,6 +552,7 @@ namespace game_testing
       yinit.cdcoretype = CDCORE_ISO;
       yinit.carttype = CART_NONE;
       yinit.regionid = REGION_AUTODETECT;
+      yinit.syslanguageid = 0;
       yinit.biospath = emulate_bios ? NULL : bios;
       yinit.cdpath = full_path.c_str();
       yinit.buppath = NULL;
@@ -799,6 +800,7 @@ namespace yabauseut
       yinit.cdcoretype = CDCORE_DUMMY;
       yinit.carttype = CART_NONE;
       yinit.regionid = REGION_AUTODETECT;
+      yinit.syslanguageid = 0;
       yinit.biospath = emulate_bios ? NULL : bios;
       yinit.cdpath = NULL;
       yinit.buppath = NULL;

--- a/yabause/src/smpc.c
+++ b/yabause/src/smpc.c
@@ -47,10 +47,11 @@ Smpc * SmpcRegs;
 u8 * SmpcRegsT;
 SmpcInternal * SmpcInternalVars;
 int intback_wait_for_line = 0;
+int syslngid = 0;
 
 //////////////////////////////////////////////////////////////////////////////
 
-int SmpcInit(u8 regionid, int clocksync, u32 basetime) {
+int SmpcInit(u8 regionid, int syslanguageid, int clocksync, u32 basetime) {
    if ((SmpcRegsT = (u8 *) calloc(1, sizeof(Smpc))) == NULL)
       return -1;
  
@@ -61,6 +62,7 @@ int SmpcInit(u8 regionid, int clocksync, u32 basetime) {
   
    SmpcInternalVars->regionsetting = regionid;
    SmpcInternalVars->regionid = regionid;
+   SmpcInternalVars->syslanguageid = syslanguageid;
    SmpcInternalVars->clocksync = clocksync;
    SmpcInternalVars->basetime = basetime ? basetime : time(NULL);
 
@@ -103,7 +105,21 @@ void SmpcRecheckRegion(void) {
 
 void SmpcReset(void) {
    memset((void *)SmpcRegs, 0, sizeof(Smpc));
-   memset((void *)SmpcInternalVars->SMEM, 0, 4);
+   syslngid = SmpcInternalVars->syslanguageid;
+   memset((void *)SmpcInternalVars->SMEM, syslngid, 4); // Language : 0=English - 1=Deutsch - 2=French - 3=Spanish - 4=Italian - 5=Japanese
+   memset((void *)SmpcInternalVars->SMEM, 0, 3); // Other Settings - MUST BE DECLARED! - By default : 0 = Button Labels=Enabled + Audio=Stereo + Sound Effects=Enabled
+
+   //   Other Settings Configuration Information :
+   //
+   // |-------------------------------------------------------------------------------------------------------|
+   // |  Settings     | Bit / Settings Value                                                                  |
+   // |               |---------------------------------------------------------------------------------------|
+   // |    Name       |   0      |  1       |   2       |  3       |  4       |  5       |  6       |  7      |
+   // |-------------------------------------------------------------------------------------------------------|
+   // | Button Labels |  Enabled | Enabled  | Enabled  | Enabled  | Disabled | Disabled | Disabled | Disabled |
+   // | Audio         |  Stereo  | Stereo   | Mono     | Mono     | Stereo   | Stereo   | Mono     | Mono     |
+   // | Sound Effects |  Enabled | Disabled | Enabled  | Disabled | Enabled  | Disabled | Enabled  | Disabled |
+   // |-------------------------------------------------------------------------------------------------------|
 
    SmpcRecheckRegion();
 

--- a/yabause/src/smpc.h
+++ b/yabause/src/smpc.h
@@ -59,6 +59,8 @@ typedef struct
 
 typedef struct {
    u8 dotsel; // 0 -> 320 | 1 -> 352
+   int syslanguageid;
+   int syslngid;
    u8 mshnmi;
    u8 sndres;
    u8 cdres;
@@ -81,7 +83,7 @@ typedef struct {
 
 extern SmpcInternal * SmpcInternalVars;
 
-int SmpcInit(u8 regionid, int clocksync, u32 basetime);
+int SmpcInit(u8 regionid, int syslanguageid, int clocksync, u32 basetime);
 void SmpcDeInit(void);
 void SmpcRecheckRegion(void);
 void SmpcReset(void);

--- a/yabause/src/yabause.c
+++ b/yabause/src/yabause.c
@@ -124,6 +124,7 @@ void print_usage(const char *program_name) {
           "Usage: %s [OPTIONS]...\n", program_name);
    printf("   -h         --help                 Print help and exit\n");
    printf("   -b STRING  --bios=STRING          bios file\n");
+   printf("   -l STRING  --language=STRING      english, deutsch, french, spanish,\n                                     italian, japanese\n");
    printf("   -i STRING  --iso=STRING           iso/cue file\n");
    printf("   -c STRING  --cdrom=STRING         cdrom path\n");
    printf("   -ns        --nosound              turn sound off\n");
@@ -312,7 +313,7 @@ int YabauseInit(yabauseinit_struct *init)
       return -1;
    }
 
-   if (SmpcInit(init->regionid, init->clocksync, init->basetime) != 0)
+   if (SmpcInit(init->regionid, init->syslanguageid, init->clocksync, init->basetime) != 0)
    {
       YabSetError(YAB_ERR_CANNOTINIT, _("SMPC"));
       return -1;

--- a/yabause/src/yabause.h
+++ b/yabause/src/yabause.h
@@ -36,6 +36,7 @@ typedef struct
    int cdcoretype;
    int carttype;
    u8 regionid;
+   int syslanguageid;
    const char *biospath;
    const char *cdpath;
    const char *ssfpath;


### PR DESCRIPTION
Hello,

I offer this small contribution to allow changing the system language from the bios settings which is always in English after each start of the emulation.

With this modification, it is now possible to change the language from the "-l" or "--language" command line, then the option can also be modified from the application settings and then saved in the configuration file.

Some games, like Rayman for example, do not allow you to select the language and are based on the language configuration from the system settings. This can be annoying if a player wants to play their game in their native language or of their choice.

Test performed on Linux. The code can be changed if necessary. Tests may be necessary on other platforms to confirm the correct functioning of this new functionality.

Hoping that this contribution can interest you because it brings a comfort during the game to the player.
